### PR TITLE
Make codegen output deterministic across processes

### DIFF
--- a/src/lvkit/graph/core.py
+++ b/src/lvkit/graph/core.py
@@ -56,6 +56,21 @@ _KIND_TO_LABELS: dict[str, list[str]] = {
 # Graph node kinds that represent executable operations
 _OPERATION_KINDS = ("vi", "primitive", "operation", "caseStruct", "loop", "formula")
 
+
+def _node_order_key(uid: str) -> tuple[str, int, str]:
+    """Deterministic ordering key for node UIDs.
+
+    Node UIDs are stored in per-VI sets whose iteration order is
+    hash-randomized between processes. Sorting by this key — VI base, then
+    numeric LabVIEW object id — gives a stable, natural order so codegen and
+    diffs are byte-for-byte reproducible. Independent (parallel) operations
+    left tied by the topological sort are broken by this key rather than by
+    set iteration order.
+    """
+    base, _, tail = uid.rpartition("::")
+    return (base, int(tail), "") if tail.isdigit() else (uid, -1, uid)
+
+
 def _get_operation_labels(kind: str) -> list[str]:
     """Get labels for an operation based on its kind."""
     return _KIND_TO_LABELS.get(kind, ["Operation"])

--- a/src/lvkit/graph/operations.py
+++ b/src/lvkit/graph/operations.py
@@ -34,6 +34,7 @@ from .core import (
     _OPERATION_KINDS,
     _get_operation_labels,
     _graph_node_to_op_kind,
+    _node_order_key,
 )
 from .models import (
     CaseStructureNode,
@@ -374,11 +375,14 @@ class OperationsMixin:
         if len(op_uid_set) <= 1:
             return list(uids)
 
-        # Build dependency graph among inner operation nodes
+        # Build dependency graph among inner operation nodes. Insert nodes in
+        # a deterministic order (op_uid_set is hash-randomized) and break
+        # topological ties with the same key, so parallel inner ops emit in a
+        # stable order — codegen must be reproducible.
         dep = nx.DiGraph()
-        dep.add_nodes_from(op_uid_set)
+        dep.add_nodes_from(sorted(op_uid_set, key=_node_order_key))
 
-        for uid in op_uid_set:
+        for uid in sorted(op_uid_set, key=_node_order_key):
             if uid not in self._graph:
                 continue
             for _, dest, edata in self._graph.out_edges(uid, data=True):
@@ -386,9 +390,11 @@ class OperationsMixin:
                     dep.add_edge(uid, dest)
 
         try:
-            sorted_ops = list(nx.topological_sort(dep))
+            sorted_ops = list(
+                nx.lexicographical_topological_sort(dep, key=_node_order_key)
+            )
         except nx.NetworkXUnfeasible:
-            sorted_ops = list(op_uid_set)
+            sorted_ops = sorted(op_uid_set, key=_node_order_key)
 
         # Build final list: sorted ops first, then non-op uids
         sorted_set = set(sorted_ops)
@@ -428,7 +434,9 @@ class OperationsMixin:
             gnode = self._graph.nodes[uid].get("node")
             if gnode is not None and gnode.parent == parent_uid:
                 children.append(uid)
-        return children
+        # node_uids is a hash-randomized set — order deterministically so the
+        # structure's inner-node ordering is reproducible.
+        return sorted(children, key=_node_order_key)
 
     def _populate_frame_operations(
         self,

--- a/src/lvkit/graph/queries.py
+++ b/src/lvkit/graph/queries.py
@@ -19,7 +19,7 @@ import networkx as nx
 
 from ..models import FPTerminal, Operation, Terminal
 from ..vilib_resolver import get_resolver as get_vilib_resolver
-from .core import _OPERATION_KINDS, _graph_node_to_op_kind
+from .core import _OPERATION_KINDS, _graph_node_to_op_kind, _node_order_key
 from .models import (
     AnyGraphNode,
     ClusterInfo,
@@ -557,8 +557,9 @@ class QueryMixin:
         ]
         op_set = set(ordered_ids)
 
-        # Add any top-level ops not in the sorted order (disconnected)
-        for uid in top_level_op_uids:
+        # Add any top-level ops not in the sorted order (disconnected) in a
+        # deterministic order — top_level_op_uids is a hash-randomized set.
+        for uid in sorted(top_level_op_uids, key=_node_order_key):
             if uid not in op_set:
                 ordered_ids.append(uid)
 
@@ -600,11 +601,15 @@ class QueryMixin:
         if not op_ids:
             return []
 
-        # Build operation-level dependency graph from edges
+        # Build operation-level dependency graph from edges. Insert nodes in
+        # a deterministic order (op_ids is a hash-randomized set) and break
+        # topological-sort ties with the same key, so independent operations
+        # land in a stable order — codegen output must be reproducible.
+        ordered_ids = sorted(op_ids, key=_node_order_key)
         op_deps = nx.DiGraph()
-        op_deps.add_nodes_from(op_ids)
+        op_deps.add_nodes_from(ordered_ids)
 
-        for uid in op_ids:
+        for uid in ordered_ids:
             if uid not in self._graph:
                 continue
             for _, dest, edata in self._graph.out_edges(uid, data=True):
@@ -612,9 +617,11 @@ class QueryMixin:
                     op_deps.add_edge(uid, dest)
 
         try:
-            return list(nx.topological_sort(op_deps))
+            return list(
+                nx.lexicographical_topological_sort(op_deps, key=_node_order_key)
+            )
         except nx.NetworkXUnfeasible:
-            return list(op_ids)
+            return ordered_ids
 
     def get_predecessors(self, vi_name: str, node_id: str) -> list[str]:
         """Get nodes that feed into this node (direct predecessors)."""

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -1,0 +1,52 @@
+"""Codegen must be byte-for-byte reproducible across processes.
+
+Node UIDs live in per-VI sets whose iteration order is randomized by
+PYTHONHASHSEED between processes. If any ordering-sensitive step (operation
+order, parallel-tier membership, inner-structure ordering, variable naming)
+iterates such a set, the generated source changes from run to run. This test
+generates the same VI under several hash seeds and asserts identical output.
+
+`In.vi` is chosen because it emits a concurrent.futures parallel tier — the
+exact path where independent operations used to come out in set order.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / "scripts" / "generate_python.py"
+# A bundled VI that emits a parallel (ThreadPoolExecutor) tier.
+PARALLEL_VI = REPO / "samples" / "DAQmx-Digital-IO" / "In.vi"
+
+
+def _generate(vi: Path, out_dir: Path, hashseed: str) -> str:
+    env = {**os.environ, "PYTHONHASHSEED": hashseed}
+    subprocess.run(
+        [sys.executable, str(SCRIPT), str(vi), "-o", str(out_dir)],
+        check=True, capture_output=True, env=env, cwd=REPO,
+    )
+    return "\n".join(
+        f"# === {p.relative_to(out_dir)} ===\n{p.read_text()}"
+        for p in sorted(out_dir.rglob("*.py"))
+    )
+
+
+@pytest.mark.skipif(not PARALLEL_VI.exists(), reason="sample VI not present")
+def test_codegen_is_hashseed_independent(tmp_path):
+    outputs = [
+        _generate(PARALLEL_VI, tmp_path / f"seed_{seed}", seed)
+        for seed in ("0", "1", "12345")
+    ]
+    assert outputs[0], "expected generated Python output"
+    assert "ThreadPoolExecutor" in outputs[0], (
+        "fixture should exercise the parallel-tier ordering path"
+    )
+    # Every seed must produce identical source.
+    assert outputs[1] == outputs[0]
+    assert outputs[2] == outputs[0]


### PR DESCRIPTION
Generated Python varied with `PYTHONHASHSEED` between runs: per-VI node UIDs live in `set`s, and several ordering-sensitive steps iterated them, so independent (parallel) operations swapped order and their collision-suffix variable names (`output_array_696` vs `_999`) swapped with them.

## Fix
Added a shared `_node_order_key` (VI base, then numeric LabVIEW object id) and applied it everywhere node order is materialized:
- `get_operation_order` / `_sort_inner_uids`: insert dependency-graph nodes in key order and break topological-sort ties with `nx.lexicographical_topological_sort(key=...)`, so parallel tiers are stable.
- `get_operations` disconnected-op append and `_get_children_of`: sort before emitting.

## Result
Generating the same VI under different hash seeds now produces byte-for-byte identical output (verified across single VIs, a formula VI, and a multi-VI class). Regression test in `tests/test_determinism.py` generates a parallel-branch sample under three seeds and asserts equality.

> Note: touches `graph/queries.py` in different functions than #11 (frame attribution) — no textual conflict expected, but re-run tests on whichever merges second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)