### PR TITLE
Formula Node numeric conformance to LabVIEW oracle (issue #8)

### DIFF
--- a/src/lvkit/formula/cparser.py
+++ b/src/lvkit/formula/cparser.py
@@ -297,10 +297,14 @@ class Parser:
             if self._is("("):
                 return self._parse_call(t.value)
             if self._is("["):
-                self._next()
-                idx = self.parse_expr()
-                self._expect("]")
-                return Index(t.value, idx)
+                # Chained subscripts for N-dimensional arrays: a[i][j].
+                node: Expr = Var(t.value)
+                while self._is("["):
+                    self._next()
+                    idx = self.parse_expr()
+                    self._expect("]")
+                    node = Index(node, idx)
+                return node
             return Var(t.value)
         raise self._err(f"unexpected token {t.value!r}", t)
 

--- a/src/lvkit/formula/emit.py
+++ b/src/lvkit/formula/emit.py
@@ -70,18 +70,23 @@ _KW_FLOAT = {"float32", "float64", "float"}
 
 # Formula-node function spelling -> emitted Python callee. Anything not here
 # fails loud. ``int`` rounds to nearest (ties to even); ``intrz`` truncates.
+# Domain-prone functions route through the non-raising _lv.* wrappers (a
+# Formula Node has no error terminal — LabVIEW coerces domain/zero errors to
+# IEEE inf/nan rather than trapping). Functions that never raise on real
+# inputs (sin, cos, atan, exp, …) keep their direct math.* mapping.
 _FUNC_MAP = {
-    "abs": "abs", "sqrt": "math.sqrt", "exp": "math.exp", "expm1": "math.expm1",
-    "ln": "math.log", "lnp1": "math.log1p", "log": "math.log10",
-    "log2": "math.log2", "ceil": "math.ceil", "floor": "math.floor",
+    "abs": "abs", "sqrt": "_lv.sqrt", "exp": "math.exp", "expm1": "math.expm1",
+    "ln": "_lv.ln", "lnp1": "math.log1p", "log": "_lv.log10",
+    "log2": "_lv.log2", "ceil": "math.ceil", "floor": "math.floor",
     "sin": "math.sin", "cos": "math.cos", "tan": "math.tan",
-    "asin": "math.asin", "acos": "math.acos", "atan": "math.atan",
+    "asin": "_lv.asin", "acos": "_lv.acos", "atan": "math.atan",
     "atan2": "math.atan2",
     "sinh": "math.sinh", "cosh": "math.cosh", "tanh": "math.tanh",
-    "asinh": "math.asinh", "acosh": "math.acosh", "atanh": "math.atanh",
-    "pow": "math.pow",
+    "asinh": "math.asinh", "acosh": "_lv.acosh", "atanh": "_lv.atanh",
+    "pow": "_lv.powf",
     "int": "round", "intrz": "math.trunc",
     "mod": "_lv.lvmod", "rem": "_lv.rem", "sign": "_lv.sign",
+    "getexp": "_lv.getexp", "getman": "_lv.getman",
     "max": "max", "min": "min",
     "cot": "_lv.cot", "csc": "_lv.csc", "sec": "_lv.sec", "sinc": "_lv.sinc",
 }
@@ -196,6 +201,17 @@ class _Emitter:
                 return f"_lv.rem({left}, {right})"
             if e.op in _LOGICAL_OP:
                 return f"{_LOGICAL_OP[e.op]}({left}, {right})"
+            # `/` yields IEEE inf/nan on a zero divisor (no error terminal to
+            # raise into). A literal nonzero divisor can't trap, so keep the
+            # plain operator there and only wrap the ambiguous cases.
+            if e.op == "/" and not _is_nonzero_literal(e.right):
+                return f"_lv.div({left}, {right})"
+            # `**` with a negative base and non-integer exponent is nan in
+            # LabVIEW, but Python returns a complex. Route through the helper
+            # unless the base is a provably non-negative literal (the common
+            # ``2 ** n`` case, kept as the plain operator).
+            if e.op == "**" and not _is_nonneg_literal(e.left):
+                return f"_lv.powf({left}, {right})"
             return f"({left} {e.op} {right})"
         raise FormulaTranspileError(f"cannot emit expression {e!r}")
 
@@ -440,6 +456,30 @@ class _Emitter:
             imports=imports,
             source=source,
         )
+
+
+def _is_nonzero_literal(e: Expr) -> bool:
+    """True if ``e`` is a numeric literal that is provably nonzero — so a
+    division by it cannot trap and needs no inf/nan wrapper."""
+    if not isinstance(e, Num):
+        return False
+    try:
+        return float(e.text) != 0.0
+    except ValueError:
+        return False
+
+
+def _is_nonneg_literal(e: Expr) -> bool:
+    """True if ``e`` is a provably non-negative numeric literal — so a power
+    with this base can never hit the negative-base complex-result case and
+    needs no helper. A unary-minus literal parses as Unary, not Num, so it
+    is correctly excluded."""
+    if not isinstance(e, Num):
+        return False
+    try:
+        return float(e.text) >= 0.0
+    except ValueError:
+        return False
 
 
 def _refs(e: Expr, name: str) -> bool:

--- a/src/lvkit/formula/emit.py
+++ b/src/lvkit/formula/emit.py
@@ -9,14 +9,22 @@ self-contained Python function instead of C. That keeps the original
 from the parsed AST) while dropping the C compiler / FFI / .so machinery
 entirely — generated code is pure Python and runs anywhere.
 
-LabVIEW numeric semantics are preserved:
-  * ``int / int``                -> real (float) division (Python ``/``)
+LabVIEW numeric semantics (confirmed against a real Formula Node, issue #8)
+are preserved:
+  * ``int / int``                -> real (float) division; a zero divisor
+                                    yields IEEE inf/nan (``_lv.div``) since a
+                                    Formula Node has no error terminal
   * float assigned to an int var -> round-to-nearest-even then wrap to the
                                     declared width (``_lv.i16`` etc.)
-  * ``**``                       -> Python ``**`` (already real for ints)
+  * ``**``                       -> right-assoc, tighter than unary minus; a
+                                    negative base with a non-integer exponent
+                                    is nan (``_lv.powf``), not a complex
+  * ``%`` / ``rem``              -> truncated remainder, sign of dividend;
+                                    ``mod`` is floored, sign of divisor
+  * ``&&`` ``||`` ``!``          -> 1/0 (``_lv.land``/``lor``/``lnot``)
   * ``abs``                      -> Python ``abs`` (polymorphic int/float)
-  * ``%`` with a float operand   -> ``math.fmod`` (C/LV sign-of-dividend)
-  * math functions               -> ``math.*`` / small ``_lv`` helpers
+  * domain funcs (sqrt/ln/...)   -> non-raising ``_lv.*`` (nan/inf on domain)
+  * N-D arrays                   -> nested indexing ``a[i][j]``; ``sizeOfDim``
 
 Unknown functions or type keywords raise FormulaTranspileError — never a
 silent guess.
@@ -89,9 +97,10 @@ _FUNC_MAP = {
     "getexp": "_lv.getexp", "getman": "_lv.getman",
     "max": "max", "min": "min",
     "cot": "_lv.cot", "csc": "_lv.csc", "sec": "_lv.sec", "sinc": "_lv.sinc",
+    "rand": "_lv.rand", "sizeOfDim": "_lv.size_of_dim",
 }
 # Functions whose result is an integer (drives int/float inference).
-_INT_RESULT_FUNCS = {"int", "intrz", "sign"}
+_INT_RESULT_FUNCS = {"int", "intrz", "sign", "sizeOfDim"}
 
 # Logical operators -> runtime helper. LabVIEW ``&&``/``||`` yield 1/0, not
 # the operand Python ``and``/``or`` would return. Comparisons and bitwise
@@ -148,8 +157,12 @@ class _Emitter:
     def _texpr(self, e: Expr) -> str:
         if isinstance(e, Num):
             return "float" if e.is_float else "int"
-        if isinstance(e, (Var, Index)):
+        if isinstance(e, Var):
             return self.kind.get(e.name, "float")
+        if isinstance(e, Index):
+            # An element has the array's (scalar) element kind, found via the
+            # root array variable — works for any nesting depth (a[i][j]).
+            return self.kind.get(_index_root(e), "float")
         if isinstance(e, Call):
             if e.name == "abs" and e.args:
                 return self._texpr(e.args[0])
@@ -179,7 +192,7 @@ class _Emitter:
         if isinstance(e, Var):
             return "math.pi" if e.name == "pi" else e.name
         if isinstance(e, Index):
-            return f"{e.name}[{self._emit_expr(e.index)}]"
+            return f"{self._emit_expr(e.base)}[{self._emit_expr(e.index)}]"
         if isinstance(e, Call):
             callee = _FUNC_MAP.get(e.name)
             if callee is None:
@@ -273,8 +286,9 @@ class _Emitter:
     def _emit_assign(self, s: Assign) -> str:
         if isinstance(s.target, Index):
             tgt = self._emit_expr(s.target)
-            # element store: an int-element array coerces like a scalar int
-            rhs = self._emit_store(s.target.name, s.value)
+            # element store: an int-element array coerces like a scalar int,
+            # keyed by the root array variable (handles a[i] and a[i][j]).
+            rhs = self._emit_store(_index_root(s.target), s.value)
             return f"{tgt} = {rhs}"
         return f"{s.target.name} = {self._emit_store(s.target.name, s.value)}"
 
@@ -458,6 +472,14 @@ class _Emitter:
         )
 
 
+def _index_root(e: Expr) -> str:
+    """The root array variable name of a (possibly nested) subscript, e.g.
+    ``a`` for ``a[i]`` and ``a[i][j]``. Empty string if the base isn't a Var."""
+    while isinstance(e, Index):
+        e = e.base
+    return e.name if isinstance(e, Var) else ""
+
+
 def _is_nonzero_literal(e: Expr) -> bool:
     """True if ``e`` is a numeric literal that is provably nonzero — so a
     division by it cannot trap and needs no inf/nan wrapper."""
@@ -487,7 +509,7 @@ def _refs(e: Expr, name: str) -> bool:
     if isinstance(e, Var):
         return e.name == name
     if isinstance(e, Index):
-        return e.name == name or _refs(e.index, name)
+        return _refs(e.base, name) or _refs(e.index, name)
     if isinstance(e, Unary):
         return _refs(e.operand, name)
     if isinstance(e, Binary):

--- a/src/lvkit/formula/emit.py
+++ b/src/lvkit/formula/emit.py
@@ -81,15 +81,17 @@ _FUNC_MAP = {
     "asinh": "math.asinh", "acosh": "math.acosh", "atanh": "math.atanh",
     "pow": "math.pow",
     "int": "round", "intrz": "math.trunc",
-    "mod": "_lv.fmod", "rem": "_lv.rem", "sign": "_lv.sign",
+    "mod": "_lv.lvmod", "rem": "_lv.rem", "sign": "_lv.sign",
     "max": "max", "min": "min",
     "cot": "_lv.cot", "csc": "_lv.csc", "sec": "_lv.sec", "sinc": "_lv.sinc",
 }
 # Functions whose result is an integer (drives int/float inference).
 _INT_RESULT_FUNCS = {"int", "intrz", "sign"}
 
-# C-style binary operator -> Python spelling. Comparisons/bitwise map 1:1.
-_OP_MAP = {"&&": "and", "||": "or"}
+# Logical operators -> runtime helper. LabVIEW ``&&``/``||`` yield 1/0, not
+# the operand Python ``and``/``or`` would return. Comparisons and bitwise
+# operators map 1:1 onto Python and need no entry here.
+_LOGICAL_OP = {"&&": "_lv.land", "||": "_lv.lor"}
 
 
 @dataclass
@@ -182,16 +184,19 @@ class _Emitter:
         if isinstance(e, Unary):
             inner = self._emit_expr(e.operand)
             if e.op == "!":
-                return f"(not {inner})"
+                return f"_lv.lnot({inner})"
             return f"({e.op}{inner})"
         if isinstance(e, Binary):
             left = self._emit_expr(e.left)
             right = self._emit_expr(e.right)
-            if e.op == "%" and "float" in (self._texpr(e.left),
-                                           self._texpr(e.right)):
-                return f"math.fmod({left}, {right})"
-            op = _OP_MAP.get(e.op, e.op)
-            return f"({left} {op} {right})"
+            # LabVIEW ``%`` is the truncated remainder (sign of dividend) for
+            # both ints and floats — Python ``%`` is floored, so always route
+            # through the helper.
+            if e.op == "%":
+                return f"_lv.rem({left}, {right})"
+            if e.op in _LOGICAL_OP:
+                return f"{_LOGICAL_OP[e.op]}({left}, {right})"
+            return f"({left} {e.op} {right})"
         raise FormulaTranspileError(f"cannot emit expression {e!r}")
 
     # --- assignment with int rounding/width coercion ---

--- a/src/lvkit/formula/nodes.py
+++ b/src/lvkit/formula/nodes.py
@@ -24,7 +24,7 @@ class Var:
 
 @dataclass
 class Index:
-    name: str
+    base: Expr         # array expression: a Var, or another Index for N-D (a[i][j])
     index: Expr
 
 

--- a/src/lvkit/runtime/lv.py
+++ b/src/lvkit/runtime/lv.py
@@ -76,8 +76,29 @@ def u64(x): return _int_store(x, 64, False)
 
 
 def sign(x):     return (x > 0) - (x < 0)
-def fmod(a, b):  return _math.fmod(a, b)            # C/LV %: sign of dividend
-def rem(a, b):   return a - b * round(a / b)        # remainder after round-div
+
+
+def rem(a, b):
+    """Truncated remainder — LabVIEW ``%`` operator and ``rem()``. Sign
+    follows the dividend (``-7 rem 3 == -1``). Integer-exact for ints."""
+    if isinstance(a, int) and isinstance(b, int):
+        q = abs(a) // abs(b)
+        r = abs(a) - q * abs(b)
+        return -r if a < 0 else r
+    return _math.fmod(a, b)
+
+
+def lvmod(a, b):
+    """Floored modulo — LabVIEW ``mod()``. Sign follows the divisor
+    (``mod(-7, 3) == 2``)."""
+    if isinstance(a, int) and isinstance(b, int):
+        return a % b                            # Python ``%`` is floored
+    return a - b * _math.floor(a / b)
+
+
+def land(a, b):  return 1 if (a and b) else 0       # && yields 1/0, not operand
+def lor(a, b):   return 1 if (a or b) else 0        # || yields 1/0, not operand
+def lnot(a):     return 0 if a else 1
 def cot(x):      return 1.0 / _math.tan(x)
 def csc(x):      return 1.0 / _math.sin(x)
 def sec(x):      return 1.0 / _math.cos(x)

--- a/src/lvkit/runtime/lv.py
+++ b/src/lvkit/runtime/lv.py
@@ -81,6 +81,8 @@ def sign(x):     return (x > 0) - (x < 0)
 def rem(a, b):
     """Truncated remainder — LabVIEW ``%`` operator and ``rem()``. Sign
     follows the dividend (``-7 rem 3 == -1``). Integer-exact for ints."""
+    if b == 0:
+        return _math.nan
     if isinstance(a, int) and isinstance(b, int):
         q = abs(a) // abs(b)
         r = abs(a) - q * abs(b)
@@ -91,9 +93,89 @@ def rem(a, b):
 def lvmod(a, b):
     """Floored modulo — LabVIEW ``mod()``. Sign follows the divisor
     (``mod(-7, 3) == 2``)."""
+    if b == 0:
+        return _math.nan
     if isinstance(a, int) and isinstance(b, int):
         return a % b                            # Python ``%`` is floored
     return a - b * _math.floor(a / b)
+
+
+# --- non-raising math (a Formula Node has no error terminal, so LabVIEW
+# coerces domain/zero errors to IEEE inf/nan instead of trapping) -----------
+
+
+def div(a, b):
+    """Real division that yields IEEE inf/nan on a zero divisor instead of
+    raising (``1/0 -> inf``, ``-1/0 -> -inf``, ``0/0 -> nan``)."""
+    if b != 0:
+        return a / b
+    if a == 0:
+        return _math.nan
+    return _math.copysign(_math.inf, a) * _math.copysign(1.0, b)
+
+
+def powf(a, b):
+    """Power with LabVIEW edge semantics: a negative base raised to a
+    non-integer exponent is ``nan`` (not a complex number); ``0**0 == 1``."""
+    if a < 0 and b != _math.floor(b):
+        return _math.nan
+    try:
+        return _math.pow(a, b)
+    except (ValueError, OverflowError):
+        return _math.nan
+
+
+def sqrt(x):  return _math.sqrt(x) if x >= 0 else _math.nan
+
+
+def ln(x):
+    if x > 0:
+        return _math.log(x)
+    return -_math.inf if x == 0 else _math.nan
+
+
+def log10(x):
+    if x > 0:
+        return _math.log10(x)
+    return -_math.inf if x == 0 else _math.nan
+
+
+def log2(x):
+    if x > 0:
+        return _math.log2(x)
+    return -_math.inf if x == 0 else _math.nan
+
+
+def asin(x):  return _math.asin(x) if -1 <= x <= 1 else _math.nan
+def acos(x):  return _math.acos(x) if -1 <= x <= 1 else _math.nan
+def acosh(x): return _math.acosh(x) if x >= 1 else _math.nan
+
+
+def atanh(x):
+    if -1 < x < 1:
+        return _math.atanh(x)
+    if x == 1:
+        return _math.inf
+    if x == -1:
+        return -_math.inf
+    return _math.nan
+
+
+def getexp(x):
+    """Binary exponent e where ``x == getman(x) * 2**e`` and the mantissa is
+    in [1, 2) — LabVIEW ``getexp`` (e.g. ``getexp(12) == 3``)."""
+    if x == 0:
+        return 0.0
+    _, e = _math.frexp(x)                        # frexp mantissa is in [0.5, 1)
+    return float(e - 1)
+
+
+def getman(x):
+    """Binary mantissa in [1, 2) — LabVIEW ``getman`` (``getman(12) == 1.5``)."""
+    if x == 0:
+        return 0.0
+    m, _ = _math.frexp(x)
+    return m * 2.0
 
 
 def land(a, b):  return 1 if (a and b) else 0       # && yields 1/0, not operand

--- a/src/lvkit/runtime/lv.py
+++ b/src/lvkit/runtime/lv.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import math as _math
 import operator as _op
+import random as _random
 from collections.abc import Callable
 
 
@@ -176,6 +177,24 @@ def getman(x):
         return 0.0
     m, _ = _math.frexp(x)
     return m * 2.0
+
+
+def rand():
+    """Uniform pseudo-random float in [0, 1) — LabVIEW ``rand()``. The value
+    is intentionally non-deterministic at runtime (codegen stays stable)."""
+    return _random.random()
+
+
+def size_of_dim(arr, dim):
+    """Length of array ``arr`` along dimension ``dim`` — LabVIEW
+    ``sizeOfDim``. Dim 0 is the outermost (``len(arr)``); deeper dims descend
+    one nesting level each. Out-of-range / ragged access returns 0."""
+    cur = arr
+    for _ in range(dim):
+        if not isinstance(cur, list) or not cur:
+            return 0
+        cur = cur[0]
+    return len(cur) if isinstance(cur, list) else 0
 
 
 def land(a, b):  return 1 if (a and b) else 0       # && yields 1/0, not operand

--- a/tests/test_formula_runtime.py
+++ b/tests/test_formula_runtime.py
@@ -35,13 +35,25 @@ def test_round_ties_to_even_on_store():
     assert lv.i32(-2.5) == -2
 
 
-def test_sign_fmod_rem():
+def test_sign_rem_mod_logical():
     assert lv.sign(-3.2) == -1
     assert lv.sign(0) == 0
     assert lv.sign(5) == 1
-    # C/LV fmod takes the sign of the dividend (Python % takes the divisor's)
-    assert lv.fmod(-7.0, 3.0) == -1.0
-    assert lv.rem(7.5, 2.0) == -0.5       # 7.5 - 2*round(3.75) = 7.5 - 8
+    # `%` / rem(): truncated remainder, sign of the dividend (oracle-confirmed).
+    assert lv.rem(-7, 3) == -1
+    assert lv.rem(7, -3) == 1
+    assert lv.rem(3, 2) == 1
+    assert lv.rem(7.5, 2.0) == 1.5
+    # mod(): floored, sign of the divisor.
+    assert lv.lvmod(-7, 3) == 2
+    assert lv.lvmod(7.5, 2.0) == 1.5
+    # &&/||/! yield 1/0, not the Python operand.
+    assert lv.land(5, 3) == 1
+    assert lv.land(5, 0) == 0
+    assert lv.lor(0, 5) == 1
+    assert lv.lor(0, 0) == 0
+    assert lv.lnot(5) == 0
+    assert lv.lnot(0) == 1
 
 
 # --- emitted function executes (scalar + array marshaling) -----------------

--- a/tests/test_formula_semantics.py
+++ b/tests/test_formula_semantics.py
@@ -108,3 +108,55 @@ def test_integer_semantics(script, expected):
 def test_float_semantics(script, expected):
     out = _run(script, _VARS, RI=[0] * 4, RF=[0.0], A=[10.0, 20, 30, 40, 50], n=5)
     assert out["RF"][0] == pytest.approx(expected, rel=1e-9, abs=1e-9), script
+
+
+# A Formula Node has no error terminal, so domain/zero errors coerce to IEEE
+# inf/nan rather than raising (oracle Script 2). The pure-Python backend
+# routes these through non-raising _lv.* helpers.
+_EDGE_CASES = [
+    ("RF[0] = 1 / 0;", math.inf), ("RF[0] = 1.0 / 0.0;", math.inf),
+    ("RF[0] = -1.0 / 0.0;", -math.inf), ("RF[0] = 0.0 / 0.0;", math.nan),
+    ("RF[0] = sqrt(-1.0);", math.nan), ("RF[0] = ln(0.0);", -math.inf),
+    ("RF[0] = ln(-1.0);", math.nan), ("RF[0] = log(0.0);", -math.inf),
+    ("RF[0] = acos(2.0);", math.nan), ("RF[0] = asin(2.0);", math.nan),
+    ("RF[0] = (-8) ** (1.0 / 3.0);", math.nan), ("RF[0] = 0 ** 0;", 1.0),
+    # getexp/getman: mantissa in [1, 2), x == getman(x) * 2**getexp(x).
+    ("RF[0] = getexp(12.0);", 3.0), ("RF[0] = getman(12.0);", 1.5),
+    ("RF[0] = getexp(0.75);", -1.0), ("RF[0] = getman(0.75);", 1.5),
+]
+
+
+@pytest.mark.parametrize("script, expected", _EDGE_CASES)
+def test_no_error_terminal_coercion(script, expected):
+    out = _run(script, _VARS, RI=[0] * 4, RF=[0.0], A=[10.0, 20, 30, 40, 50], n=5)
+    got = out["RF"][0]
+    if math.isnan(expected):
+        assert isinstance(got, float) and math.isnan(got), script
+    else:
+        assert got == expected, script
+
+
+def test_division_wraps_only_ambiguous_divisors():
+    # A nonzero literal divisor can't trap -> keep the plain operator; a
+    # variable (or expression) divisor routes through the inf/nan helper.
+    src = transpile("y = a / 2; z = a / b;", [
+        VarSpec("y", "NumFloat64", "out", False),
+        VarSpec("z", "NumFloat64", "out", False),
+        VarSpec("a", "NumFloat64", "in", False),
+        VarSpec("b", "NumFloat64", "in", False),
+    ]).source
+    assert "a / 2" in src
+    assert "_lv.div(a, b)" in src
+
+
+def test_power_wraps_only_non_literal_base():
+    # ``2 ** n`` can't produce a complex result -> plain operator; a base that
+    # might be negative routes through _lv.powf.
+    src = transpile("y = 2 ** n; z = b ** 0.5;", [
+        VarSpec("y", "NumFloat64", "out", False),
+        VarSpec("z", "NumFloat64", "out", False),
+        VarSpec("n", "NumInt32", "in", False),
+        VarSpec("b", "NumFloat64", "in", False),
+    ]).source
+    assert "2 ** n" in src
+    assert "_lv.powf(b, 0.5)" in src

--- a/tests/test_formula_semantics.py
+++ b/tests/test_formula_semantics.py
@@ -160,3 +160,39 @@ def test_power_wraps_only_non_literal_base():
     ]).source
     assert "2 ** n" in src
     assert "_lv.powf(b, 0.5)" in src
+
+
+def test_rand_is_uniform_unit_interval():
+    out = _run("RF[0] = rand();", _VARS,
+               RI=[0] * 4, RF=[0.0], A=[1.0], n=1)
+    assert isinstance(out["RF"][0], float) and 0.0 <= out["RF"][0] < 1.0
+
+
+def test_size_of_dim_1d():
+    # Oracle: sizeOfDim(A, 0) == 5 for a 5-element array.
+    out = _run("RI[0] = sizeOfDim(A, 0);", _VARS,
+               RI=[0] * 4, RF=[0.0], A=[10.0, 20, 30, 40, 50], n=5)
+    assert out["RI"][0] == 5
+
+
+def test_size_of_dim_2d_natural_convention():
+    # Dim 0 is the outer length, dim 1 the inner — natural nested convention.
+    variables = [
+        VarSpec("RI", "NumInt32", "inout", True),
+        VarSpec("B", "NumFloat64", "in", True),
+    ]
+    out = _run("RI[0] = sizeOfDim(B, 0); RI[1] = sizeOfDim(B, 1);",
+               variables, RI=[0, 0], B=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    assert out["RI"][0] == 2   # rows
+    assert out["RI"][1] == 3   # columns
+
+
+def test_2d_index_read_and_write():
+    variables = [
+        VarSpec("B", "NumFloat64", "inout", True),
+        VarSpec("y", "NumFloat64", "out", False),
+    ]
+    out = _run("y = B[1][2]; B[0][1] = 99.0;", variables,
+               B=[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    assert out["y"] == 6.0              # nested read, row 1 col 2
+    assert out["B"][0][1] == 99.0       # nested write in place

--- a/tests/test_formula_semantics.py
+++ b/tests/test_formula_semantics.py
@@ -1,0 +1,110 @@
+"""Locked LabVIEW Formula Node numeric-semantics regression.
+
+Ground truth: a real Formula Node run reported by @Himmelt on
+github.com/pragmatest-dev/lvkit issues/8 (the probe in
+docs/formula_semantics_probe.md). Each case below transpiles a tiny
+script, EXECUTES the emitted Python, and asserts the value LabVIEW
+produced — pinning the numeric model the NI docs leave underspecified.
+
+Covers only the constructs the backend supports today and whose oracle
+result is consistent. Deliberately NOT locked here (tracked separately):
+  * `~`/negative-operand bitwise: LV returned INT32_MAX for `~0`, `~5`,
+    `-1 & 255` — anomalous vs two's complement; needs interpretation.
+  * getexp/getman/rand/sizeOfDim and 2D indexing: not yet supported
+    (fail loud).
+  * div-by-zero / domain edges (Script 2): LV yields inf/nan, the pure
+    Python backend currently raises — a separate decision.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from lvkit.formula.emit import VarSpec, transpile
+from lvkit.runtime import lv as _lv
+
+
+def _run(script: str, variables: list[VarSpec], **inputs):
+    res = transpile(script, variables)
+    ns: dict = {"_lv": _lv, "math": math}
+    exec(res.source, ns)
+    return ns["formula"](**inputs)
+
+
+# Int32 inout array RI, float64 inout array RF, double input array A, n int32.
+_VARS = [
+    VarSpec("RI", "NumInt32", "inout", True),
+    VarSpec("RF", "NumFloat64", "inout", True),
+    VarSpec("A", "NumFloat64", "in", True),
+    VarSpec("n", "NumInt32", "in", False),
+]
+
+# (script line, expected int32 result) — oracle RI rows, anomalies excluded.
+_INT_CASES = [
+    # round-to-nearest-even when a real is stored into an int terminal
+    ("RI[0] = 0.5;", 0), ("RI[0] = 1.5;", 2), ("RI[0] = 2.5;", 2),
+    ("RI[0] = 3.5;", 4), ("RI[0] = -2.5;", -2),
+    # fixed-width integer wrap on a typed local, then read back
+    ("uInt8 u; u = 300; RI[0] = u;", 44),
+    ("uInt8 u; u = -1; RI[0] = u;", 255),
+    ("int8 i; i = 200; RI[0] = i;", -56),
+    ("uInt16 u; u = 70000; RI[0] = u;", 4464),
+    ("int16 i; i = 40000; RI[0] = i;", -25536),
+    ("uInt32 u; u = 5000000000; RI[0] = u;", 705032704),
+    # arithmetic promotes — int16 30000+30000 does NOT wrap at 16 bits
+    ("int16 a; int16 b; a = 30000; b = 30000; RI[0] = a + b;", 60000),
+    # `/` is always real division; the int store rounds (ties to even)
+    ("RI[0] = 7 / 2;", 4), ("RI[0] = -7 / 2;", -4), ("RI[0] = 5 / 2;", 2),
+    # `%` is truncated (sign of dividend)
+    ("RI[0] = -7 % 3;", -1), ("RI[0] = 7 % -3;", 1),
+    # bitwise (non-anomalous rows)
+    ("RI[0] = 12 & 10;", 8), ("RI[0] = 12 | 10;", 14), ("RI[0] = 12 ^ 10;", 6),
+    ("RI[0] = 1 << 4;", 16), ("RI[0] = 1 << 31;", -2147483648),
+    ("RI[0] = -8 >> 1;", -4), ("RI[0] = 256 >> 2;", 64),
+    # comparisons + logical yield 1/0
+    ("RI[0] = (3 > 2);", 1), ("RI[0] = (2 > 3);", 0),
+    ("RI[0] = (5 == 5);", 1), ("RI[0] = (3 <= 3);", 1),
+    ("RI[0] = (5 && 3);", 1), ("RI[0] = (5 && 0);", 0),
+    ("RI[0] = (0 || 5);", 1), ("RI[0] = (0 || 0);", 0),
+    ("RI[0] = !5;", 0), ("RI[0] = !0;", 1), ("RI[0] = !!5;", 1),
+    # power: right-assoc, binds tighter than unary minus; integer powers
+    ("RI[0] = 2 ** 3;", 8), ("RI[0] = (-2) ** 2;", 4), ("RI[0] = (-2) ** 3;", -8),
+    ("RI[0] = 2 ** 3 ** 2;", 512), ("RI[0] = -2 ** 2;", -4),
+    # precedence: * over +, + over <<, left-assoc subtraction
+    ("RI[0] = 1 + 2 * 3;", 7), ("RI[0] = 1 << 2 + 1;", 8),
+    ("RI[0] = 20 - 5 - 3;", 12),
+    ("RI[0] = abs(-3);", 3), ("RI[0] = sign(-3);", -1), ("RI[0] = sign(0);", 0),
+]
+
+# (script line, expected float result) — oracle RF rows.
+_FLOAT_CASES = [
+    ("RF[0] = 7 / 2;", 3.5), ("RF[0] = 1 / 3;", 1 / 3),
+    ("RF[0] = 2 ** -1;", 0.5), ("RF[0] = 2 ** 0.5;", math.sqrt(2)),
+    ("RF[0] = mod(-7, 3);", 2.0), ("RF[0] = mod(7.5, 2);", 1.5),
+    ("RF[0] = rem(7, 3);", 1.0), ("RF[0] = rem(-7, 3);", -1.0),
+    ("RF[0] = sin(pi / 2);", 1.0), ("RF[0] = log(100.0);", 2.0),
+    ("RF[0] = ln(2.718281828459045);", 1.0), ("RF[0] = log2(8.0);", 3.0),
+    ("RF[0] = sqrt(2.0);", math.sqrt(2)), ("RF[0] = abs(-2.5);", 2.5),
+    ("RF[0] = int(2.5);", 2.0), ("RF[0] = int(-2.5);", -2.0),
+    ("RF[0] = intrz(2.7);", 2.0), ("RF[0] = intrz(-2.7);", -2.0),
+    ("RF[0] = ceil(2.1);", 3.0), ("RF[0] = floor(-2.1);", -3.0),
+    ("RF[0] = max(2.0, 5.0);", 5.0), ("RF[0] = min(2.0, 5.0);", 2.0),
+    ("RF[0] = cot(1.0);", 1.0 / math.tan(1.0)),
+    ("RF[0] = sinc(1.0);", math.sin(1.0)),
+    ("RF[0] = pi;", math.pi),
+    ("RF[0] = A[0];", 10.0), ("RF[0] = A[n - 1];", 50.0),
+]
+
+
+@pytest.mark.parametrize("script, expected", _INT_CASES)
+def test_integer_semantics(script, expected):
+    out = _run(script, _VARS, RI=[0] * 4, RF=[0.0], A=[10.0, 20, 30, 40, 50], n=5)
+    assert out["RI"][0] == expected, script
+
+
+@pytest.mark.parametrize("script, expected", _FLOAT_CASES)
+def test_float_semantics(script, expected):
+    out = _run(script, _VARS, RI=[0] * 4, RF=[0.0], A=[10.0, 20, 30, 40, 50], n=5)
+    assert out["RF"][0] == pytest.approx(expected, rel=1e-9, abs=1e-9), script

--- a/tests/test_formula_transpile.py
+++ b/tests/test_formula_transpile.py
@@ -79,13 +79,15 @@ def test_fixed_width_integer_wraps():
     assert _run("k = a;", variables, a=300)["k"] == 44     # 300 % 256
 
 
-def test_modulo_float_uses_fmod():
+def test_modulo_is_truncated_remainder():
     variables = [
         VarSpec("y", "NumFloat64", "out", False),
         VarSpec("a", "NumFloat64", "in", False),
         VarSpec("b", "NumFloat64", "in", False),
     ]
-    assert "math.fmod(a, b)" in _src("y = a % b;", variables)
+    # LV `%` is the truncated remainder (sign of the dividend) for ints and
+    # floats alike, so it always routes through the helper, not Python `%`.
+    assert "_lv.rem(a, b)" in _src("y = a % b;", variables)
     assert _run("y = a % b;", variables, a=7.5, b=2.0)["y"] == 1.5
 
 


### PR DESCRIPTION
Conforms the Formula Node → Python backend to a real LabVIEW Formula Node run reported by @Himmelt in #8 (the probe in `docs/formula_semantics_probe.md`). Decoding the oracle confirmed most of the shipped model and exposed several divergences, now fixed and locked as executing regression tests.

## Numeric bug fixes (commit 1)
| construct | was | LabVIEW | fix |
|---|---|---|---|
| int `%` | `-7%3 → 2` (floored) | `-1` (truncated) | `_lv.rem` |
| `mod()` | fmod (truncated) | floored | `_lv.lvmod` |
| `rem()` | round-based | truncated | rewrote `_lv.rem` |
| `&&` `\|\|` `!` | returns operand (`5&&3→3`) | `1/0` | `_lv.land/lor/lnot` |

## Domain/zero coercion (commit 2)
A Formula Node has no error terminal, so LabVIEW coerces domain and divide-by-zero errors to IEEE inf/nan instead of raising. Added non-raising `_lv` wrappers (`div`, `powf`, `sqrt`, `ln`, `log10`, `log2`, `asin`, `acos`, `acosh`, `atanh`). Division wraps only when the divisor isn't a provably-nonzero literal, and `**` wraps only when the base isn't a provably-non-negative literal, so common `x / 2` and `2 ** n` stay plain operators. Also added `getexp`/`getman`. Matches the oracle: `1/0→inf`, `0/0→nan`, `sqrt(-1)→nan`, `(-8)**(1/3)→nan` (was a Python complex — a latent bug), `0**0→1`.

## rand / sizeOfDim / N-D indexing (commit 3)
Previously failed loud. `rand()`→`_lv.rand`, `sizeOfDim`→`_lv.size_of_dim` (natural nested convention), and `a[i][j]` N-D indexing (extended the `Index` AST node + parser chained subscripts).

## Tests
Locked in `tests/test_formula_semantics.py` (oracle rows as executing assertions). The Himmelt calibration VI regenerates and still imports. Full suite + ruff + pyright clean.

## Known divergences left (tracked, not guessed)
- LabVIEW returns the element default (0) on out-of-bounds index for every dimension; lvkit raises `IndexError`.
- `~0` / `~5` / `-1 & 255` returned INT32_MAX in the oracle — anomalous vs two's complement, excluded pending a re-probe on #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)