### PR TITLE
Fix mis-IDed arithmetic prims: 1050 Add, 1052 Multiply

### DIFF
--- a/src/lvkit/codegen/elementwise.py
+++ b/src/lvkit/codegen/elementwise.py
@@ -37,13 +37,17 @@ def _call(fn: str, args: list[ast.expr]) -> ast.Call:
 def _is_array_valued(node: ast.expr, array_vars: frozenset[str]) -> bool:
     """An operator's operand carries an array if it names a known array
     variable or is already an ``_lv.*`` broadcast call (which returns an array
-    when its input was one). A subscript (``a[i]``) is an element — scalar."""
+    when its input was one). A subscript is array-valued only when it's a
+    *slice* of an array (``a[i:j]`` stays an array); a single integer index
+    (``a[i]``) is a scalar element."""
     if isinstance(node, ast.Name):
         return node.id in array_vars
     if (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
             and isinstance(node.func.value, ast.Name)
             and node.func.value.id == "_lv"):
         return True
+    if isinstance(node, ast.Subscript) and isinstance(node.slice, ast.Slice):
+        return _is_array_valued(node.value, array_vars)
     return False
 
 

--- a/src/lvkit/codegen/nodes/__init__.py
+++ b/src/lvkit/codegen/nodes/__init__.py
@@ -88,11 +88,6 @@ def _generate_primitive(
         case "printf":
             return printf.generate(node, ctx)
         case _:
-            # Build Array as a plain prim (resID 1050) — not the expandable
-            # aBuild class — still concatenates inputs (scalars wrapped, arrays
-            # joined), not nested into `[scalar, array]`.
-            if node.primResID == 1050:
-                return compound.generate_array_build(node, ctx)
             return primitive.generate(node, ctx)
 
 

--- a/src/lvkit/data/primitives.json
+++ b/src/lvkit/data/primitives.json
@@ -217,35 +217,13 @@
       "pdf_page": 689
     },
     "1050": {
-      "name": "Build Array",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "appended array",
-          "type": "polymorphic"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "element",
-          "type": "polymorphic",
-          "expandable": true
-        }
-      ],
-      "python_code": "[{expandable_inputs}]",
-      "inline": true,
-      "verified": true,
-      "pdf_page": 400
-    },
-    "1052": {
-      "name": "Subtract",
+      "name": "Add",
       "elementwise": true,
       "terminals": [
         {
           "index": 0,
           "direction": "out",
-          "name": "difference",
+          "name": "sum",
           "type": "polymorphic"
         },
         {
@@ -262,7 +240,37 @@
         }
       ],
       "python_code": {
-        "difference": "in_1 - in_2"
+        "sum": "in_1 + in_2"
+      },
+      "inline": true,
+      "verified": true,
+      "pdf_page": 517
+    },
+    "1052": {
+      "name": "Multiply",
+      "elementwise": true,
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "product",
+          "type": "polymorphic"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "polymorphic"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "y",
+          "type": "polymorphic"
+        }
+      ],
+      "python_code": {
+        "product": "in_1 * in_2"
       },
       "inline": true,
       "verified": true,

--- a/tests/test_elementwise.py
+++ b/tests/test_elementwise.py
@@ -22,6 +22,15 @@ def test_list_list_elementwise():
     assert lv.add([1, 2], [10, 20]) == [11, 22]
 
 
+def test_mismatched_arrays_truncate_to_shortest():
+    # LabVIEW: a binary numeric op on two arrays of different sizes outputs an
+    # array the size of the *smaller* input. zip() stops at the shorter one.
+    assert lv.add([1, 2, 3, 4, 5], [10, 20, 30]) == [11, 22, 33]
+    assert lv.sub([10, 20], [1, 2, 3, 4]) == [9, 18]
+    # recurses for 2D — ragged inner rows also truncate to the shorter row
+    assert lv.mul([[1, 2, 3], [4, 5]], [[2, 2], [10, 10, 10]]) == [[2, 4], [40, 50]]
+
+
 def test_scalar_array_broadcast():
     assert lv.sub([10, 20, 30], 5) == [5, 15, 25]
     assert lv.sub(100, [1, 2, 3]) == [99, 98, 97]

--- a/tests/test_elementwise.py
+++ b/tests/test_elementwise.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import ast
 
 from lvkit.codegen.ast_utils import parse_expr, to_var_name
-from lvkit.codegen.elementwise import arrayify
+from lvkit.codegen.elementwise import arrayify, arrayify_module
 from lvkit.runtime import lv
 
 # --- runtime helper: scalar / list / broadcast ---
@@ -20,6 +20,17 @@ def test_scalar_passthrough():
 def test_list_list_elementwise():
     assert lv.sub([3, 5, 7], [1, 2, 3]) == [2, 3, 4]
     assert lv.add([1, 2], [10, 20]) == [11, 22]
+
+
+def test_module_arrayify_broadcasts_over_array_slice():
+    # `5.0 + arr[:3]` is scalar + a *sliced array* — it must broadcast
+    # (_lv.add), not emit a plain `+` (which crashes: float + list). This was
+    # the exact runtime bug exposed by 1050 -> Add. A single index stays scalar.
+    body = ast.parse("x = 5.0 + arr[:3]").body
+    assert arrayify_module(body, frozenset({"arr"}))
+    assert ast.unparse(body[0]) == "x = _lv.add(5.0, arr[:3])"
+    scalar_index = ast.parse("y = 5.0 + arr[2]").body
+    assert not arrayify_module(scalar_index, frozenset({"arr"}))
 
 
 def test_mismatched_arrays_truncate_to_shortest():

--- a/tests/test_primitive_resolutions.py
+++ b/tests/test_primitive_resolutions.py
@@ -15,9 +15,6 @@ from __future__ import annotations
 
 import pytest
 
-from lvkit.codegen.context import CodeGenContext
-from lvkit.codegen.nodes import _generate_primitive
-from lvkit.models import LVType, PrimitiveOperation, Terminal
 from lvkit.primitive_resolver import get_resolver
 
 EXPECTED_NAMES = {
@@ -27,8 +24,13 @@ EXPECTED_NAMES = {
     1057: "Absolute Value",
     1049: "Sign",
     1140: "To Byte Integer",
+    # The 2-input arithmetic block: 1050 Add, 1051 Subtract, 1052 Multiply,
+    # 1053 Divide. 1050 was previously mis-IDed as "Build Array" (it was an
+    # Add broadcasting a scalar over an array); 1052 was a duplicate "Subtract".
+    1050: "Add",
     1051: "Subtract",
-    1050: "Build Array",
+    1052: "Multiply",
+    1053: "Divide",
 }
 
 
@@ -60,35 +62,25 @@ def test_key_python_code_semantics():
     # Sign -> +/-1, To Byte Integer -> saturating I8
     assert "(in_1 > 0) - (in_1 < 0)" in str(res.resolve(prim_id=1049).python_code)
     assert "127" in str(res.resolve(prim_id=1140).python_code)
+    # 2-input arithmetic: Add / Subtract / Multiply / Divide (operators give
+    # LV's type coercion for free; Divide is true division -> always float).
+    assert "in_1 + in_2" in str(res.resolve(prim_id=1050).python_code)
+    assert "in_1 - in_2" in str(res.resolve(prim_id=1051).python_code)
+    assert "in_1 * in_2" in str(res.resolve(prim_id=1052).python_code)
+    assert "in_1 / in_2" in str(res.resolve(prim_id=1053).python_code)
 
 
 def test_numeric_primitives_are_elementwise():
     res = get_resolver()
-    for prim_id in (1051, 1049):  # Subtract, Sign broadcast over arrays
+    # Add, Subtract, Multiply, Sign all broadcast over arrays
+    for prim_id in (1050, 1051, 1052, 1049):
         assert res.resolve(prim_id=prim_id).elementwise is True
 
 
-def test_build_array_prim_1050_concatenates_not_nests():
-    """prim 1050 (plain Build Array) must route to the concatenating handler
-    ([scalar] + array), not nest into [scalar, array]."""
-    arr = LVType(kind="array", underlying_type="Array",
-                 element_type=LVType(kind="primitive", underlying_type="NumFloat64"))
-    dbl = LVType(kind="primitive", underlying_type="NumFloat64")
-    op = PrimitiveOperation(
-        id="vi::1", name="Build Array", labels=["Primitive"],
-        node_type="prim", primResID=1050,
-        terminals=[
-            Terminal(id="o", index=0, direction="output", name="appended", lv_type=arr),
-            Terminal(id="s", index=1, direction="input", name="scalar", lv_type=dbl),
-            Terminal(id="a", index=2, direction="input", name="arr", lv_type=arr),
-        ],
-    )
-    frag = _generate_primitive(op, CodeGenContext(vi_name="vi"))
-    import ast
-    mod = ast.Module(body=list(frag.statements), type_ignores=[])
-    ast.fix_missing_locations(mod)
-    src = ast.unparse(mod)
-    # The concatenating handler wraps the scalar and joins with '+';
-    # the (wrong) nesting path emits a 2-element list literal `[x, y]`.
-    assert " + " in src, f"expected concatenation, got: {src}"
-    assert "[None, None]" not in src
+def test_arithmetic_block_is_not_build_array():
+    """The 2-input arithmetic block must never resolve back to Build Array —
+    1050 was mis-IDed that way (a scalar+array Add read as concatenation).
+    Real Build Array is the expandable 'aBuild' node class, not a plain prim."""
+    res = get_resolver()
+    for prim_id in (1050, 1051, 1052, 1053):
+        assert res.resolve(prim_id=prim_id).name != "Build Array"


### PR DESCRIPTION
## Summary

Fixes two mis-identified entries in the 2-input arithmetic primitive block, exposed by an `array average.vi` (sum-in-a-loop, then divide by N) that lvkit rendered as "Build Array" + `unknown_primitive_1053`.

The block is **1050 Add, 1051 Subtract, 1052 Multiply, 1053 Divide**. Two were wrong:

- **`1050` was `"Build Array"` → it's the 2-input Add.** The prior session saw it as `scalar + array → array` in the calibration VI and read that as Build Array concatenation `[scalar, array]`, but it's Add **broadcasting** a scalar over an array (element-wise), exactly like Subtract. Removed the `1050 → generate_array_build` routing in `nodes/__init__.py`; the *real* Build Array stays the expandable **`aBuild`** node class.
- **`1052` was a duplicate `"Subtract"` → it's Multiply.**

## Details

- All four are `elementwise: true` (LV numeric polymorphism): scalar+scalar → plain operator, scalar+array → broadcast, array+array → element-wise zip **truncated to the shorter array** (matches LV's documented "shorter/smallest array" pattern). Plain Python operators give LV's type coercion for free; Divide is true division (always floats).
- **Corrects the calibration VI** from the Formula Node work — it previously *concatenated* where it should *element-wise add* (no LV oracle had caught it). Regenerates with 0 errors.
- Tests updated to lock the block (names, `python_code`, `elementwise`, "never regresses to Build Array") + a new runtime test for the truncate-to-shortest behavior. **683 pass, ruff + pyright clean.**

## Known follow-up (out of scope)

The `array average.vi` that surfaced this now uses the correct `+` / `/` operations, but its **shift-register accumulator loop** still generates incorrectly (empty loop body, mangled expression) — a separate codegen issue, not the primitive mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
