### PR TITLE
Attribute frame-nested constants; denoise diff Wiring section

### DIFF
--- a/src/lvkit/graph/construction.py
+++ b/src/lvkit/graph/construction.py
@@ -792,43 +792,58 @@ class ConstructionMixin:
         # === 4. Set parent/frame on inner operation nodes ===
         # After all nodes are created, walk parser structures and stamp
         # containment info on the graph nodes they own.
+        #
+        # frame_owner maps each structure inner-node UID (operations AND the
+        # per-frame sRN boundary nodes) to (structure_id, frame_key). It lets
+        # us attribute *constants* to their frame below: a diagram constant
+        # nested inside a frame carries an sRN as its terminal's parent_uid,
+        # and that sRN is one of the frame's inner_node_uids.
+        frame_owner: dict[str, tuple[str, str | int | None]] = {}
+
+        def _stamp(uid: str, struct_id: str, frame_key: str | int | None) -> None:
+            frame_owner[uid] = (struct_id, frame_key)
+            q_uid = self._qid(vi_name, uid)
+            if q_uid in g and "node" in g.nodes[q_uid]:
+                inner_node = g.nodes[q_uid]["node"]
+                inner_node.parent = struct_id
+                inner_node.frame = frame_key
 
         for loop in bd.loops:
             q_loop_uid = self._qid(vi_name, loop.uid)
             for uid in loop.inner_node_uids:
-                q_uid = self._qid(vi_name, uid)
-                if q_uid in g and "node" in g.nodes[q_uid]:
-                    inner_node = g.nodes[q_uid]["node"]
-                    inner_node.parent = q_loop_uid
-                    inner_node.frame = None
+                _stamp(uid, q_loop_uid, None)
 
         for cs in bd.case_structures:
             q_cs_uid = self._qid(vi_name, cs.uid)
             for frame in cs.frames:
                 for uid in frame.inner_node_uids:
-                    q_uid = self._qid(vi_name, uid)
-                    if q_uid in g and "node" in g.nodes[q_uid]:
-                        inner_node = g.nodes[q_uid]["node"]
-                        inner_node.parent = q_cs_uid
-                        inner_node.frame = frame.selector_value
+                    _stamp(uid, q_cs_uid, frame.selector_value)
 
         for fs in bd.flat_sequences:
             q_fs_uid = self._qid(vi_name, fs.uid)
             for idx, frame in enumerate(fs.frames):
                 for uid in frame.inner_node_uids:
-                    q_uid = self._qid(vi_name, uid)
-                    if q_uid in g and "node" in g.nodes[q_uid]:
-                        inner_node = g.nodes[q_uid]["node"]
-                        inner_node.parent = q_fs_uid
-                        inner_node.frame = str(idx)
+                    _stamp(uid, q_fs_uid, str(idx))
 
         for ds in bd.decompose_structures:
             q_ds_uid = self._qid(vi_name, ds.uid)
             for uid in ds.inner_node_uids:
-                q_uid = self._qid(vi_name, uid)
-                if q_uid in g and "node" in g.nodes[q_uid]:
-                    inner_node = g.nodes[q_uid]["node"]
-                    inner_node.parent = q_ds_uid
+                _stamp(uid, q_ds_uid, None)
+
+        # Attribute constants to the frame that contains them. A constant
+        # wired inside a structure is a diagram constant whose output
+        # terminal (keyed by the constant UID) is parented to the frame's
+        # sRN boundary node. Map: constant -> its terminal's parent -> frame.
+        for const in bd.constants:
+            ct = bd.terminal_info.get(const.uid)
+            if ct is None or ct.parent_uid not in frame_owner:
+                continue
+            q_const_uid = self._qid(vi_name, const.uid)
+            if q_const_uid in g and "node" in g.nodes[q_const_uid]:
+                struct_id, frame_key = frame_owner[ct.parent_uid]
+                cnode = g.nodes[q_const_uid]["node"]
+                cnode.parent = struct_id
+                cnode.frame = frame_key
 
         # === 5. Register remaining terminal_info entries in term_lookup ===
         # Most tunnel/sRN terminals are already registered by

--- a/src/lvkit/graph/describe.py
+++ b/src/lvkit/graph/describe.py
@@ -6,6 +6,7 @@ Used by the MCP server and CLI ``describe`` command.
 
 from __future__ import annotations
 
+import ast
 from typing import TYPE_CHECKING
 
 from ..models import (
@@ -16,6 +17,7 @@ from ..models import (
     PrimitiveOperation,
     SequenceOperation,
     Terminal,
+    _is_error_cluster,
 )
 from ..vilib_resolver import get_resolver as _get_vilib_resolver
 from .models import Constant, VIContext
@@ -69,13 +71,13 @@ def describe_vi(graph: InMemoryVIGraph, vi_name: str) -> str:
     # Class context: when this VI is a .lvclass method
     lines.extend(_describe_class_context(graph, ctx))
 
-    # Constants: show actual values
-    if ctx.constants:
+    # Constants: show actual values. Constants nested inside a structure
+    # are shown with their frame (in Control Flow below), not here.
+    top_level_constants = [c for c in ctx.constants if c.parent is None]
+    if top_level_constants:
         lines.append("## Constants")
-        for c in ctx.constants:
-            type_str = c.lv_type.to_python() if c.lv_type else "unknown"
-            name = c.name or "(unnamed)"
-            lines.append(f"  {name}: {type_str} = {c.value!r}")
+        for c in top_level_constants:
+            lines.append(f"  {_describe_constant_line(c)}")
         lines.append("")
 
     # Dependencies: SubVI calls with their signatures and descriptions
@@ -185,7 +187,7 @@ def describe_structure(
 
     match op:
         case CaseOperation():
-            _describe_case_structure(op, lines)
+            _describe_case_structure(op, list(ctx.constants), lines)
         case LoopOperation():
             _describe_loop(op, lines)
         case SequenceOperation():
@@ -207,9 +209,10 @@ def describe_constants(
 
     lines = [f"Constants in {vi_name}:", ""]
     for c in constants:
-        type_str = c.lv_type.to_python() if c.lv_type else "unknown"
-        name = c.name or "(unnamed)"
-        lines.append(f"  {name}: {type_str} = {c.value!r}")
+        line = f"  {_describe_constant_line(c)}"
+        if c.parent is not None:
+            line += f"  [{c.parent.split('::')[-1]} frame {c.frame}]"
+        lines.append(line)
 
     if not constants:
         lines.append("  (none)")
@@ -491,6 +494,85 @@ def _count_operations(operations: list[Operation]) -> int:
     return count
 
 
+def _const_type_str(c: Constant) -> str:
+    """Human-readable type label for a constant."""
+    if c.lv_type and _is_error_cluster(c.lv_type):
+        return "error cluster"
+    return c.lv_type.to_python() if c.lv_type else "unknown"
+
+
+def _format_error_cluster(value: object) -> str:
+    """Render an error-cluster value as ``code N: "source"``."""
+    data = value
+    if isinstance(value, str):
+        try:
+            data = ast.literal_eval(value)
+        except (ValueError, SyntaxError):
+            return value
+    if isinstance(data, dict):
+        code = data.get("code", 0)
+        source = data.get("source", "")
+        status = data.get("status", False)
+        if not status and not code:
+            return "no error"
+        if source:
+            return f'code {code}: "{source}"'
+        return f"code {code}"
+    return str(value)
+
+
+def _const_value_str(c: Constant) -> str:
+    """Human-readable value for a constant (no redundant quoting)."""
+    if c.lv_type and _is_error_cluster(c.lv_type):
+        return _format_error_cluster(c.value)
+    return str(c.value)
+
+
+def _describe_constant_line(c: Constant) -> str:
+    """One-line ``name: type = value`` for a constant."""
+    name = c.name or "(unnamed)"
+    return f"{name}: {_const_type_str(c)} = {_const_value_str(c)}"
+
+
+def _frame_constants(
+    constants: list[Constant], parent_id: str, frame_key: object,
+) -> list[Constant]:
+    """Constants attributed to a specific frame of a structure."""
+    return [
+        c for c in constants
+        if c.parent == parent_id and str(c.frame) == str(frame_key)
+    ]
+
+
+def _has_output_tunnel(op: Operation) -> bool:
+    """True if the structure routes any value out (so an empty frame is a
+    pass-through, not truly empty — LV requires output tunnels wired in
+    every frame)."""
+    return any(t.direction == "output" for t in op.terminals)
+
+
+def _describe_frame_body(
+    frame_ops: list[Operation],
+    frame_consts: list[Constant],
+    all_constants: list[Constant],
+    lines: list[str],
+    prefix: str,
+    indent: int,
+    *,
+    passthrough: bool,
+) -> None:
+    """Render a frame's operations + attributed constants, or a placeholder."""
+    if frame_ops or frame_consts:
+        if frame_ops:
+            _describe_op_list(frame_ops, all_constants, lines, indent + 2)
+        for c in frame_consts:
+            lines.append(f"{prefix}    {_describe_constant_line(c)}")
+    elif passthrough:
+        lines.append(f"{prefix}    (pass-through)")
+    else:
+        lines.append(f"{prefix}    (empty)")
+
+
 def _describe_op_list(
     operations: list[Operation],
     constants: list[Constant],
@@ -506,33 +588,34 @@ def _describe_op_list(
 
         match op:
             case CaseOperation():
+                passthrough = _has_output_tunnel(op)
                 for frame in op.frames:
                     default = " (default)" if frame.is_default else ""
                     lines.append(
                         f'{prefix}  Frame "{frame.selector_value}"{default}:'
                     )
-                    if frame.operations:
-                        _describe_op_list(
-                            frame.operations, constants, lines,
-                            indent + 2,
-                        )
-                    else:
-                        lines.append(f"{prefix}    (empty)")
+                    _describe_frame_body(
+                        frame.operations,
+                        _frame_constants(constants, op.id, frame.selector_value),
+                        constants, lines, prefix, indent,
+                        passthrough=passthrough,
+                    )
             case SequenceOperation():
                 for i, frame in enumerate(op.frames):
                     lines.append(f'{prefix}  Frame {i}:')
-                    if frame.operations:
-                        _describe_op_list(
-                            frame.operations, constants, lines,
-                            indent + 2,
-                        )
-                    else:
-                        lines.append(f"{prefix}    (empty)")
+                    _describe_frame_body(
+                        frame.operations,
+                        _frame_constants(constants, op.id, i),
+                        constants, lines, prefix, indent,
+                        passthrough=False,
+                    )
             case _:
                 if op.inner_nodes:
                     _describe_op_list(
                         op.inner_nodes, constants, lines, indent + 1,
                     )
+                for c in (c for c in constants if c.parent == op.id):
+                    lines.append(f"{prefix}  {_describe_constant_line(c)}")
 
 
 def _describe_single_op(op: Operation) -> str:
@@ -594,7 +677,7 @@ def _find_operation(
 
 
 def _describe_case_structure(
-    op: CaseOperation, lines: list[str],
+    op: CaseOperation, constants: list[Constant], lines: list[str],
 ) -> None:
     """Describe a case structure in detail."""
     lines.append(f"Case Structure: {op.id}")
@@ -606,15 +689,22 @@ def _describe_case_structure(
             lines.append(f"  Selector type: {t.lv_type.to_python()}")
             break
 
+    passthrough = _has_output_tunnel(op)
     lines.append(f"  Frames: {len(op.frames)}")
     for frame in op.frames:
         default = " (default)" if frame.is_default else ""
+        frame_consts = _frame_constants(constants, op.id, frame.selector_value)
         lines.append(
             f"  Frame \"{frame.selector_value}\"{default}:"
-            f" {len(frame.operations)} operations"
+            f" {len(frame.operations)} operations,"
+            f" {len(frame_consts)} constants"
         )
         for fop in frame.operations:
             lines.append(f"    - {_describe_single_op(fop)}")
+        for c in frame_consts:
+            lines.append(f"    - constant {_describe_constant_line(c)}")
+        if not frame.operations and not frame_consts and passthrough:
+            lines.append("    - (pass-through)")
 
 
 def _describe_loop(op: LoopOperation, lines: list[str]) -> None:

--- a/src/lvkit/graph/diff.py
+++ b/src/lvkit/graph/diff.py
@@ -18,7 +18,7 @@ from ..models import (
     _is_error_cluster,
 )
 from .describe import describe_vi
-from .models import Constant, Wire
+from .models import Constant, Wire, WireEnd
 
 if TYPE_CHECKING:
     from .core import InMemoryVIGraph
@@ -303,15 +303,46 @@ def _diff_wiring(
     ga: InMemoryVIGraph, gb: InMemoryVIGraph,
     va: str, vb: str,
 ) -> list[WiringChange]:
-    wires_a = ga.get_wires(va)
-    wires_b = gb.get_wires(vb)
+    # Relabel unnamed-constant endpoints by type/value (e.g. "error cluster")
+    # instead of an opaque raw UID.
+    const_labels = _const_label_by_id(ga.get_constants(va))
+    const_labels.update(_const_label_by_id(gb.get_constants(vb)))
+    return _wiring_changes(ga.get_wires(va), gb.get_wires(vb), const_labels)
 
-    keys_a = Counter(_wire_key(w) for w in wires_a)
-    keys_b = Counter(_wire_key(w) for w in wires_b)
+
+def _wiring_changes(
+    wires_a: list[Wire], wires_b: list[Wire],
+    const_labels: Mapping[str, str],
+) -> list[WiringChange]:
+    # Drop structure-internal edges (tunnel/selector/sRN plumbing — always
+    # self-loops on the structure node). They're implied by the structure
+    # add/remove and are surfaced in the Structures section instead.
+    wires_a = [w for w in wires_a if not _is_internal_wire(w)]
+    wires_b = [w for w in wires_b if not _is_internal_wire(w)]
+
+    # A wire is only noteworthy if it touches a node present in BOTH
+    # versions (a genuine rewire of unchanged topology — a "splice"). A
+    # wire whose endpoints are all new/removed is dragged along by the
+    # node change that the Operations/Constants/Structures sections already
+    # report, so it's redundant noise here.
+    shared = _endpoint_names(wires_a) & _endpoint_names(wires_b)
+
+    keys_a = Counter(_wire_key(w, const_labels) for w in wires_a)
+    keys_b = Counter(_wire_key(w, const_labels) for w in wires_b)
+    raw_names: dict[tuple[str, str], tuple[str | None, str | None]] = {}
+    for w in (*wires_a, *wires_b):
+        raw_names.setdefault(
+            _wire_key(w, const_labels), (w.source.name, w.dest.name),
+        )
 
     changes: list[WiringChange] = []
     for key in sorted(set(keys_a) | set(keys_b)):
         diff = keys_b.get(key, 0) - keys_a.get(key, 0)
+        if diff == 0:
+            continue
+        src_name, dst_name = raw_names[key]
+        if src_name not in shared and dst_name not in shared:
+            continue  # implied by a node add/remove — suppress
         src, dst = key
         desc = f"{src} -> {dst}"
         for _ in range(max(0, diff)):
@@ -329,6 +360,10 @@ def _diff_structures(
     structs_b = _collect_structures(gb.get_operations(vb))
     consts_a = ga.get_constants(va)
     consts_b = gb.get_constants(vb)
+    wires_a = ga.get_wires(va)
+    wires_b = gb.get_wires(vb)
+    labels = _const_label_by_id(consts_a)
+    labels.update(_const_label_by_id(consts_b))
 
     map_a = {(s.name, type(s).__name__): s for s in structs_a}
     map_b = {(s.name, type(s).__name__): s for s in structs_b}
@@ -339,27 +374,50 @@ def _diff_structures(
         label = name or kind
         if key not in map_a:
             changes.append(StructureChange(
-                "added", label, _structure_content_summary(map_b[key], consts_b),
+                "added",
+                label,
+                _structure_content_summary(map_b[key], consts_b, wires_b, labels),
             ))
         elif key not in map_b:
             changes.append(StructureChange(
-                "removed", label, _structure_content_summary(map_a[key], consts_a),
+                "removed",
+                label,
+                _structure_content_summary(map_a[key], consts_a, wires_a, labels),
             ))
         else:
             detail = _compare_structure(
                 map_a[key], map_b[key], consts_a, consts_b,
+                wires_a, wires_b, labels,
             )
             if detail:
                 changes.append(StructureChange("changed", label, detail))
     return changes
 
 
+def _selector_source(
+    case: CaseOperation, wires: list[Wire], const_labels: Mapping[str, str],
+) -> str | None:
+    """The external node feeding a case structure's selector terminal —
+    the splice that drives which frame runs. Recovered here because that
+    wire (new node -> new case) is suppressed in the Wiring section."""
+    sel = case.selector_terminal
+    if not sel:
+        return None
+    for w in wires:
+        if w.dest.terminal_id == sel and not _is_internal_wire(w):
+            return _endpoint_label(w.source, const_labels)
+    return None
+
+
 def _structure_content_summary(
     s: Operation, constants: list[Constant],
+    wires: list[Wire] | None = None,
+    const_labels: Mapping[str, str] | None = None,
 ) -> str | None:
-    """Enumerate a structure's per-frame operations + constants, so an
-    added/removed structure shows what's inside it (incl. nested constants
-    that are excluded from the flat Constants section)."""
+    """Enumerate a structure's selector source + per-frame operations and
+    constants, so an added/removed structure shows what's inside it (incl.
+    nested constants excluded from the flat Constants section) and what
+    drives it (the selector, whose wire the Wiring section suppresses)."""
     by_frame = _consts_by_frame(constants, s.id)
     if isinstance(s, CaseOperation):
         frames = [(str(f.selector_value), f) for f in s.frames]
@@ -369,6 +427,10 @@ def _structure_content_summary(
         return None
 
     parts: list[str] = []
+    if isinstance(s, CaseOperation):
+        sel = _selector_source(s, wires or [], const_labels or {})
+        if sel:
+            parts.append(f"selector <- {sel}")
     for fkey, frame in frames:
         items = [op.name or op.node_type or "op" for op in frame.operations]
         items += [_const_label(c) for c in by_frame.get(fkey, [])]
@@ -401,10 +463,37 @@ def _const_key(c: Constant) -> tuple[str, str]:
     return (repr(c.value), type_str)
 
 
-def _wire_key(w: Wire) -> tuple[str, str]:
-    src = w.source.name or w.source.node_id.split("::")[-1]
-    dst = w.dest.name or w.dest.node_id.split("::")[-1]
-    return (src, dst)
+def _is_internal_wire(w: Wire) -> bool:
+    """A structure-internal edge (tunnel inner<->outer, selector, sRN
+    in->out pairing) — always a self-loop on the structure node."""
+    return w.source.node_id == w.dest.node_id
+
+
+def _endpoint_names(wires: list[Wire]) -> set[str]:
+    """Named nodes appearing as a wire endpoint (identity across versions)."""
+    names: set[str] = set()
+    for w in wires:
+        if w.source.name:
+            names.add(w.source.name)
+        if w.dest.name:
+            names.add(w.dest.name)
+    return names
+
+
+def _const_label_by_id(constants: list[Constant]) -> dict[str, str]:
+    """Map each unnamed constant's node id to a type/value display label."""
+    return {c.id: _const_label(c) for c in constants if not c.name}
+
+
+def _endpoint_label(end: WireEnd, const_labels: Mapping[str, str]) -> str:
+    return end.name or const_labels.get(end.node_id) or end.node_id.split("::")[-1]
+
+
+def _wire_key(
+    w: Wire, const_labels: Mapping[str, str] | None = None,
+) -> tuple[str, str]:
+    labels = const_labels or {}
+    return (_endpoint_label(w.source, labels), _endpoint_label(w.dest, labels))
 
 
 def _collect_structures(ops: list[Operation]) -> list[Operation]:
@@ -466,16 +555,29 @@ def _frame_content_delta(
 def _compare_structure(
     a: Operation, b: Operation,
     consts_a: list[Constant], consts_b: list[Constant],
+    wires_a: list[Wire] | None = None,
+    wires_b: list[Wire] | None = None,
+    const_labels: Mapping[str, str] | None = None,
 ) -> str | None:
+    wa, wb, labels = wires_a or [], wires_b or [], const_labels or {}
     if isinstance(a, CaseOperation) and isinstance(b, CaseOperation):
+        parts: list[str] = []
+        sel_a = _selector_source(a, wa, labels)
+        sel_b = _selector_source(b, wb, labels)
+        if sel_a != sel_b:
+            parts.append(f"selector {sel_a} -> {sel_b}")
         if len(a.frames) != len(b.frames):
-            return f"{len(a.frames)} frames -> {len(b.frames)} frames"
-        return _compare_frames(
-            {str(f.selector_value): f for f in a.frames},
-            {str(f.selector_value): f for f in b.frames},
-            _consts_by_frame(consts_a, a.id),
-            _consts_by_frame(consts_b, b.id),
-        )
+            parts.append(f"{len(a.frames)} frames -> {len(b.frames)} frames")
+        else:
+            frame_detail = _compare_frames(
+                {str(f.selector_value): f for f in a.frames},
+                {str(f.selector_value): f for f in b.frames},
+                _consts_by_frame(consts_a, a.id),
+                _consts_by_frame(consts_b, b.id),
+            )
+            if frame_detail:
+                parts.append(frame_detail)
+        return "; ".join(parts) if parts else None
     if isinstance(a, LoopOperation) and isinstance(b, LoopOperation):
         if a.loop_type != b.loop_type:
             return f"{a.loop_type} -> {b.loop_type}"

--- a/src/lvkit/graph/diff.py
+++ b/src/lvkit/graph/diff.py
@@ -4,15 +4,18 @@ from __future__ import annotations
 
 import difflib
 from collections import Counter
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from ..models import (
     CaseOperation,
+    Frame,
     LoopOperation,
     Operation,
     SequenceOperation,
     Terminal,
+    _is_error_cluster,
 )
 from .describe import describe_vi
 from .models import Constant, Wire
@@ -123,7 +126,10 @@ class DiffReport:
             for s in self.structures:
                 if s.category in ("added", "removed"):
                     tag = "+" if s.category == "added" else "-"
-                    lines.append(f"  {tag} {s.name}")
+                    line = f"  {tag} {s.name}"
+                    if s.details:
+                        line += f" ({s.details})"
+                    lines.append(line)
                 else:
                     lines.append(f"  ~ {s.name}: {s.details}")
             sections.append("\n".join(lines))
@@ -247,8 +253,11 @@ def _diff_constants(
     ga: InMemoryVIGraph, gb: InMemoryVIGraph,
     va: str, vb: str,
 ) -> list[ConstantChange]:
-    consts_a = ga.get_constants(va)
-    consts_b = gb.get_constants(vb)
+    # Top-level constants only. Constants nested inside a structure frame
+    # are positioned by the Structures section (mirrors how nested
+    # operations are reported under Structures, not flat Operations).
+    consts_a = [c for c in ga.get_constants(va) if c.parent is None]
+    consts_b = [c for c in gb.get_constants(vb) if c.parent is None]
 
     changes: list[ConstantChange] = []
 
@@ -318,6 +327,8 @@ def _diff_structures(
 ) -> list[StructureChange]:
     structs_a = _collect_structures(ga.get_operations(va))
     structs_b = _collect_structures(gb.get_operations(vb))
+    consts_a = ga.get_constants(va)
+    consts_b = gb.get_constants(vb)
 
     map_a = {(s.name, type(s).__name__): s for s in structs_a}
     map_b = {(s.name, type(s).__name__): s for s in structs_b}
@@ -327,14 +338,43 @@ def _diff_structures(
         name, kind = key
         label = name or kind
         if key not in map_a:
-            changes.append(StructureChange("added", label))
+            changes.append(StructureChange(
+                "added", label, _structure_content_summary(map_b[key], consts_b),
+            ))
         elif key not in map_b:
-            changes.append(StructureChange("removed", label))
+            changes.append(StructureChange(
+                "removed", label, _structure_content_summary(map_a[key], consts_a),
+            ))
         else:
-            detail = _compare_structure(map_a[key], map_b[key])
+            detail = _compare_structure(
+                map_a[key], map_b[key], consts_a, consts_b,
+            )
             if detail:
                 changes.append(StructureChange("changed", label, detail))
     return changes
+
+
+def _structure_content_summary(
+    s: Operation, constants: list[Constant],
+) -> str | None:
+    """Enumerate a structure's per-frame operations + constants, so an
+    added/removed structure shows what's inside it (incl. nested constants
+    that are excluded from the flat Constants section)."""
+    by_frame = _consts_by_frame(constants, s.id)
+    if isinstance(s, CaseOperation):
+        frames = [(str(f.selector_value), f) for f in s.frames]
+    elif isinstance(s, SequenceOperation):
+        frames = [(str(i), f) for i, f in enumerate(s.frames)]
+    else:
+        return None
+
+    parts: list[str] = []
+    for fkey, frame in frames:
+        items = [op.name or op.node_type or "op" for op in frame.operations]
+        items += [_const_label(c) for c in by_frame.get(fkey, [])]
+        if items:
+            parts.append(f"frame {fkey}: {', '.join(items)}")
+    return "; ".join(parts) if parts else None
 
 
 # ── Utility functions ─────────────────────────────────────────────────
@@ -374,14 +414,97 @@ def _collect_structures(ops: list[Operation]) -> list[Operation]:
     ]
 
 
-def _compare_structure(a: Operation, b: Operation) -> str | None:
+def _consts_by_frame(
+    constants: list[Constant], parent_id: str,
+) -> dict[str, list[Constant]]:
+    """Group a structure's nested constants by frame key (as str)."""
+    grouped: dict[str, list[Constant]] = {}
+    for c in constants:
+        if c.parent == parent_id:
+            grouped.setdefault(str(c.frame), []).append(c)
+    return grouped
+
+
+def _const_label(c: Constant) -> str:
+    """Short label for a constant in a frame diff."""
+    if c.lv_type and _is_error_cluster(c.lv_type):
+        return "error cluster"
+    type_str = c.lv_type.to_python() if c.lv_type else "unknown"
+    return f"{type_str} constant"
+
+
+def _frame_content_delta(
+    ops_a: list[Operation], consts_a: list[Constant],
+    ops_b: list[Operation], consts_b: list[Constant],
+) -> list[str]:
+    """Per-frame additions/removals of operations and constants."""
+    parts: list[str] = []
+
+    oa, ob = _op_counts(ops_a), _op_counts(ops_b)
+    for key in sorted(set(oa) | set(ob), key=lambda k: (k[0] or "", k[1] or "")):
+        delta = ob.get(key, 0) - oa.get(key, 0)
+        label = key[0] or f"(unnamed {key[1]})"
+        if delta > 0:
+            parts.append(f"+{delta} {label}")
+        elif delta < 0:
+            parts.append(f"-{-delta} {label}")
+
+    ka = Counter(_const_key(c) for c in consts_a)
+    kb = Counter(_const_key(c) for c in consts_b)
+    label_for = {_const_key(c): _const_label(c) for c in (*consts_a, *consts_b)}
+    for key in sorted(set(ka) | set(kb)):
+        delta = kb.get(key, 0) - ka.get(key, 0)
+        label = label_for[key]
+        if delta > 0:
+            parts.append(f"+{delta} {label}")
+        elif delta < 0:
+            parts.append(f"-{-delta} {label}")
+
+    return parts
+
+
+def _compare_structure(
+    a: Operation, b: Operation,
+    consts_a: list[Constant], consts_b: list[Constant],
+) -> str | None:
     if isinstance(a, CaseOperation) and isinstance(b, CaseOperation):
         if len(a.frames) != len(b.frames):
             return f"{len(a.frames)} frames -> {len(b.frames)} frames"
+        return _compare_frames(
+            {str(f.selector_value): f for f in a.frames},
+            {str(f.selector_value): f for f in b.frames},
+            _consts_by_frame(consts_a, a.id),
+            _consts_by_frame(consts_b, b.id),
+        )
     if isinstance(a, LoopOperation) and isinstance(b, LoopOperation):
         if a.loop_type != b.loop_type:
             return f"{a.loop_type} -> {b.loop_type}"
     if isinstance(a, SequenceOperation) and isinstance(b, SequenceOperation):
         if len(a.frames) != len(b.frames):
             return f"{len(a.frames)} frames -> {len(b.frames)} frames"
+        return _compare_frames(
+            {str(i): f for i, f in enumerate(a.frames)},
+            {str(i): f for i, f in enumerate(b.frames)},
+            _consts_by_frame(consts_a, a.id),
+            _consts_by_frame(consts_b, b.id),
+        )
     return None
+
+
+def _compare_frames(
+    frames_a: Mapping[str, Frame], frames_b: Mapping[str, Frame],
+    consts_a: Mapping[str, list[Constant]], consts_b: Mapping[str, list[Constant]],
+) -> str | None:
+    """Per-frame content diff, attributed to each frame key."""
+    details: list[str] = []
+    for key in sorted(set(frames_a) | set(frames_b)):
+        fa, fb = frames_a.get(key), frames_b.get(key)
+        ops_a = list(fa.operations) if fa is not None else []
+        ops_b = list(fb.operations) if fb is not None else []
+        delta = _frame_content_delta(
+            ops_a, consts_a.get(key, []),
+            ops_b, consts_b.get(key, []),
+        )
+        if delta:
+            details.append(f"frame {key}: {', '.join(delta)}")
+    return "; ".join(details) if details else None

--- a/src/lvkit/graph/models.py
+++ b/src/lvkit/graph/models.py
@@ -275,6 +275,10 @@ class Constant(BaseModel):
     lv_type: LVType | None = None
     raw_value: str | None = None
     name: str | None = None
+    # Structure containment (None = top-level diagram). Mirrors GraphNode:
+    # parent = containing structure's node id, frame = selector value / index.
+    parent: str | None = None
+    frame: str | int | None = None
 
 
 class SubVICall(BaseModel):

--- a/src/lvkit/graph/queries.py
+++ b/src/lvkit/graph/queries.py
@@ -522,6 +522,8 @@ class QueryMixin:
                 lv_type=gnode.lv_type,
                 raw_value=gnode.raw_value,
                 name=gnode.label,
+                parent=gnode.parent,
+                frame=gnode.frame,
             ))
         return results
 

--- a/tests/test_diff_wiring_denoise.py
+++ b/tests/test_diff_wiring_denoise.py
@@ -1,0 +1,184 @@
+"""Tests for the diff Wiring-section denoise (the "net design").
+
+Three behaviours:
+1. Suppress wires internal to the added/removed subgraph (both endpoints
+   new/removed); keep any wire touching a node present in both versions
+   (a "splice" — a real rewire of unchanged topology).
+2. Relabel unnamed-constant endpoints by type/value, not a raw UID.
+3. Drop structure-internal tunnel/selector self-loops from Wiring and
+   surface the case selector source in the Structures section instead.
+
+These exercise the pure core (`_wiring_changes` + helpers) with synthetic
+Wire/Constant/CaseOperation models — no graph load, no user VIs.
+"""
+
+from __future__ import annotations
+
+from lvkit.graph.diff import (
+    _const_label_by_id,
+    _endpoint_names,
+    _is_internal_wire,
+    _selector_source,
+    _structure_content_summary,
+    _wire_key,
+    _wiring_changes,
+)
+from lvkit.graph.models import Constant, Wire, WireEnd
+from lvkit.models import (
+    CaseFrame,
+    CaseOperation,
+    ClusterField,
+    LVType,
+)
+
+
+def _we(node_id: str, name: str | None = None, term: str | None = None) -> WireEnd:
+    return WireEnd(terminal_id=term or node_id, node_id=node_id, name=name)
+
+
+def _wire(
+    src_id: str, src_name: str | None, dst_id: str, dst_name: str | None,
+    *, src_term: str | None = None, dst_term: str | None = None,
+) -> Wire:
+    return Wire(
+        source=_we(src_id, src_name, src_term),
+        dest=_we(dst_id, dst_name, dst_term),
+    )
+
+
+def _error_cluster_type() -> LVType:
+    return LVType(kind="cluster", fields=[
+        ClusterField(name="status"),
+        ClusterField(name="code"),
+        ClusterField(name="source"),
+    ])
+
+
+# ── Internal-edge detection ──────────────────────────────────────────────
+
+
+class TestInternalWire:
+    def test_self_loop_is_internal(self):
+        assert _is_internal_wire(_wire("vi::174", "case", "vi::174", "case"))
+
+    def test_distinct_nodes_not_internal(self):
+        assert not _is_internal_wire(_wire("vi::1", "Mean.vi", "vi::2", "Gt"))
+
+
+# ── Splice kept, new-subgraph wires suppressed ───────────────────────────
+
+
+class TestSpliceVsInternal:
+    def test_wrap_in_case_keeps_only_the_splice(self):
+        # A: Mean.vi feeds the VI output directly.
+        wires_a = [_wire("vi::m", "Mean.vi", "vi::out", "out")]
+        # B: a case ("error constant") was inserted. Mean now also feeds a
+        # new guard; guard + const feed the new case (all new-internal); the
+        # old Mean->out link is unchanged; the case's tunnels are self-loops.
+        wires_b = [
+            _wire("vi::m", "Mean.vi", "vi::out", "out"),          # unchanged
+            _wire("vi::m", "Mean.vi", "vi::g", "Greater Than 0?"),  # splice
+            _wire("vi::g", "Greater Than 0?", "vi::c", "error constant"),
+            _wire("vi::k", None, "vi::c", "error constant"),       # const -> case
+            _wire("vi::c", "error constant", "vi::c", "error constant"),  # tunnel
+        ]
+        changes = _wiring_changes(wires_a, wires_b, {})
+        descs = [(c.category, c.description) for c in changes]
+        assert descs == [("added", "Mean.vi -> Greater Than 0?")]
+
+    def test_removed_wire_touching_shared_node_is_kept(self):
+        wires_a = [
+            _wire("vi::a", "A", "vi::b", "B"),
+            _wire("vi::a", "A", "vi::x", "X"),
+        ]
+        wires_b = [_wire("vi::a", "A", "vi::b", "B")]  # A -> X removed
+        changes = _wiring_changes(wires_a, wires_b, {})
+        assert [(c.category, c.description) for c in changes] == [
+            ("removed", "A -> X"),
+        ]
+
+
+# ── Unnamed-constant relabel ─────────────────────────────────────────────
+
+
+class TestConstRelabel:
+    def test_unnamed_const_endpoint_uses_type_label(self):
+        labels = {"vi::261": "error cluster"}
+        key = _wire_key(_wire("vi::261", None, "vi::loop", "For Loop"), labels)
+        assert key == ("error cluster", "For Loop")
+
+    def test_relabel_in_diff_output(self):
+        # For Loop exists in both versions; an unnamed const newly feeds it.
+        wires_a = [_wire("vi::loop", "For Loop", "vi::sink", "sink")]
+        wires_b = [
+            _wire("vi::loop", "For Loop", "vi::sink", "sink"),
+            _wire("vi::343", None, "vi::loop", "For Loop"),
+        ]
+        labels = {"vi::343": "list[float] constant"}
+        changes = _wiring_changes(wires_a, wires_b, labels)
+        assert [(c.category, c.description) for c in changes] == [
+            ("added", "list[float] constant -> For Loop"),
+        ]
+
+    def test_identical_unnamed_const_uid_churn_cancels(self):
+        # Same type+value const feeds the same node in both versions, only
+        # the UID changed -> no net wiring change.
+        wires_a = [_wire("vi::388", None, "vi::loop", "For Loop")]
+        wires_b = [_wire("vi::474", None, "vi::loop", "For Loop")]
+        labels = {"vi::388": "float constant", "vi::474": "float constant"}
+        assert _wiring_changes(wires_a, wires_b, labels) == []
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+class TestHelpers:
+    def test_endpoint_names_collects_named_skips_unnamed(self):
+        wires = [_wire("vi::1", "A", "vi::2", None)]
+        assert _endpoint_names(wires) == {"A"}
+
+    def test_const_label_by_id_only_unnamed(self):
+        consts = [
+            Constant(id="vi::1", value="0.0", lv_type=LVType(kind="DBL")),
+            Constant(id="vi::2", value="x", name="named", lv_type=LVType(kind="DBL")),
+        ]
+        labels = _const_label_by_id(consts)
+        assert set(labels) == {"vi::1"}
+
+
+# ── Selector callout in Structures ───────────────────────────────────────
+
+
+def _case_with_selector() -> CaseOperation:
+    return CaseOperation(
+        id="vi::174", name="error constant", labels=["CaseStructure"],
+        selector_terminal="vi::204",
+        frames=[CaseFrame(selector_value="False"), CaseFrame(selector_value="True")],
+    )
+
+
+class TestSelectorCallout:
+    def test_selector_source_resolves_feeding_node(self):
+        case = _case_with_selector()
+        wires = [_wire("vi::g", "Greater Than 0?", "vi::174", "error constant",
+                       dst_term="vi::204")]
+        assert _selector_source(case, wires, {}) == "Greater Than 0?"
+
+    def test_summary_includes_selector_and_frame_content(self):
+        case = _case_with_selector()
+        const = Constant(
+            id="vi::261", value="{'status': True, 'code': 17, 'source': 'x'}",
+            lv_type=_error_cluster_type(), parent="vi::174", frame="True",
+        )
+        wires = [_wire("vi::g", "Greater Than 0?", "vi::174", "error constant",
+                       dst_term="vi::204")]
+        summary = _structure_content_summary(case, [const], wires, {})
+        assert summary == "selector <- Greater Than 0?; frame True: error cluster"
+
+    def test_summary_without_wires_omits_selector(self):
+        case = _case_with_selector()
+        const = Constant(
+            id="vi::261", value="{'status': True, 'code': 17, 'source': 'x'}",
+            lv_type=_error_cluster_type(), parent="vi::174", frame="True",
+        )
+        assert _structure_content_summary(case, [const]) == "frame True: error cluster"

--- a/tests/test_frame_attribution.py
+++ b/tests/test_frame_attribution.py
@@ -1,0 +1,172 @@
+"""Tests for constant attribution to structure frames.
+
+LabVIEW diagram constants wired inside a case/sequence frame carry an sRN
+boundary node as their terminal parent. Graph construction stamps the
+constant graph node with the containing structure + frame so describe and
+diff can position it (instead of reporting an "(empty)" frame and a flat,
+position-less "a constant appeared").
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from lvkit.graph.core import InMemoryVIGraph
+from lvkit.graph.describe import (
+    _const_type_str,
+    _describe_constant_line,
+    _format_error_cluster,
+)
+from lvkit.graph.diff import (
+    _compare_frames,
+    _frame_content_delta,
+    _structure_content_summary,
+)
+from lvkit.graph.models import Constant
+from lvkit.models import (
+    CaseFrame,
+    CaseOperation,
+    ClusterField,
+    LVType,
+    PrimitiveOperation,
+    Terminal,
+)
+
+IN_VI = Path("samples/DAQmx-Digital-IO/In.vi")
+
+
+def _error_cluster_type() -> LVType:
+    return LVType(
+        kind="cluster",
+        fields=[
+            ClusterField(name="status"),
+            ClusterField(name="code"),
+            ClusterField(name="source"),
+        ],
+    )
+
+
+def _error_const(
+    *, parent: str | None = None, frame: str | None = None,
+    value: str = "{'status': True, 'code': 17, 'source': 'bad'}",
+) -> Constant:
+    return Constant(
+        id="vi::261", value=value, lv_type=_error_cluster_type(),
+        parent=parent, frame=frame,
+    )
+
+
+# ── Error-cluster formatting ─────────────────────────────────────────────
+
+
+class TestErrorClusterFormatting:
+    def test_type_label_is_error_cluster(self):
+        assert _const_type_str(_error_const()) == "error cluster"
+
+    def test_value_renders_code_and_source(self):
+        out = _format_error_cluster(
+            "{'status': True, 'code': 17, 'source': 'Mean should be positive'}"
+        )
+        assert out == 'code 17: "Mean should be positive"'
+
+    def test_value_accepts_dict(self):
+        out = _format_error_cluster(
+            {"status": True, "code": 42, "source": "boom"}
+        )
+        assert out == 'code 42: "boom"'
+
+    def test_no_error_value(self):
+        out = _format_error_cluster({"status": False, "code": 0, "source": ""})
+        assert out == "no error"
+
+    def test_constant_line_has_no_raw_dict(self):
+        line = _describe_constant_line(_error_const())
+        assert "error cluster" in line
+        assert "code 17" in line
+        # The ugly raw dict repr must not leak through.
+        assert "{'status'" not in line
+
+
+# ── Real-VI construction: constants get attributed to frames ─────────────
+
+
+class TestConstructionAttribution:
+    def test_in_vi_has_frame_attributed_constants(self):
+        graph = InMemoryVIGraph()
+        graph.load_vi(str(IN_VI), expand_subvis=False)
+        vi_name = graph.resolve_vi_name(IN_VI.name)
+
+        consts = graph.get_constants(vi_name)
+        attributed = [c for c in consts if c.parent is not None]
+
+        assert attributed, "expected at least one frame-nested constant in In.vi"
+        # Every attributed constant must name both a parent structure and a
+        # frame key (so position is recoverable).
+        for c in attributed:
+            assert c.parent
+            assert c.frame is not None
+
+
+# ── Synthetic per-frame diff logic ───────────────────────────────────────
+
+
+def _case_with_const() -> tuple[CaseOperation, list[Constant]]:
+    """A boolean case whose True frame holds an error-cluster constant and
+    whose False frame is a pass-through (no content, has an output tunnel)."""
+    out_term = Terminal(id="vi::548", index=1, direction="output")
+    op = CaseOperation(
+        id="vi::174", name="error constant", labels=["CaseStructure"],
+        terminals=[out_term],
+        frames=[
+            CaseFrame(selector_value="False"),
+            CaseFrame(selector_value="True"),
+        ],
+    )
+    return op, [_error_const(parent="vi::174", frame="True")]
+
+
+class TestPerFrameDiff:
+    def test_structure_summary_positions_constant(self):
+        op, consts = _case_with_const()
+        summary = _structure_content_summary(op, consts)
+        assert summary == "frame True: error cluster"
+
+    def test_added_constant_shows_in_frame_delta(self):
+        delta = _frame_content_delta(
+            [], [],
+            [], [_error_const(parent="vi::174", frame="True")],
+        )
+        assert delta == ["+1 error cluster"]
+
+    def test_removed_constant_shows_in_frame_delta(self):
+        delta = _frame_content_delta(
+            [], [_error_const(parent="vi::174", frame="True")],
+            [], [],
+        )
+        assert delta == ["-1 error cluster"]
+
+    def test_compare_frames_attributes_to_frame_key(self):
+        a_frames = {"False": CaseFrame(selector_value="False"),
+                    "True": CaseFrame(selector_value="True")}
+        b_frames = {"False": CaseFrame(selector_value="False"),
+                    "True": CaseFrame(selector_value="True")}
+        const = _error_const(parent="vi::174", frame="True")
+        detail = _compare_frames(
+            a_frames, b_frames, {}, {"True": [const]},
+        )
+        assert detail == "frame True: +1 error cluster"
+
+    def test_identical_frames_no_delta(self):
+        a_frames = {"True": CaseFrame(selector_value="True")}
+        const = _error_const(parent="vi::174", frame="True")
+        detail = _compare_frames(
+            a_frames, a_frames, {"True": [const]}, {"True": [const]},
+        )
+        assert detail is None
+
+    def test_op_count_delta(self):
+        prim = PrimitiveOperation(
+            id="vi::9", name="Add", labels=["Primitive"], primResID=1050,
+        )
+        delta = _frame_content_delta([], [], [prim], [])
+        assert delta == ["+1 Add"]


### PR DESCRIPTION
Improves `lvkit describe` and `lvkit diff` for structures (case/sequence/loop/in-place).

## Frame attribution (commit 1)
Graph construction only stamped operation nodes with `parent`/`frame`, so a constant wired inside a case/sequence frame carried `parent=None` — the graph couldn't position it, and `diff`/`describe` reported populated frames as `(empty)` with a flat, position-less "a constant appeared". Now a `frame_owner` map stamps each frame-nested constant with its owning structure + frame, mirroring how operation nodes are stamped. describe/diff position constants per frame, distinguish `(pass-through)` from `(empty)`, and render error clusters as `error cluster = code N: "source"` instead of a raw dict repr. Codegen is unaffected (it resolves constants by dataflow, never by parent/frame) — output is byte-identical.

## Wiring denoise (commit 2)
The structured diff's Wiring section echoed every wire dragged along by a node add/remove. Wrapping existing logic in a case produced 7 wiring lines that were all implied by the structure add, burying the one real change. Now:
- Suppress wires internal to the added/removed subgraph (both endpoints new/removed); keep any wire touching a node present in both versions (the genuine rewire — a "splice").
- Relabel unnamed-constant endpoints by type (`list[float] constant`) instead of a raw UID.
- Drop structure-internal tunnel/selector self-loops from Wiring and surface the case selector source in the Structures section.

On the motivating add-a-case diff, the Wiring section collapses from 7 lines to the single splice `Mean.vi -> Greater Than 0?`, and Structures shows `+ error constant (selector <- Greater Than 0?; frame True: error cluster)`. Identical-VI diffs stay empty.

## Tests
`tests/test_frame_attribution.py` and `tests/test_diff_wiring_denoise.py` (synthetic models — no graph load). Full suite + ruff + pyright clean.

> Note: touches `graph/queries.py` in different functions than #10 (determinism) — no textual conflict expected, but re-run tests on whichever merges second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)