### PR TITLE
Fix `lvkit setup copilot` treating skill name as a directory

### DIFF
--- a/src/lvkit/cli.py
+++ b/src/lvkit/cli.py
@@ -535,6 +535,14 @@ def _detect_ai_editors(root: Path) -> list[str]:
 
 def cmd_setup(args: argparse.Namespace) -> int:
     """Handle the setup command — install AI skills and create .lvkit/ store."""
+    # `directory` and `skills` are both optional positionals, so a lone
+    # `lvkit setup copilot` binds "copilot" to `directory`. If the only
+    # positional given is a skills choice, treat it as the skills target in
+    # the current directory (the obvious intent).
+    if args.skills is None and args.directory in ("claude", "copilot", "all"):
+        args.skills = args.directory
+        args.directory = "."
+
     root = Path(args.directory).resolve()
     if not root.is_dir():
         print(f"Error: Not a directory: {root}", file=sys.stderr)

--- a/tests/test_project_store.py
+++ b/tests/test_project_store.py
@@ -234,6 +234,23 @@ def test_cli_setup_creates_project_store(tmp_path: Path) -> None:
     assert not (tmp_path / ".claude").exists()
 
 
+def test_cli_setup_skills_choice_is_not_a_directory(tmp_path: Path) -> None:
+    """`lvkit setup copilot` installs copilot skills in CWD — it must NOT bind
+    'copilot' to the directory arg. Regression: that failed with 'Not a
+    directory: .../copilot'."""
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [sys.executable, "-m", "lvkit.cli", "setup", "copilot"],
+        cwd=tmp_path, capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Not a directory" not in result.stderr
+    assert (tmp_path / ".lvkit").is_dir()
+    assert (tmp_path / ".github" / "prompts").is_dir()   # copilot skills, in CWD
+
+
 # ============================================================
 # Skill installation
 # ============================================================


### PR DESCRIPTION
## Summary

`lvkit setup copilot` (reported on Windows) failed with:

```
Error: Not a directory: C:\Users\rhamner\copilot
```

`setup` has two optional positionals — `directory` (first) then `skills` — so a lone `lvkit setup copilot` binds `"copilot"` to **`directory`**, then errors because no `copilot` folder exists.

## Fix

When the only positional given is a skills choice (`claude` / `copilot` / `all`), treat it as the **skills** target in the current directory — the obvious intent:

```
lvkit setup copilot          -> directory=".", skills="copilot"   (now works)
lvkit setup <dir> copilot    -> unchanged
lvkit setup                  -> unchanged (auto-detect)
```

## Test

Added a regression test that runs `lvkit setup copilot` with `cwd=tmp_path` and asserts it installs Copilot skills (`.github/prompts/`) in the working dir without the "Not a directory" error. 34 project-store tests pass, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
