### PR TITLE
Formula Node: copy array args (fix in-place aliasing)

### DIFF
--- a/src/lvkit/codegen/nodes/formula.py
+++ b/src/lvkit/codegen/nodes/formula.py
@@ -84,6 +84,12 @@ def generate(node: FormulaOperation, ctx: CodeGenContext) -> CodeFragment:
             val = ctx.resolve(term.id) if term else None
             if val is None:
                 val = "[]" if spec.is_array else "0"
+            elif spec.is_array:
+                # LabVIEW value-copies arrays at a wire branch; the formula
+                # node works on its own buffer per terminal. Copy each array
+                # arg so the function's in-place writes can't alias the caller's
+                # data or another terminal (which corrupts results).
+                val = f"list({val})"
             input_args.append(f"{spec.name}={val}")
 
     bindings: dict[str, str] = {}

--- a/tests/test_formula_codegen.py
+++ b/tests/test_formula_codegen.py
@@ -82,6 +82,41 @@ def test_int_output_pulls_in_lv_runtime_import():
     assert "from lvkit.runtime import lv as _lv" in frag.imports
 
 
+def test_formula_does_not_mutate_callers_array():
+    """BEHAVIORAL guard (not a string match): a Formula Node writes its in/out
+    array in place, so the caller's array must NOT be mutated — LabVIEW value-
+    copies arrays at a wire branch. Built + executed end to end, so it survives
+    ANY future copy mechanism (formula-call copy OR value-copy-at-branch): if a
+    branching change re-introduces aliasing, the caller's list gets mutated and
+    this fails. This is the exact failure mode that corrupted Himmelt's VI."""
+    arr = LVType(kind="array", underlying_type="Array", element_type=_dbl())
+    op = FormulaOperation(
+        id="vi::9", name="Formula Node", labels=["FormulaNode"], node_type="fBox",
+        script="int32 i=0;\nfor (i=0; i<n; i++) buf[i] = buf[i] + 1;",
+        terminals=[
+            Terminal(id="t_in", index=0, direction="input", name="buf", lv_type=arr),
+            Terminal(id="t_out", index=1, direction="output", name="buf", lv_type=arr),
+            Terminal(id="t_n", index=2, direction="input", name="n",
+                     lv_type=LVType(kind="primitive", underlying_type="NumInt32")),
+        ],
+    )
+    from tests.helpers import make_ctx
+    ctx = make_ctx("t_in", "t_out", "t_n")
+    ctx.bind("t_in", "data")   # the input array wire...
+    ctx.bind("t_n", "count")
+    frag = formula.generate(op, ctx)
+
+    mod = ast.Module(body=[ctx.formula_helpers[0], *frag.statements],
+                     type_ignores=[])
+    ast.fix_missing_locations(mod)
+    ns: dict = {"data": [1.0, 2.0, 3.0], "count": 3}
+    exec("import math\nfrom lvkit.runtime import lv as _lv\n" + ast.unparse(mod), ns)
+
+    assert ns["data"] == [1.0, 2.0, 3.0], "caller's array was mutated (aliased!)"
+    out_var = frag.bindings["t_out"]
+    assert ns[out_var] == [2.0, 3.0, 4.0]          # the node's own (copied) buffer
+
+
 def test_unknown_function_in_script_fails_loud():
     op = _op(script="y = mystery(a);")
     ctx = CodeGenContext(vi_name="my_vi.vi")


### PR DESCRIPTION
## Summary

Fixes array **aliasing** in generated Formula Node calls. The Python backend passes arrays to the formula function by reference; a formula node writes its in/out arrays **in place**, so when one wire feeds several array terminals (input + in/out), they aliased the caller's list and each other — corrupting results.

On the calibration VI (Himmelt's issue-#2 VI) this produced wrong output: `REF_ANGLE_OUT_1` and `SETPOINT_IN_1` came back as the *same* corrupted list and the input array was mutated mid-computation.

## Root cause

LabVIEW value-copies arrays at a wire branch (value semantics, like a functional language); lvkit used Python's reference semantics. This stayed invisible because almost all codegen is expression-based/immutable — the Formula Node is one of the few places we emit genuine in-place mutation.

It also explains why the **old C/FFI backend was correct here**: marshalling copied each terminal into its own ctypes buffer (`(ctype*len)(*list)` → mutate → read back as a new list), silently providing the value-copy. Dropping the FFI dropped that free copy.

## Fix

Each array arg to the formula call is now `list(...)` — restoring the per-terminal copy.

```
ref_angle_out_1 (before): [33792, 17920, 2048, -13824, -29696]  (== setpoint, input mutated)
ref_angle_out_1 (after):  [-31744, -15872, 0, 15872, 31744]     (clean ramp, input intact)
```

With the fix, the VI runs **and** produces correct output matching the C backend (gain 15.87 ≈ 15.9 for a realistic input).

## Test

**Behavioral, not a string match:** builds the formula call, executes it, and asserts the caller's array is **not mutated**. This survives any future copy mechanism — including the proper general fix — so if a change ever re-introduces aliasing, the caller's list gets mutated and the test fails. **685 pass, ruff + pyright clean.**

## Follow-up (out of scope)

The proper general fix is **value-copy at wire branches** with in-place analysis (copy a branch only when a downstream consumer mutates, so read-only branches share) — this targeted copy patches the one mutation site (Formula Node) that the FFI used to cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
