### PR TITLE
Event structures: parse + render + event-family primitives (#75)

### DIFF
--- a/src/lvkit/codegen/class_builder.py
+++ b/src/lvkit/codegen/class_builder.py
@@ -379,11 +379,16 @@ class ClassBuilder:
         simple_node_types = {
             "select", "case", "unbundle", "bundle", "nMux", "nDmux", "mux", "demux",
         }
+        # Error-handling primitives that keep an accessor "simple". Bundle /
+        # Unbundle are node-CLASSES, already covered by simple_node_types
+        # above -- they are not primResID prims and must not be listed here.
+        # Clear Errors is a vi.lib VI (no primResID), so it cannot be
+        # whitelisted by id. (This set was historically populated with stale
+        # ids -- 1340/1302/2075/2076 actually map to One Button Dialog / Wait
+        # (ms) / Destroy User Event / Unregister For Events -- so real Merge
+        # Errors was never recognized here; corrected to 2401.)
         simple_prim_ids = {
-            1340,  # Unbundle
-            1302,  # Bundle
-            2075,  # Merge Errors
-            2076,  # Clear Error
+            2401,  # Merge Errors
         }
 
         for op in operations:

--- a/src/lvkit/codegen/nodes/queue_ops.py
+++ b/src/lvkit/codegen/nodes/queue_ops.py
@@ -1,7 +1,15 @@
 """Code generator for LabVIEW Queue Operations primitives.
 
 Covers Obtain Queue (9108), Enqueue Element (9111), Enqueue Element At
-Opposite End (9129), Dequeue Element (9113), and Get Queue Status (9109).
+Opposite End (9129), and Dequeue Element (9113).
+
+Get Queue Status (9110) and Release Queue (9109) are intentionally NOT
+handled here: their codegen is deferred to the queue-runtime design work
+(the runtime must be extended to return Get Queue Status's full 8-output
+pane, and a release_queue() helper added). Until then both are codegen
+placeholders in primitives.json. NOTE: 9109 was historically (and wrongly)
+mapped here as "Get Queue Status" -- it is actually Release Queue; the real
+Get Queue Status is 9110.
 
 These are generic `<Prim class="prim">` XML nodes distinguished only by
 `primResID` (verified against real samples — see phaseB_findings.md), so
@@ -28,20 +36,18 @@ from ..context import CodeGenContext
 from ..fragment import CodeFragment
 
 OBTAIN_QUEUE = 9108
-GET_QUEUE_STATUS = 9109
 ENQUEUE_ELEMENT = 9111
 DEQUEUE_ELEMENT = 9113
 ENQUEUE_AT_OPPOSITE_END = 9129
 
 QUEUE_PRIM_IDS = frozenset(
-    {OBTAIN_QUEUE, GET_QUEUE_STATUS, ENQUEUE_ELEMENT, DEQUEUE_ELEMENT,
-     ENQUEUE_AT_OPPOSITE_END},
+    {OBTAIN_QUEUE, ENQUEUE_ELEMENT, DEQUEUE_ELEMENT, ENQUEUE_AT_OPPOSITE_END},
 )
 
 _QUEUE_IMPORT = (
     "from lvkit.labview_queue import ("
     "dequeue_element, enqueue_element, enqueue_element_at_opposite_end, "
-    "get_queue_status, obtain_queue)"
+    "obtain_queue)"
 )
 
 
@@ -60,8 +66,6 @@ def generate(node: PrimitiveOperation, ctx: CodeGenContext) -> CodeFragment:
         )
     if prim_id == DEQUEUE_ELEMENT:
         return _generate_dequeue(node, by_index, ctx)
-    if prim_id == GET_QUEUE_STATUS:
-        return _generate_status(node, by_index, ctx)
 
     raise ValueError(
         f"queue_ops.generate() called for unsupported prim_id {prim_id!r}; "
@@ -188,25 +192,4 @@ def _generate_dequeue(
         [(by_index.get(9), "element"), (by_index.get(10), "timed_out")],
     )
     bindings.update(call_bindings)
-    return CodeFragment(statements=stmts, bindings=bindings, imports={_QUEUE_IMPORT})
-
-
-def _generate_status(
-    node: PrimitiveOperation, by_index: dict[int, Terminal], ctx: CodeGenContext,
-) -> CodeFragment:
-    """Get Queue Status(queue, return_elements) -> (name, elements).
-
-    primitives.json only carries `name` (idx 8) and `elements` (idx 9) as
-    observed outputs — no separate pending-count terminal was wired in any
-    sample this was resolved against, so "pending count" is `len(elements)`
-    (requires `return_elements=True`; NI docs default is False).
-    """
-    queue_val = _resolve_input(by_index.get(0), ctx, "None")
-    return_elements_val = _resolve_input(by_index.get(2), ctx, "False")
-
-    stmts, bindings = _emit_call(
-        node, ctx, "get_queue_status",
-        [queue_val, return_elements_val],
-        [(by_index.get(8), "queue_name"), (by_index.get(9), "queue_elements")],
-    )
     return CodeFragment(statements=stmts, bindings=bindings, imports={_QUEUE_IMPORT})

--- a/src/lvkit/data/primitives.json
+++ b/src/lvkit/data/primitives.json
@@ -700,13 +700,15 @@
       "note": "Constant that returns the <Not A Path> value. In Python, None represents an invalid/empty path."
     },
     "2076": {
-      "name": "Unknown Event/Notification Primitive 2076",
+      "name": "Unregister For Events",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/unregister-for-events.html",
+      "verified": false,
       "placeholder": true,
       "terminals": [
         {
           "index": 0,
           "direction": "in",
-          "name": "refnum_in",
+          "name": "event_reg_refnum",
           "type": "Refnum"
         },
         {
@@ -722,22 +724,24 @@
           "type": "Cluster"
         }
       ],
-      "python_code": "pass"
+      "python_code": "pass",
+      "note": "REPLACES the prior generic placeholder ('Unknown Event/Notification Primitive 2076'). Confirmed via NI doc exact match: 'event registration refnum' (EventReg, from Register For Events / the eventRegNode), error in ('This node runs normally even if an error occurred before this node runs' -- same special wording as Destroy User Event) -> error out ONLY, no refnum passthrough (unregistering invalidates the registration). In 'DAQmx AO.vi' (lv-flex-channel-examples) the single observed instance's idx0 input comes directly from the eventRegNode-fed while-loop shift register carrying the accumulated EventReg -- exactly where an 'unregister everything on exit' call belongs (called once, outside/after the event loop). Only 1 real call site in the corpus (verified stays false). Identity is solid; CODEGEN is not. No lvkit user-event/event-registration runtime exists yet (queues have lvkit.labview_queue + codegen/nodes/queue_ops.py; notifiers got the same 'identity solid, placeholder codegen' treatment at 9101/9104/9102). Marked placeholder so it renders/describes under the correct name but cannot emit silently-wrong code."
     },
     "2074": {
-      "name": "Unknown Event/Notification Primitive",
+      "name": "Register Event Source (internal)",
+      "verified": false,
       "placeholder": true,
       "terminals": [
         {
           "index": 0,
           "direction": "in",
-          "name": "refnum_in",
+          "name": "event_reg_in",
           "type": "Refnum"
         },
         {
           "index": 1,
           "direction": "in",
-          "name": "data_in",
+          "name": "event_source_data",
           "type": "Cluster"
         },
         {
@@ -749,13 +753,13 @@
         {
           "index": 4,
           "direction": "in",
-          "name": "timeout_ms",
+          "name": "config",
           "type": "NumUInt32"
         },
         {
           "index": 8,
           "direction": "out",
-          "name": "refnum_out",
+          "name": "event_reg_out",
           "type": "Refnum"
         },
         {
@@ -765,7 +769,8 @@
           "type": "Cluster"
         }
       ],
-      "python_code": "pass"
+      "python_code": "pass",
+      "note": "Renamed from the generic 'Unknown Event/Notification Primitive' placeholder with much more specific (but still not fully confident) evidence; kept as placeholder because no NI-documented function matches this exact shape. Found in 'DAQmx AO.vi' (lv-flex-channel-examples), appearing 6 times, always alongside prim 2135 (5 instances in the same VI): in EVERY 2074 instance where idx3 (error_in) is wired, its source is the error_out of a 2135 node -- i.e. 2074 is chained immediately AFTER 2135 per registered event source. 2135 is independently confirmed (see that entry) to register ONE event source of one selected event-type (its idx2 enum literally enumerates LabVIEW's built-in Event Type list: Value Change, Mouse Down, Panel Close, User Event, etc.). Given that pairing, 2074 most likely folds the freshly-registered single-source EventReg (idx0) plus its associated data/config (idx1 Cluster, idx4 UInt32) into the running accumulated EventReg (idx8 out), i.e. a per-source companion step to the pure 2-refnum merge done by 2402. This is a plausible, evidence-backed ROLE, not a confirmed NI verb -- no public doc page exists for anything at this exact shape, so identity is left as an internal/placeholder entry rather than asserting a name NI never published. verified stays false."
     },
     "2401": {
       "name": "Merge Errors",
@@ -2694,8 +2699,8 @@
       "note": "Queue op (ref_type=Queue on idx8). Handled by codegen/nodes/queue_ops.py (dispatched by primResID, not this template) -- calls lvkit.labview_queue.obtain_queue()."
     },
     "9109": {
-      "name": "Get Queue Status",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/get-queue-status.html",
+      "name": "Release Queue",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/release-queue.html",
       "verified": true,
       "terminals": [
         {
@@ -2707,7 +2712,7 @@
         {
           "index": 2,
           "direction": "in",
-          "name": "return_elements",
+          "name": "force_destroy",
           "type": "Boolean"
         },
         {
@@ -2719,13 +2724,13 @@
         {
           "index": 8,
           "direction": "out",
-          "name": "name",
+          "name": "queue_name",
           "type": "String"
         },
         {
           "index": 9,
           "direction": "out",
-          "name": "elements",
+          "name": "remaining_elements",
           "type": "Array"
         },
         {
@@ -2735,10 +2740,11 @@
           "type": "Cluster"
         }
       ],
-      "python_code": {
-        "_body": "raise RuntimeError('Get Queue Status (9109) should be dispatched to codegen/nodes/queue_ops.py by primResID -- this stub should be unreachable')"
-      },
-      "note": "Queue op. Handled by codegen/nodes/queue_ops.py (dispatched by primResID, not this template) -- calls lvkit.labview_queue.get_queue_status(). No separate pending-count terminal was ever observed wired in samples used to resolve this entry; count = len(elements) with return_elements=True."
+      "placeholder": true,
+      "python_code": "pass",
+      "note": [
+        "CORRECTED (was mislabeled 'Get Queue Status'). Full-pane comparison against 9110 (below) proves the two are DIFFERENT functions, not twins: this pane has NO queue_out refnum output at all (releasing the reference invalidates it), while 9110's pane has a queue_out refnum at idx8. Real 'Get Queue Status' also has 5 more outputs (max_queue_size, #pending_remove, #pending_insert, #elements_in_queue) that this pane never carries in any observed instance. This 6-terminal shape (queue, force_destroy?, error_in -> queue_name, remaining_elements, error_out) is an EXACT type+count match for NI's Release Queue doc, including the 'error in ... runs normally even if an error occurred before this node runs' exception noted for error_in. FOLLOW-UP NEEDED (out of scope for this pass -- primitives.json only): codegen/nodes/queue_ops.py currently maps primResID 9109 to GET_QUEUE_STATUS/_generate_status() and calls lvkit.labview_queue.get_queue_status(queue, return_elements); that must be changed to a RELEASE_QUEUE=9109 case calling a new release_queue(queue, force_destroy) in lvkit/labview_queue.py, and QUEUE_PRIM_IDS/GET_QUEUE_STATUS must be repointed at 9110 (see that entry)."
+      ]
     },
     "9101": {
       "name": "Obtain Notifier",
@@ -5126,6 +5132,598 @@
       "inline": true,
       "verified": false,
       "note": "Identity from ref_type=DataValueRef on the out#3 refnum (per the skill, ref_type IS the identity); every call-site is a *_New.vi LVOOP constructor. Cluster directions pinned because idx7 is sometimes a Refnum (a DVR wrapping a refnum), which an error-in never is. python_code models the DVR as a 1-element list and is PROVISIONAL - belongs with the lvkit runtime decision, not inlined."
+    },
+    "9110": {
+      "name": "Get Queue Status",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/get-queue-status.html",
+      "verified": true,
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "queue",
+          "type": "Refnum"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "return_elements",
+          "type": "Boolean"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error_in",
+          "type": "Cluster"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "max_queue_size",
+          "type": "NumInt32"
+        },
+        {
+          "index": 5,
+          "direction": "out",
+          "name": "elements",
+          "type": "Array"
+        },
+        {
+          "index": 6,
+          "direction": "out",
+          "name": "queue_name",
+          "type": "String"
+        },
+        {
+          "index": 7,
+          "direction": "out",
+          "name": "elements_in_queue",
+          "type": "NumInt32"
+        },
+        {
+          "index": 8,
+          "direction": "out",
+          "name": "queue_out",
+          "type": "Refnum"
+        },
+        {
+          "index": 9,
+          "direction": "out",
+          "name": "pending_remove",
+          "type": "NumInt32"
+        },
+        {
+          "index": 10,
+          "direction": "out",
+          "name": "pending_insert",
+          "type": "NumInt32"
+        },
+        {
+          "index": 11,
+          "direction": "out",
+          "name": "error_out",
+          "type": "Cluster"
+        }
+      ],
+      "placeholder": true,
+      "python_code": "pass",
+      "note": [
+        "This is the FULL, 11-terminal Get Queue Status pane -- an exact type+count match to the NI doc (queue, return_elements?, error_in -> max_queue_size, queue_name, queue_out, #pending_remove, #pending_insert, error_out, #elements_in_queue, elements), cross-checked identical across 2 independent VIs ('Graphical Test Runner - Main UI - .vi' and 'test Queue Size is Zero.vi', JKI VI-Tester). idx7 (elements_in_queue) is confirmed by DIRECT dataflow: in 'test Queue Size is Zero.vi' idx7's output feeds prim 1115 ('Less Or Equal To 0?', in_1<=0) -- i.e. the VI literally computes 'is queue size <= 0', which only makes sense if idx7 is the element count. idx8/idx11/idx5/idx6 are unambiguous by unique type (Refnum/Cluster/Array/String). idx4 (max_queue_size), idx9 (pending_remove), idx10 (pending_insert) are the 3 remaining same-typed (NumInt32) slots, assigned by connector-pane column position: idx8-9-10-11 form one single-height output column running top-to-bottom in the SAME order as the NI doc list (queue_out, pending_remove, pending_insert, error_out) -- idx4 is what's left by elimination. 9109 was previously (and wrongly) labeled 'Get Queue Status' with only a 6-terminal subset pane; see the corrected 9109 entry (Release Queue) for the full comparison. FOLLOW-UP NEEDED (out of scope for this pass): queue_ops.py's GET_QUEUE_STATUS constant and QUEUE_PRIM_IDS must be repointed from 9109 to 9110, _generate_status() must be extended to unpack all 8 outputs, and lvkit.labview_queue.get_queue_status() must be extended to return (max_queue_size, queue_name, queue_out, pending_remove, pending_insert, elements_in_queue, elements) instead of just (name, elements)."
+      ]
+    },
+    "9114": {
+      "name": "Flush Queue",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/flush-queue.html",
+      "verified": true,
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "queue",
+          "type": "Refnum"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error_in",
+          "type": "Cluster"
+        },
+        {
+          "index": 8,
+          "direction": "out",
+          "name": "queue_out",
+          "type": "Refnum"
+        },
+        {
+          "index": 9,
+          "direction": "out",
+          "name": "remaining_elements",
+          "type": "Array"
+        },
+        {
+          "index": 11,
+          "direction": "out",
+          "name": "error_out",
+          "type": "Cluster"
+        }
+      ],
+      "python_code": {
+        "_body": "raise RuntimeError('Flush Queue (9114) should be dispatched to codegen/nodes/queue_ops.py by primResID -- this stub should be unreachable')"
+      },
+      "note": [
+        "Exact type+count match to NI's Flush Queue doc (queue, error_in -> queue_out, remaining_elements, error_out; NO extra terminals -- distinguishes it from Release Queue/9109, which lacks queue_out, and from Get Queue Status/9110, which has far more outputs). Index pattern (idx0 queue in, idx3 error_in, idx8 queue_out, idx9 element(s) out, idx11 error_out) matches the sibling Dequeue Element (9113) pane exactly, minus the timeout/timed_out pair Flush Queue doesn't have. Cross-checked identical across 2 independent VIs ('Graphical Test Runner - Main UI - .vi' and 'Measurement UI.vi' / Game Of Life, measurement-plugin-labview). FOLLOW-UP NEEDED (out of scope for this pass): codegen/nodes/queue_ops.py needs a FLUSH_QUEUE=9114 case added to QUEUE_PRIM_IDS/generate(), and lvkit/labview_queue.py needs a flush_queue(queue) function (pop all pending elements front-to-back into a list and return it, mirroring LVQueue.status() but draining instead of peeking)."
+      ]
+    },
+    "2073": {
+      "name": "Create User Event",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/create-user-event.html",
+      "verified": true,
+      "placeholder": true,
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "user_event_data_type",
+          "type": "polymorphic"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error_in",
+          "type": "Cluster"
+        },
+        {
+          "index": 8,
+          "direction": "out",
+          "name": "user_event_out",
+          "type": "Refnum"
+        },
+        {
+          "index": 11,
+          "direction": "out",
+          "name": "error_out",
+          "type": "Cluster"
+        }
+      ],
+      "python_code": "pass",
+      "note": "Confirmed via NI doc exact match: 'user event data type' (a cluster of elements or an individual element whose labels/types define the event's name+data), error in -> user event out (strictly-typed UserEvent refnum), error out. ref_type=UserEvent on the output is the clean-room identity signal. Cross-checked identical across 2 independent VIs (JKI VI-Tester 'Graphical Test Runner - Main UI - .vi': idx0 resolved Boolean; lv-flex-channel-examples 'WaveGen.vi': idx0 resolved Cluster) -- the varying idx0 type across instances is exactly the documented polymorphism ('cluster of elements OR an individual element'). Identity is solid; CODEGEN is not. No lvkit user-event/event-registration runtime exists yet (queues have lvkit.labview_queue + codegen/nodes/queue_ops.py; notifiers got the same 'identity solid, placeholder codegen' treatment at 9101/9104/9102). Marked placeholder so it renders/describes under the correct name but cannot emit silently-wrong code."
+    },
+    "2075": {
+      "name": "Destroy User Event",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/destroy-user-event.html",
+      "verified": true,
+      "placeholder": true,
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "user_event",
+          "type": "Refnum"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error_in",
+          "type": "Cluster"
+        },
+        {
+          "index": 7,
+          "direction": "out",
+          "name": "error_out",
+          "type": "Cluster"
+        }
+      ],
+      "python_code": "pass",
+      "note": "Confirmed via NI doc exact match: 'user event' (UserEvent refnum from Create User Event), error in ('This node runs normally even if an error occurred before this node runs' -- matches this primitive's special error-in semantics) -> error out ONLY (no refnum passthrough -- destroying invalidates the reference, which is why this pane has no 'user event out'). Cross-checked identical across 2 independent VIs (JKI VI-Tester Graphical Test Runner; measurement-plugin-labview 'Run Client.vi'). NOTE FOR MAINTAINER (not touched, out of scope): src/lvkit/codegen/class_builder.py line ~385 has a stale/incorrect comment listing prim 2075 as 'Merge Errors' in _is_simple_accessor()'s simple_prim_ids set (2076 is listed there too, as 'Clear Error'). Per this resolution and the adjacent 2076 entry (Unregister For Events), NEITHER of those identifications is correct -- flagging for a follow-up fix, not changed here since it's outside primitives.json/tests scope. Identity is solid; CODEGEN is not. No lvkit user-event/event-registration runtime exists yet (queues have lvkit.labview_queue + codegen/nodes/queue_ops.py; notifiers got the same 'identity solid, placeholder codegen' treatment at 9101/9104/9102). Marked placeholder so it renders/describes under the correct name but cannot emit silently-wrong code."
+    },
+    "2402": {
+      "name": "Merge Event Registrations",
+      "verified": false,
+      "placeholder": true,
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "event_reg_a",
+          "type": "Refnum"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "event_reg_b",
+          "type": "Refnum"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "event_reg_out",
+          "type": "Refnum"
+        }
+      ],
+      "python_code": "pass",
+      "note": "No public NI doc page found for this exact 2-EventReg-refnum-in / 1-EventReg-refnum-out shape with NO error cluster at all -- searched the full NI function catalog under 'event'/'regist'/'refnum' keywords; nothing matches. Deduced as a COMPILER-INTERNAL glue primitive (name is a clean-room descriptive label, not an NI-documented title), analogous in role to prim 2401 Merge Errors at the immediately adjacent resID (also a pure-refnum-combine op with no error terminal of its own). Evidence: NI's Register For Events doc explicitly documents refnum-chaining ('wire the top left input of the Register For Events function to... modify the existing registration instead of registering again'), i.e. LabVIEW natively combines multiple dynamic event-source registrations into one EventReg. In 'DAQmx AO.vi' (lv-flex-channel-examples), 2402 appears 3 times: one instance's idx0 comes directly from the diagram's eventRegNode, and its output feeds both a Bundle node and the enclosing while loop's shift register (the master EventReg the Event structure reads each iteration); the other two instances chain off a 'Read Event.vi' SubVI call (which itself likely performs an internal dynamic registration and returns a fresh EventReg to fold in). This reads as the compiler's automatic merge step whenever a static eventRegNode registration is combined with additional dynamically-obtained registrations, mirroring how 2401 merges multiple error-cluster branches. Cross-checked structurally identical (3 same-shaped instances in 'DAQmx AO.vi' plus matching instances in 'WaveGen.vi' and 'Control.vi', same library). No runtime exists for event registration in lvkit, and the exact merge semantics (which refnum 'wins', or whether both remain independently live) cannot be confirmed without a public spec, so left as placeholder pass."
+    },
+    "2135": {
+      "name": "Register Event Source For Event Type (internal)",
+      "verified": false,
+      "placeholder": true,
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "event_reg_in",
+          "type": "Refnum"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "dynamic",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "event_type",
+          "type": "enum"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error_in",
+          "type": "Cluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "source_id",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "config",
+          "type": "NumInt32"
+        },
+        {
+          "index": 8,
+          "direction": "out",
+          "name": "event_reg_out",
+          "type": "Refnum"
+        },
+        {
+          "index": 9,
+          "direction": "out",
+          "name": "registration_id",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 11,
+          "direction": "out",
+          "name": "error_out",
+          "type": "Cluster"
+        }
+      ],
+      "python_code": "pass",
+      "note": "No public NI function page matches this shape -- deduced as a compiler-internal primitive that the eventRegNode / Register For Events construct expands into once per configured (event source, event type) pair; users never place this node directly (per NI docs, they configure it via the Register For Events icon's right-click menu or the eventRegNode UI). STRONG evidence for the domain: idx2's enum type (UnitUInt32) carries LabVIEW's actual built-in Event Type enumeration as its values -- 'Timeout', 'Value Change', 'Mouse Down', 'Mouse Down?', 'Panel Close', 'Panel Close?', 'Key Down', 'User Event', 'Cell Edit', 'Tree Item Open', etc. (67 values, read directly from the VI's own type map in 'DAQmx AO.vi') -- this is exactly the closed set of events NI's Register For Events doc describes selecting via 'right-click the data item for the event source and select the event to detect'. Cross-checked structurally identical across 5 instances within 'DAQmx AO.vi' and confirmed in the sibling 'WaveGen.vi' (same lv-flex-channel-examples library). Exact field semantics for idx1 (dynamic/static?), idx4/idx5 (a source identifier and some config value) are a reasonable but unconfirmed reading -- no doc page exists to pin them precisely, hence placeholder + verified:false despite the strong enum evidence for the overall identity/domain."
+    },
+    "9000": {
+      "name": "Current VI's Menubar",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/current-vi-s-menubar.html",
+      "verified": false,
+      "placeholder": true,
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "menu_reference",
+          "type": "Refnum"
+        }
+      ],
+      "python_code": "pass",
+      "note": "Confirmed via NI doc exact match: the ONLY function in the Menu category with a single terminal (menu reference output, no inputs, no error terminals at all -- 'Returns the menu reference refnum of the current VI'). ref_type=Menu on the sole output is the clean-room identity signal. Identity is solid; CODEGEN is not. No lvkit Menu/VI-Server runtime exists (there is no live front-panel/menu model to manipulate in generated Python -- same 'identity solid, no runtime' situation as the Notifier family at 9101/9102/9104 and Close Reference at 8011). Marked placeholder so it renders/describes under the correct name but cannot emit silently-wrong or fabricated UI-manipulation code. Single call site in the corpus (JKI VI-Tester's 'Graphical Test Runner - Main UI - .vi'), so verified stays false."
+    },
+    "9003": {
+      "name": "Insert Menu Items",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/insert-menu-items.html",
+      "verified": false,
+      "placeholder": true,
+      "terminals": [
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "menu_tag",
+          "type": "String"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "after_item",
+          "type": "String"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "error_in",
+          "type": "Cluster"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "item_names",
+          "type": "Array"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "item_tags",
+          "type": "Array"
+        },
+        {
+          "index": 9,
+          "direction": "in",
+          "name": "menu_reference",
+          "type": "Refnum"
+        },
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error_out",
+          "type": "Cluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "item_tags_out",
+          "type": "Array"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "menu_reference_out",
+          "type": "Refnum"
+        }
+      ],
+      "python_code": "pass",
+      "note": "Confirmed via NI doc exact match: 6 inputs (menu tag, menu reference, item names, item tags, error in, after item) + 3 outputs (menu reference out, item tags out, error out) = 9 named terminals, exactly matching the observed 9-terminal pane. Types pin most slots unambiguously: idx9=Refnum=menu reference, idx6=Cluster=error in, idx7/idx8=Array[String]=item names/item tags (this instance wired arrays; the doc also allows a single string per slot), idx3=Refnum=menu reference out, idx1=Array[String]=item tags out, idx0=Cluster=error out -- all confirmed unambiguous by output-column termBounds order, which matches the NI doc's output listing order exactly (top-to-bottom: menu reference out, item tags out, error out). The remaining ambiguity is idx4 vs idx5 (both scalar String): termBounds geometry places them in their own double-height connector-pane column, separate from the single-height 4-slot column holding menu_reference/item_names/item_tags/error_in (which independently matches doc order top-to-bottom). menu_tag is the FIRST-listed doc input and after_item is the LAST-listed; assigning top-of-column=idx5=menu_tag, bottom-of-column=idx4=after_item is a deduction (not a doc-confirmed index), supported by dataflow: idx5 (hypothesized menu_tag) IS wired in the sole corpus instance, idx4 (hypothesized after_item, a rarely-customized insertion-position parameter) is UNWIRED -- consistent with menu_tag being commonly specified and after_item commonly left at its default. Identity is solid; CODEGEN is not. No lvkit Menu/VI-Server runtime exists (there is no live front-panel/menu model to manipulate in generated Python -- same 'identity solid, no runtime' situation as the Notifier family at 9101/9102/9104 and Close Reference at 8011). Marked placeholder so it renders/describes under the correct name but cannot emit silently-wrong or fabricated UI-manipulation code. Single call site in the corpus (JKI VI-Tester's 'Graphical Test Runner - Main UI - .vi'), so verified stays false."
+    },
+    "9004": {
+      "name": "Delete Menu Items",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/delete-menu-items.html",
+      "verified": false,
+      "placeholder": true,
+      "terminals": [
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "error_in",
+          "type": "Cluster"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "items",
+          "type": "Array"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "menu_tag",
+          "type": "String"
+        },
+        {
+          "index": 9,
+          "direction": "in",
+          "name": "menu_reference",
+          "type": "Refnum"
+        },
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error_out",
+          "type": "Cluster"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "menu_reference_out",
+          "type": "Refnum"
+        }
+      ],
+      "python_code": "pass",
+      "note": "Confirmed via NI doc exact match, and cleanly unambiguous: NI lists exactly 4 inputs (menu reference, menu tag, items, error in) and 2 outputs (menu reference out, error out), matching the observed 6-terminal pane count. Every input has a UNIQUE type in this pane (idx9=Refnum, idx8=String, idx7=Array[String], idx6=Cluster), so no shape-guessing was needed -- 'items' (doc: 'a tag, an array of tags, a position index, or an array of position indexes') was wired here as Array[String], the only array-typed input. Column top-to-bottom order (idx9,idx8,idx7,idx6) independently matches the doc's listed order (menu reference, menu tag, items, error in), and the output column (idx3 top, idx0 bottom) matches (menu reference out, error out). Identity is solid; CODEGEN is not. No lvkit Menu/VI-Server runtime exists (there is no live front-panel/menu model to manipulate in generated Python -- same 'identity solid, no runtime' situation as the Notifier family at 9101/9102/9104 and Close Reference at 8011). Marked placeholder so it renders/describes under the correct name but cannot emit silently-wrong or fabricated UI-manipulation code. Single call site in the corpus (JKI VI-Tester's 'Graphical Test Runner - Main UI - .vi'), so verified stays false."
+    },
+    "9005": {
+      "name": "Get Menu Item Info",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/get-menu-item-info.html",
+      "verified": false,
+      "placeholder": true,
+      "terminals": [
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "item_tag",
+          "type": "String"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "error_in",
+          "type": "Cluster"
+        },
+        {
+          "index": 11,
+          "direction": "in",
+          "name": "menu_reference",
+          "type": "Refnum"
+        },
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error_out",
+          "type": "Cluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "enabled",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "item_name",
+          "type": "String"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "menu_reference_out",
+          "type": "Refnum"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "checked",
+          "type": "Boolean"
+        },
+        {
+          "index": 5,
+          "direction": "out",
+          "name": "submenu_tags",
+          "type": "Array"
+        },
+        {
+          "index": 6,
+          "direction": "out",
+          "name": "shortcut_info",
+          "type": "Cluster"
+        }
+      ],
+      "python_code": "pass",
+      "note": "Confirmed via NI doc exact match: 3 inputs (item tag, menu reference, error in) confirmed unambiguous by unique type. NI's doc lists 10 named outputs, but 3 of them (short cut, include Shift key?, include Ctrl key?, shortcut key) collapse into ONE cluster terminal on the actual icon -- confirmed by resolving this VI's own type map for the cluster at idx6, whose fields are literally {'include Shift key?': Boolean, 'include Ctrl key?': Boolean, 'shortcut key': String}, an exact field-name match to those 3 doc entries. That collapses the doc's 10 outputs to 7 real terminals: submenu_tags (Array), menu_reference_out (Refnum), item_name (String), enabled? (Boolean), error_out (Cluster, confirmed by its OWN type-map fields status/code/source), checked? (Boolean), shortcut_info (Cluster) -- an exact type-multiset match to the observed 7-output pane. idx2/idx3/idx5/idx0/idx6 are unambiguous by unique type. The remaining ambiguity is idx1 vs idx4 (both Boolean = enabled?/checked?, both UNWIRED in the sole corpus instance so no dataflow tiebreak was available): idx1 sits in the single-height output column whose OTHER 3 slots (menu_reference_out, item_name, error_out) independently match doc order top-to-bottom, and 'enabled' is the doc item immediately between item_name and error_out in that same run -- so idx1 is assigned enabled? by the same column-preserves-doc-order pattern verified elsewhere in this pane, leaving idx4 (in the separate double-height column with submenu_tags) as checked? by elimination. This idx1/idx4 assignment is the one part of this entry NOT independently confirmed by type or wiring -- flagging for scrutiny. Identity is solid; CODEGEN is not. No lvkit Menu/VI-Server runtime exists (there is no live front-panel/menu model to manipulate in generated Python -- same 'identity solid, no runtime' situation as the Notifier family at 9101/9102/9104 and Close Reference at 8011). Marked placeholder so it renders/describes under the correct name but cannot emit silently-wrong or fabricated UI-manipulation code. Single call site in the corpus (JKI VI-Tester's 'Graphical Test Runner - Main UI - .vi'), so verified stays false."
+    },
+    "1156": {
+      "name": "To Unsigned Quad Integer",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/to-unsigned-quad-integer.html",
+      "verified": true,
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "result",
+          "type": "NumUInt64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "polymorphic"
+        }
+      ],
+      "python_code": {
+        "result": "int(in_1) & 0xFFFFFFFFFFFFFFFF"
+      },
+      "inline": true,
+      "note": [
+        "Confirmed via NI doc match and completes the existing sibling family (1140 To Byte Integer, 1141 To Word Integer, 1142 To Long Integer, 1143 To Unsigned Byte Integer, 1144 To Unsigned Word Integer -- all already share the idx0=out/idx1=in convention this entry follows). Cross-checked across 2 independent VIs: 'pco.camera_FloatingMean_Example_IMAQ.vi' (idx1=NumUInt8 in, idx0=NumUInt64 out -- a widening conversion) and 'testNumericU64.vi' (JKI-EasyXML, name is itself confirmatory: idx1=NumUInt64 in, idx0=NumUInt64 out -- an identity-shaped polymorphic instantiation). Masking with 0xFFFFFFFFFFFFFFFF mirrors the & 0xFF / & 0xFFFF pattern already used by the unsigned siblings."
+      ]
+    },
+    "1341": {
+      "name": "Two Button Dialog",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/two-button-dialog.html",
+      "verified": true,
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "t_button_pressed",
+          "type": "Boolean"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "t_button_name",
+          "type": "String"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "f_button_name",
+          "type": "String"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "message",
+          "type": "String"
+        }
+      ],
+      "placeholder": true,
+      "python_code": "pass",
+      "note": [
+        "Codegen deferred (placeholder): unlike sibling 1340 One Button Dialog (a single button -> deterministic outcome), Two Button Dialog's T-vs-F result is a real branch, so hard-coding a winner would be a silent guess -- render/describe still use the confirmed identity below.",
+        "Confirmed via NI doc exact match: message, T button name (default 'OK'), F button name (default 'Cancel') -> T button? (True if the T-named button was clicked). 4-terminal count (3 string in, 1 bool out) is exactly one more input than the already-resolved sibling 1340 One Button Dialog, whose own note explicitly flagged 'Two Button Dialog excluded (three strings)' as the distinguishing shape -- confirming this entry closes that gap correctly. Index-to-field mapping is evidence-based, not assumed: across 5 observed instances (3 in 'Graphical Test Runner - Main UI - .vi', 1 in 'Dictionary Example.vi', 1 in 'Folder Reuse Warning.vi'), idx3 is WIRED in 5/5 (matches 'message', which the doc marks required, no default), idx1 is UNWIRED in 3/5 (matches 'T button name', which defaults to \"OK\"), idx2 is wired in 3/5 (matches 'F button name', default \"Cancel\", occasionally customized). In 'Folder Reuse Warning.vi', idx3 is fed by a 'Concatenate Strings' primitive -- a dynamically-built message, never plausible for a short button-name string, corroborating idx3=message. python_code hard-codes True (the affirmative/T-button path) since generated code runs headlessly with no real dialog to click through -- same non-interactive-substitute approach sibling 1340 uses."
+      ]
+    },
+    "1184": {
+      "name": "Decimal String To Number",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/decimal-string-to-number.html",
+      "verified": true,
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "number",
+          "type": "polymorphic"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "offset_past_number",
+          "type": "NumInt32"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "default",
+          "type": "polymorphic"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "offset",
+          "type": "NumInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "string",
+          "type": "String"
+        }
+      ],
+      "placeholder": true,
+      "python_code": "pass",
+      "note": [
+        "Codegen deferred (placeholder): the identity is confirmed (below), but a faithful template needs `re` (inline __import__ is disallowed by the project style rule) plus polymorphic float/exponent handling not exercised by the corpus -- render/describe use the confirmed identity.",
+        "Confirmed via NI doc exact match: string, offset, default (numeric representation for the polymorphic output) -> offset past number, number. 3-input/2-output count and type-multiset (String + 2x numeric in, 2x numeric out) is an exact match. idx4 (String) is unambiguous by unique type. idx3/idx2 (both numeric in) assigned by connector-pane column position: the left-hand input column runs top-to-bottom idx4, idx3, idx2, matching the doc's listed order (string, offset, default) exactly. idx1/idx0 (both numeric out) assigned the same way (top=idx1=offset_past_number, bottom=idx0=number, matching doc order top-to-bottom). Cross-checked polymorphism across 2 independent VIs: 'Results Status Update Process__core.vi' (JKI VI-Tester, 2 call sites, Int32-shaped) and 'Get LV Mem Usage.vi' (idx0 resolves NumFloat64) -- exactly the documented polymorphic behavior where 'number'/idx0's type tracks whatever is wired to 'default'/idx2. python_code regex-scans a leading [sign]digits run after skipping whitespace, matching all 3 of NI's own worked examples exactly: '13ax' offset0 -> number=13, offset_past=2; '-4.8bcde' offset0 -> number=-4, offset_past=2 (stops at the decimal point since the target is integer); 'a49b' offset0 default=-9 -> no digits found, number=-9 (default), offset_past=0 (unchanged). Only handles integer scanning (matches the corpus instances observed, both integer-typed defaults); float/exponent variants of this polymorphic function are not exercised by any call site found."
+      ]
+    },
+    "1350": {
+      "name": "Unknown Boolean-Sink Primitive 1350",
+      "placeholder": true,
+      "verified": false,
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "value",
+          "type": "Boolean"
+        }
+      ],
+      "python_code": "pass",
+      "note": [
+        "Exhausted investigation without a confident identification. Single Boolean input, NO outputs at all (not even an error cluster) -- an unusual shape with no obvious NI Dialog/Boolean/Comparison-category match of this exact count. Context (Step 3): in every traced instance the input comes from either 'Simple Error Handler.vi' (a common error-display subVI) or directly from prim 1340 (One Button Dialog's boolean 'true?' output, itself always True and rarely consumed downstream) -- i.e. this primitive always sits at the very end of a diagram branch consuming a boolean nobody else uses, which reads like a deliberate 'discard/terminate this branch' sink, but no NI function of that description was found in the catalog. 6 distinct top-level example VIs contain it (PCO camera examples, Moog SmartMotor examples) always as a lone terminal node with no further dataflow. Left as a placeholder per the skill's last-resort rule; asked no further since this is a shape/behavior question the corpus can answer, not a LabVIEW-inspection question."
+      ]
     }
   },
   "node_types": {

--- a/src/lvkit/graph/builders/context.py
+++ b/src/lvkit/graph/builders/context.py
@@ -25,6 +25,7 @@ class GraphBuildContext:
     flatseq_by_uid: dict[str, Any]
     decompose_by_uid: dict[str, Any]
     disable_by_uid: dict[str, Any]
+    event_by_uid: dict[str, Any]
     iuse_to_qname: dict[str, str]   # iUse uid -> qualified callee name
     iuse_to_qpath: dict[str, str]   # iUse uid -> qualified on-disk path
     # For the early ref handlers (ctlRefConst / gRef / statVIRef):

--- a/src/lvkit/graph/builders/structures.py
+++ b/src/lvkit/graph/builders/structures.py
@@ -154,6 +154,10 @@ class EventBuildHandler(StructureBuildHandler):
             parser_tunnels, q_node_uid,
         )
 
+        filter_node_uids = frozenset(
+            ctx.qid(u) for u in (event_struct.filter_node_uids if event_struct else ())
+        )
+
         return EventStructureNode(
             id=q_node_uid,
             vi=ctx.vi_name,
@@ -162,6 +166,7 @@ class EventBuildHandler(StructureBuildHandler):
             terminals=structure_terminals,
             frames=event_frames,
             displayed_frame=displayed_frame,
+            filter_node_uids=filter_node_uids,
         )
 
 

--- a/src/lvkit/graph/builders/structures.py
+++ b/src/lvkit/graph/builders/structures.py
@@ -10,12 +10,13 @@ from __future__ import annotations
 import logging
 from abc import ABC, abstractmethod
 
-from lvkit.models import CaseFrame, SequenceFrame, Terminal
+from lvkit.models import CaseFrame, EventFrame, SequenceFrame, Terminal
 from lvkit.parser.models import ParsedNode
 
 from ..models import (
     CaseStructureNode,
     DisableStructureNode,
+    EventStructureNode,
     InPlaceNode,
     LoopNode,
     SequenceNode,
@@ -126,6 +127,41 @@ class CaseBuildHandler(StructureBuildHandler):
             case_insensitive=(
                 case_struct.case_insensitive if case_struct else False
             ),
+        )
+
+
+class EventBuildHandler(StructureBuildHandler):
+    """Builds an Event Structure — same frame-tunnel wiring as
+    CaseBuildHandler (border tunnels use the identical per-frame ``selTun``-
+    style shape — see parser/nodes/event.py), but no selector terminal: the
+    active frame is chosen at runtime by whichever event fires, not a wire.
+    """
+
+    node_types = ("eventStruct",)
+
+    def build(self, node, node_name, q_node_uid, ctx):
+        event_struct = ctx.event_by_uid.get(node.uid)
+        event_frames: list[EventFrame] = []
+        displayed_frame: int | None = None
+
+        parser_tunnels: list = []
+        if event_struct:
+            parser_tunnels = event_struct.tunnels
+            event_frames = list(event_struct.frames)
+            displayed_frame = event_struct.displayed_frame
+
+        structure_terminals = ctx.build_structure_terminals(
+            parser_tunnels, q_node_uid,
+        )
+
+        return EventStructureNode(
+            id=q_node_uid,
+            vi=ctx.vi_name,
+            name=node_name or "Event Structure",
+            node_type=node.node_type,
+            terminals=structure_terminals,
+            frames=event_frames,
+            displayed_frame=displayed_frame,
         )
 
 
@@ -246,6 +282,7 @@ _HANDLERS: list[StructureBuildHandler] = [
     SequenceBuildHandler(),
     InPlaceBuildHandler(),
     DisableBuildHandler(),
+    EventBuildHandler(),
 ]
 
 STRUCTURE_BUILD_HANDLERS: dict[str, StructureBuildHandler] = {

--- a/src/lvkit/graph/construction.py
+++ b/src/lvkit/graph/construction.py
@@ -673,6 +673,35 @@ class ConstructionMixin:
                 cnode.parent = struct_id
                 cnode.frame = frame_key
 
+        # Attribute FP terminals (front-panel controls placed on a diagram
+        # via an sRN — e.g. an Event Structure's registered event-source
+        # control glyph) to the frame that contains THAT placement. Same
+        # shape as the constants loop just above: the terminal's own
+        # terminal_info.parent_uid points to the owning sRN, already stamped
+        # into frame_owner by the loops above. FPTerminal isn't a GraphNode
+        # (one FPTerminal is shared VI-wide, not one per placement — a
+        # control can be referenced from multiple frames), so the
+        # attribution is stamped directly on the Terminal rather than via
+        # ``_stamp``. Without this, render/scene.py has no structural
+        # signal for these terminals and falls back to inferring frame scope
+        # from wire connectivity — which is wrong/absent for a control used
+        # purely as an event source (no ordinary data wire into the frame),
+        # making its glyph (and any wire touching it) render as always-
+        # visible base content instead of scoped to its real frame.
+        vi_terminal_by_id = {
+            t.id: t for t in vi_node.terminals if isinstance(t, FPTerminal)
+        }
+        for fp_term in bd.fp_terminals:
+            ct = bd.terminal_info.get(fp_term.uid)
+            if ct is None or ct.parent_uid not in frame_owner:
+                continue
+            terminal = vi_terminal_by_id.get(self._qid(vi_name, fp_term.uid))
+            if terminal is None:
+                continue
+            struct_id, frame_key = frame_owner[ct.parent_uid]
+            terminal.parent = struct_id
+            terminal.frame = frame_key
+
         # === 5. Register remaining terminal_info entries in term_lookup ===
         # Most tunnel/sRN terminals are already registered by
         # _build_structure_terminals. This catches any stragglers whose

--- a/src/lvkit/graph/construction.py
+++ b/src/lvkit/graph/construction.py
@@ -419,15 +419,16 @@ class ConstructionMixin:
         flatseq_by_uid = {fs.uid: fs for fs in bd.flat_sequences}
         decompose_by_uid = {ds.uid: ds for ds in bd.decompose_structures}
         disable_by_uid = {ds.uid: ds for ds in bd.disable_structures}
+        event_by_uid = {es.uid: es for es in bd.event_structures}
 
-        # Structure nodes (loop/case/sequence/IPES/disable) are built by
+        # Structure nodes (loop/case/sequence/IPES/disable/event) are built by
         # registered per-kind handlers rather than an inlined if/elif — see
         # graph/builders/.
         build_ctx = GraphBuildContext(
             mixin=self, bd=bd, vi_name=vi_name, term_lookup=term_lookup,
             loop_by_uid=loop_by_uid, case_by_uid=case_by_uid,
             flatseq_by_uid=flatseq_by_uid, decompose_by_uid=decompose_by_uid,
-            disable_by_uid=disable_by_uid,
+            disable_by_uid=disable_by_uid, event_by_uid=event_by_uid,
             iuse_to_qname=iuse_to_qname or {}, iuse_to_qpath=iuse_to_qpath,
             fp=fp, ddo_to_fpdco=ddo_to_fpdco,
             param_wire_ends=param_wire_ends, vi_node_uids=vi_node_uids,
@@ -648,6 +649,15 @@ class ConstructionMixin:
                 for uid in frame.inner_node_uids:
                     _stamp(uid, q_disable_uid, frame.selector_value)
 
+        # Event structure frames are keyed by INDEX (str(idx)) — like a
+        # stacked sequence, not a case — since the active frame is chosen at
+        # runtime by whichever event fires, not a selector wire/value.
+        for es in bd.event_structures:
+            q_es_uid = self._qid(vi_name, es.uid)
+            for idx, frame in enumerate(es.frames):
+                for uid in frame.inner_node_uids:
+                    _stamp(uid, q_es_uid, str(idx))
+
         # Attribute constants to the frame that contains them. A constant
         # wired inside a structure is a diagram constant whose output
         # terminal (keyed by the constant UID) is parented to the frame's
@@ -727,6 +737,14 @@ class ConstructionMixin:
                                     effective_parent = self._qid(
                                         vi_name, disable.uid,
                                     )
+                                    break
+                            if effective_parent != q_parent_uid:
+                                break
+                    if effective_parent == q_parent_uid:
+                        for es in bd.event_structures:
+                            for frame in es.frames:
+                                if parent_uid in frame.inner_node_uids:
+                                    effective_parent = self._qid(vi_name, es.uid)
                                     break
                             if effective_parent != q_parent_uid:
                                 break

--- a/src/lvkit/graph/construction.py
+++ b/src/lvkit/graph/construction.py
@@ -1256,6 +1256,21 @@ class ConstructionMixin:
                 if srn_in_scope:
                     all_srn_parents.add(ti.parent_uid)
 
+        # An sRN group can aggregate terminals from UNRELATED conceptual
+        # placements (e.g. a "Front Panel Window" property bundle mixing
+        # Behavior/Title rows with a completely separate control's event-
+        # registration stub, or an unrelated indicator's own terminal) that
+        # happen to share a raw index purely by coincidence of parse order —
+        # NOT because LabVIEW pairs them. A real front-panel control/
+        # indicator terminal (``bd.fp_terminals``) already has its own
+        # independently-derived identity, direction, and wiring (the FP-
+        # terminal init above, plus its genuine ``bd.wires`` entries); it is
+        # never one physical side of an sRN pass-through. Pairing it anyway
+        # via same-index matching below fabricates a wrongly-directed edge
+        # (e.g. a control's own terminal ending up as a wire's DEST, or an
+        # indicator's own terminal ending up as a wire's SOURCE) — see #86.
+        fp_terminal_uids = {fp_term.uid for fp_term in bd.fp_terminals}
+
         for srn_uid in all_srn_parents:
             # Collect all terminals owned by this sRN
             srn_terms = [
@@ -1306,6 +1321,8 @@ class ConstructionMixin:
                 (input_by_idx[idx], output_by_idx[idx])
                 for idx in input_by_idx
                 if idx in output_by_idx
+                and input_by_idx[idx][0] not in fp_terminal_uids
+                and output_by_idx[idx][0] not in fp_terminal_uids
             ]
             for (in_uid, _in_ti), (out_uid, _out_ti) in paired:
                 q_in_uid = self._qid(vi_name, in_uid)

--- a/src/lvkit/graph/core.py
+++ b/src/lvkit/graph/core.py
@@ -22,6 +22,7 @@ from .models import (
     AnyGraphNode,
     ConstantNode,
     DisableStructureNode,
+    EventStructureNode,
     LocalVariableNode,
     PolyInfo,
     StructureNode,
@@ -60,12 +61,13 @@ _KIND_TO_LABELS: dict[str, list[str]] = {
     "formula": ["FormulaNode"],
     "local_variable": ["LocalVariable"],
     "disableStruct": ["DisableStructure"],
+    "eventStruct": ["EventStructure"],
 }
 
 # Graph node kinds that represent executable operations
 _OPERATION_KINDS = (
     "vi", "primitive", "operation", "caseStruct", "loop", "formula",
-    "disableStruct",
+    "disableStruct", "eventStruct",
 )
 
 
@@ -98,6 +100,8 @@ def _graph_node_to_op_kind(node: AnyGraphNode) -> str:
         return "primitive"
     if isinstance(node, DisableStructureNode):
         return "disableStruct"
+    if isinstance(node, EventStructureNode):
+        return "eventStruct"
     if isinstance(node, StructureNode):
         if node.node_type in ("caseStruct", "select"):
             return "caseStruct"

--- a/src/lvkit/graph/diff.py
+++ b/src/lvkit/graph/diff.py
@@ -11,6 +11,7 @@ from ..models import (
     CaseFrame,
     CaseOperation,
     DisableStructureOperation,
+    EventOperation,
     Frame,
     LoopOperation,
     Operation,
@@ -163,6 +164,7 @@ class ChangeMap:
 
 _STRUCT_OPS = (
     CaseOperation, LoopOperation, SequenceOperation, DisableStructureOperation,
+    EventOperation,
 )
 
 
@@ -182,6 +184,8 @@ def _struct_label(op: Operation) -> str:
         return "While loop" if op.loop_type == "whileLoop" else "For loop"
     if isinstance(op, SequenceOperation):
         return "Flat sequence"
+    if isinstance(op, EventOperation):
+        return "Event structure"
     return op.node_type or "structure"
 
 
@@ -266,7 +270,7 @@ def _collect_elements(
         kind = "structure" if isinstance(op, _STRUCT_OPS) else "node"
         out[_uid_of(op.id)] = _ElemInfo(op, kind, container_uid, frame_path)
         if isinstance(op, (CaseOperation, SequenceOperation,
-                           DisableStructureOperation)):
+                           DisableStructureOperation, EventOperation)):
             struct_uid = _uid_of(op.id)
             interactive = _is_interactive_struct(op)
             for frame in op.frames:

--- a/src/lvkit/graph/models.py
+++ b/src/lvkit/graph/models.py
@@ -187,6 +187,12 @@ class EventStructureNode(StructureNode):
     # faithful initial view. None if unresolved (renderer falls back to
     # frame 0).
     displayed_frame: int | None = None
+    # Qualified (vi-prefixed) node ids of this structure's Event FILTER Nodes
+    # — same heap class (``eventDataNode``) as an Event DATA Node, so this is
+    # the only way to tell which is which (see parser/nodes/event.py). Used
+    # by the renderer to draw the Filter Node's accent band on the opposite
+    # (right) edge from a Data Node's (left) — see render/nodes.py.
+    filter_node_uids: frozenset[str] = frozenset()
 
 
 class FormulaNode(GraphNode):

--- a/src/lvkit/graph/models.py
+++ b/src/lvkit/graph/models.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel
 from ..models import (
     CaseFrame,
     ClusterField,
+    EventFrame,
     LVType,
     Operation,
     PropertyDef,
@@ -169,6 +170,25 @@ class DisableStructureNode(StructureNode):
     active_frame: int | None = None
 
 
+class EventStructureNode(StructureNode):
+    """An Event Structure — one frame per registered event.
+
+    Unlike CaseStructureNode, the active frame is chosen at RUNTIME by
+    whichever event actually fires — there is no selector wire/value, so
+    frames are keyed by INDEX (matching a stacked sequence's convention, not
+    a case's ``selector_value``). See EventFrame.
+    """
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    frames: list[EventFrame] = []
+    # Frame LabVIEW last displayed (heap ``dIdx``), whose ``event_label``
+    # came from the heap's own precomputed ``selString`` text — the
+    # faithful initial view. None if unresolved (renderer falls back to
+    # frame 0).
+    displayed_frame: int | None = None
+
+
 class FormulaNode(GraphNode):
     """A Formula Node (fBox) — an embedded C-like script over typed terminals.
 
@@ -219,7 +239,7 @@ class LocalVariableNode(GraphNode):
 # Discriminated union of all node types
 AnyGraphNode = (
     VINode | PrimitiveNode | StructureNode | ConstantNode | InPlaceNode
-    | FormulaNode | LocalVariableNode | DisableStructureNode
+    | FormulaNode | LocalVariableNode | DisableStructureNode | EventStructureNode
 )
 
 

--- a/src/lvkit/graph/netlist.py
+++ b/src/lvkit/graph/netlist.py
@@ -594,9 +594,10 @@ def _build_event_scope(
 
     NOT run through ``_selector_label``: there's no runtime selector (the
     active frame is chosen by whichever event fires), so ``EventFrame.
-    event_label`` already IS the faithful display text (LabVIEW's own
-    bracketed ``[N] EventName`` rendering for the frame it last displayed,
-    an honest ``"[N]"`` placeholder for every other frame -- see
+    event_label`` already IS the display text (LabVIEW's own bracketed
+    ``[N] EventName`` rendering for the frame it last displayed, a
+    reconstructed label from that frame's ``EventSpec`` for every other
+    frame, degrading to an honest ``"[N]"`` when unresolvable -- see
     parser/nodes/event.py). Same reasoning as ``_build_disabled_scope``.
     """
     passthrough = _has_output_tunnel(op)

--- a/src/lvkit/graph/netlist.py
+++ b/src/lvkit/graph/netlist.py
@@ -33,6 +33,7 @@ from ..models import (
     CaseOperation,
     ClusterField,
     DisableStructureOperation,
+    EventOperation,
     InPlaceOperation,
     LoopOperation,
     LVType,
@@ -152,10 +153,10 @@ class NetlistFrame:
 
 @dataclass
 class NetlistScope:
-    """A structure: case / for / while / sequence / disabled."""
+    """A structure: case / for / while / sequence / disabled / event."""
 
     uid: str
-    kind: str  # "case" | "for" | "while" | "sequence" | "disabled"
+    kind: str  # "case" | "for" | "while" | "sequence" | "disabled" | "event"
     selector: NetRef | None
     frames: list[NetlistFrame]
 
@@ -240,7 +241,10 @@ def _walk_flat(operations: list[Operation]) -> list[Operation]:
     for op in operations:
         flat.append(op)
         match op:
-            case CaseOperation() | SequenceOperation() | DisableStructureOperation():
+            case (
+                CaseOperation() | SequenceOperation() | DisableStructureOperation()
+                | EventOperation()
+            ):
                 for frame in op.frames:
                     flat.extend(_walk_flat(frame.operations))
             case _:
@@ -268,7 +272,7 @@ def _assign_occurrences(root_ops: list[Operation]) -> dict[str, int]:
         if not isinstance(
             op,
             (CaseOperation, LoopOperation, SequenceOperation,
-             DisableStructureOperation, InPlaceOperation),
+             DisableStructureOperation, InPlaceOperation, EventOperation),
         )
     ]
     names = [_display_name(op) for op in insts]
@@ -472,6 +476,10 @@ def _build_items(
                 items.append(
                     _build_disabled_scope(graph, ctx, root_ops, op, build_ctx)
                 )
+            case EventOperation():
+                items.append(
+                    _build_event_scope(graph, ctx, root_ops, op, build_ctx)
+                )
             case LoopOperation():
                 items.append(
                     _build_loop_scope(graph, ctx, root_ops, op, build_ctx)
@@ -575,6 +583,40 @@ def _build_disabled_scope(
     )
 
 
+def _build_event_scope(
+    graph: InMemoryVIGraph,
+    ctx: VIContext,
+    root_ops: list[Operation],
+    op: EventOperation,
+    build_ctx: _BuildCtx,
+) -> NetlistScope:
+    """An Event Structure's frames -- one per registered event.
+
+    NOT run through ``_selector_label``: there's no runtime selector (the
+    active frame is chosen by whichever event fires), so ``EventFrame.
+    event_label`` already IS the faithful display text (LabVIEW's own
+    bracketed ``[N] EventName`` rendering for the frame it last displayed,
+    an honest ``"[N]"`` placeholder for every other frame -- see
+    parser/nodes/event.py). Same reasoning as ``_build_disabled_scope``.
+    """
+    passthrough = _has_output_tunnel(op)
+    frames = [
+        NetlistFrame(
+            label=frame.event_label,
+            value=frame.event_label,
+            is_default=False,
+            body=_build_items(
+                graph, ctx, frame.operations, root_ops, build_ctx,
+            ),
+            passthrough=passthrough,
+        )
+        for frame in op.frames
+    ]
+    return NetlistScope(
+        uid=_uid_of(op.id), kind="event", selector=None, frames=frames,
+    )
+
+
 def _build_sequence_scope(
     graph: InMemoryVIGraph,
     ctx: VIContext,
@@ -636,7 +678,7 @@ def _build_loop_scope(
 
 _STRUCTURE_OPERATION_TYPES = (
     CaseOperation, LoopOperation, SequenceOperation,
-    DisableStructureOperation, InPlaceOperation,
+    DisableStructureOperation, InPlaceOperation, EventOperation,
 )
 
 
@@ -1012,6 +1054,13 @@ def _render_scope(
     elif scope.kind == "sequence":
         for frame in scope.frames:
             lines.append(f"{prefix}  frame {frame.label}:")
+            _render_frame_body(frame, indent + 2, lines, ambiguous)
+    elif scope.kind == "event":
+        # frame.label is already LabVIEW's own faithful bracketed rendering
+        # (or an honest "[N]" placeholder) -- no extra quoting/prefix needed,
+        # unlike a case's plain selector-value label.
+        for frame in scope.frames:
+            lines.append(f"{prefix}  {frame.label}:")
             _render_frame_body(frame, indent + 2, lines, ambiguous)
     else:  # "for" / "while"
         _render_frame_body(scope.frames[0], indent + 1, lines, ambiguous)

--- a/src/lvkit/graph/op_walk.py
+++ b/src/lvkit/graph/op_walk.py
@@ -20,6 +20,7 @@ from ..models import (
     CaseOperation,
     ClusterField,
     DisableStructureOperation,
+    EventOperation,
     LVType,
     Operation,
     SelectorRange,
@@ -51,7 +52,9 @@ def _find_op_owning_terminal(
         if hit:
             return hit
         if isinstance(
-            op, (CaseOperation, SequenceOperation, DisableStructureOperation),
+            op,
+            (CaseOperation, SequenceOperation, DisableStructureOperation,
+             EventOperation),
         ):
             for frame in op.frames:
                 hit = _find_op_owning_terminal(frame.operations, terminal_id)

--- a/src/lvkit/graph/operations.py
+++ b/src/lvkit/graph/operations.py
@@ -15,6 +15,8 @@ from ..models import (
     CaseFrame,
     CaseOperation,
     DisableStructureOperation,
+    EventFrame,
+    EventOperation,
     FormulaOperation,
     FPTerminal,
     InPlaceOperation,
@@ -40,6 +42,7 @@ from .core import (
 from .models import (
     CaseStructureNode,
     DisableStructureNode,
+    EventStructureNode,
     InPlaceNode,
     LoopNode,
     PolyInfo,
@@ -98,6 +101,7 @@ class OperationsMixin:
         stop_cond_inverted = False
         case_frames: list[CaseFrame] = []
         seq_frames: list[SequenceFrame] = []
+        event_frames: list[EventFrame] = []
         selector_terminal: str | None = None
         decompose: list[PrimitiveOperation] = []
         recompose: list[PrimitiveOperation] = []
@@ -143,6 +147,12 @@ class OperationsMixin:
                 all_inner = self._build_inner_nodes(child_uids, vi_name)
                 decompose, recompose, inner_nodes = _classify_ipes_ops(all_inner)
 
+            elif isinstance(gnode, EventStructureNode):
+                labels = ["EventStructure"]
+                event_frames = self._populate_frame_operations(  # type: ignore[assignment]
+                    gnode.frames, vi_name, child_uids,
+                )
+
         # Name fallback for unnamed structures
         node_name = gnode.name
         if not node_name and node_type:
@@ -183,6 +193,11 @@ class OperationsMixin:
             return SequenceOperation(
                 **common,
                 frames=seq_frames,
+            )
+        if isinstance(gnode, EventStructureNode):
+            return EventOperation(
+                **common,
+                frames=event_frames,
             )
         if isinstance(gnode, LoopNode):
             return LoopOperation(
@@ -456,26 +471,33 @@ class OperationsMixin:
 
     def _populate_frame_operations(
         self,
-        frames: list[CaseFrame] | list[SequenceFrame],
+        frames: list[CaseFrame] | list[SequenceFrame] | list[EventFrame],
         vi_name: str,
         child_uids: list[str],
-    ) -> list[CaseFrame] | list[SequenceFrame]:
+    ) -> list[CaseFrame] | list[SequenceFrame] | list[EventFrame]:
         """Populate operations on existing frames from graph children."""
         frame_to_uids = self._group_children_by_frame(child_uids)
 
-        for frame in frames:
-            # Match by selector_value (cases) or index (sequences)
+        for list_position, frame in enumerate(frames):
+            # Match by selector_value (cases), index (sequences), or list
+            # POSITION (events -- there's no runtime selector_value/index of
+            # its own; construction.py stamps children with str(idx) in the
+            # same diagram order the parser built es.frames in).
             if isinstance(frame, CaseFrame):
                 key = frame.selector_value
             elif isinstance(frame, SequenceFrame):
                 key = str(frame.index)
+            elif isinstance(frame, EventFrame):
+                key = str(list_position)
             else:
                 continue
             uids = frame_to_uids.get(key, [])
             frame.inner_node_uids = uids
             frame.operations = self._build_inner_nodes(uids, vi_name)
 
-        return cast("list[CaseFrame] | list[SequenceFrame]", frames)
+        return cast(
+            "list[CaseFrame] | list[SequenceFrame] | list[EventFrame]", frames,
+        )
 
     def _group_children_by_frame(
         self, child_uids: list[str],

--- a/src/lvkit/models.py
+++ b/src/lvkit/models.py
@@ -198,6 +198,18 @@ class FPTerminal(Terminal):
     control_type: str | None = None
     default_value: ScalarValue = None
     enum_values: list[str] = []
+    # Structure containment for a SPECIFIC on-diagram GLYPH of this control —
+    # set only when the heap places this terminal inside a case/event/disable
+    # frame or a stacked-sequence frame via an sRN's termList (a control used
+    # as e.g. an Event Structure's registered event-source terminal — see
+    # graph/construction.py's frame-attribution pass). None (the common case)
+    # means no such frame-scoped placement was found — either the control is
+    # genuinely VI-global, or it was never referenced via an sRN. FPTerminal
+    # itself isn't a GraphNode (one FPTerminal is shared VI-wide, not one per
+    # placement), so this can't just inherit GraphNode.parent/frame — it
+    # mirrors that shape instead (see render/scene.py's frame-path lookup).
+    parent: str | None = None
+    frame: str | int | None = None
 
 
 class TunnelTerminal(Terminal):

--- a/src/lvkit/models.py
+++ b/src/lvkit/models.py
@@ -321,8 +321,11 @@ class EventFrame(Frame):
     table like a case's dataspace ``SelectorTable``. That ONE frame's label
     is the faithful, LabVIEW-rendered text (e.g. ``[3] "Control": Value
     Change`` or ``[0] Timeout``, brackets included — LabVIEW's own
-    convention); every other frame falls back to an honest ``"[N]"``
-    placeholder rather than a guessed event name (see parser/nodes/event.py).
+    convention). Every OTHER frame's label is RECONSTRUCTED from its
+    ``EventSpec`` heap entry (source control caption + event-type name, when
+    both are resolvable) in the same bracketed format; an unresolvable
+    control or an unconfirmed event-type code degrades gracefully rather
+    than fabricating a name (see parser/nodes/event.py).
     """
 
     event_label: str = ""

--- a/src/lvkit/models.py
+++ b/src/lvkit/models.py
@@ -297,6 +297,25 @@ class SequenceFrame(Frame):
     index: int = 0
 
 
+class EventFrame(Frame):
+    """A frame in an Event Structure — handles ONE registered event.
+
+    Unlike a case frame, the active frame is chosen at RUNTIME by whichever
+    event actually fires — there is no fixed selector wire/value, so this
+    carries a display ``event_label`` instead of ``selector_value``.
+
+    LabVIEW stores a per-frame label only for the frame it last displayed in
+    the editor (heap ``selString``/``dIdx``) — there is no per-frame label
+    table like a case's dataspace ``SelectorTable``. That ONE frame's label
+    is the faithful, LabVIEW-rendered text (e.g. ``[3] "Control": Value
+    Change`` or ``[0] Timeout``, brackets included — LabVIEW's own
+    convention); every other frame falls back to an honest ``"[N]"``
+    placeholder rather than a guessed event name (see parser/nodes/event.py).
+    """
+
+    event_label: str = ""
+
+
 # ============================================================
 # Codegen types (Pydantic) — consumed by code generation
 # Converted from graph nodes by lvkit.graph (InMemoryVIGraph.get_operations())
@@ -377,6 +396,21 @@ class SequenceOperation(Operation):
     """Flat or stacked sequence."""
 
     frames: list[SequenceFrame] = []
+
+
+class EventOperation(Operation):
+    """Event Structure with one frame per registered event.
+
+    Frame-bearing like a case (one subdiagram per frame), but the active
+    frame is chosen at RUNTIME by whichever event fires -- there is no
+    selector wire, unlike CaseOperation. Codegen has no dedicated generator
+    for it yet (falls through to the existing "unknown node type" comment
+    fallback, same as DisableStructureOperation) -- this slice only wires it
+    through describe/diff/netlist/render so its content stays visible
+    rather than silently dropped.
+    """
+
+    frames: list[EventFrame] = []
 
 
 class DisableStructureOperation(Operation):

--- a/src/lvkit/parser/constants.py
+++ b/src/lvkit/parser/constants.py
@@ -19,6 +19,14 @@ NODE_CLASS_CASE_STRUCT = "caseStruct"
 NODE_CLASS_SEQ = "seq"
 NODE_CLASS_SEQUENCE = "sequence"  # Older LV versions use "sequence" instead of "seq"
 NODE_CLASS_EVENT_STRUCT = "eventStruct"
+# An Event Structure frame's data/filter node (inner-left "Event Data Node" /
+# inner-right "Event Filter Node" — same heap class for both, see
+# parser/nodes/event.py). Structurally identical to nMux (dcoAgg + named
+# dcoList fields) — registered as an operation node (not a tunnel) so it
+# parses via _EventDataNodeHandler instead of falling into the generic
+# unknown-node capture (which drew it as an oversized, mis-positioned box —
+# task #75).
+NODE_CLASS_EVENT_DATA_NODE = "eventDataNode"
 NODE_CLASS_PROP_NODE = "propNode"
 NODE_CLASS_INVOKE_NODE = "invokeNode"
 NODE_CLASS_CPD_ARITH = "cpdArith"  # Compound arithmetic (e.g., Or of multiple booleans)
@@ -92,6 +100,7 @@ OPERATION_NODE_CLASSES = (
     NODE_CLASS_CALL_PARENT,
     NODE_CLASS_CALL_BY_REF,
     NODE_CLASS_DECOMPOSE_RECOMPOSE,
+    NODE_CLASS_EVENT_DATA_NODE,
     # Inner decompose/recompose node types (inside IPES structures)
     "decomposeClusterNode",
     "decomposeArrayNode",

--- a/src/lvkit/parser/models.py
+++ b/src/lvkit/parser/models.py
@@ -261,6 +261,12 @@ class ParsedEventStructure:
     # came from the heap's own precomputed ``selString`` text — the
     # faithful initial view. None if ``dIdx`` was out of range.
     displayed_frame: int | None = None
+    # uids of frames' Event FILTER Node (heap class ``eventDataNode``, same as
+    # the Event Data Node — see module docstring), from the eventStruct's own
+    # ``filterNodeList``. The renderer uses this to tell a frame's Filter Node
+    # apart from its Data Node (same heap class, only this list says which is
+    # which) so it draws the Filter Node's accent band on the opposite edge.
+    filter_node_uids: frozenset[str] = field(default_factory=frozenset)
 
 
 @dataclass

--- a/src/lvkit/parser/models.py
+++ b/src/lvkit/parser/models.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from ..models import ClusterField, LVType, Tunnel
+from ..models import ClusterField, EventFrame, LVType, Tunnel
 
 if TYPE_CHECKING:
     from .layout import Layout
@@ -245,6 +245,25 @@ class ParsedFlatSequenceStructure:
 
 
 @dataclass
+class ParsedEventStructure:
+    """An Event Structure on the block diagram.
+
+    Structurally close to a case structure — one frame ("diag") per
+    registered event, border tunnels threading data through every frame —
+    but the active frame is chosen at runtime by whichever event fires, not
+    a selector wire. See parser/nodes/event.py.
+    """
+
+    uid: str
+    frames: list[EventFrame] = field(default_factory=list)
+    tunnels: list[Tunnel] = field(default_factory=list)
+    # Frame LabVIEW last displayed (heap ``dIdx``), whose ``event_label``
+    # came from the heap's own precomputed ``selString`` text — the
+    # faithful initial view. None if ``dIdx`` was out of range.
+    displayed_frame: int | None = None
+
+
+@dataclass
 class ParsedConnectorPaneSlot:
     """A slot on the connector pane."""
     index: int  # Slot position (0-based)
@@ -446,6 +465,7 @@ class ParsedBlockDiagram:
         default_factory=list,
     )
     disable_structures: list[ParsedDisableStructure] = field(default_factory=list)
+    event_structures: list[ParsedEventStructure] = field(default_factory=list)
     # Maps sRN UID → containing structure UID (for scoped terminal collection)
     srn_to_structure: dict[str, str] = field(default_factory=dict)
 
@@ -493,6 +513,13 @@ class ParsedBlockDiagram:
         # Also check IPES tunnels
         for ds in self.decompose_structures:
             for tunnel in ds.tunnels:
+                if tunnel.outer_terminal_uid == terminal_uid:
+                    return tunnel
+                if tunnel.inner_terminal_uid == terminal_uid:
+                    return tunnel
+        # Also check event structure tunnels
+        for es in self.event_structures:
+            for tunnel in es.tunnels:
                 if tunnel.outer_terminal_uid == terminal_uid:
                     return tunnel
                 if tunnel.inner_terminal_uid == terminal_uid:

--- a/src/lvkit/parser/node_types.py
+++ b/src/lvkit/parser/node_types.py
@@ -787,6 +787,27 @@ class _DemuxHandler(NMuxHandler):
     display_name = "Unbundle"
 
 
+class _EventDataNodeHandler(NMuxHandler):
+    """Handles class="eventDataNode" — an Event Structure's data/filter node.
+
+    A frame's Event Data Node (event-data fields, inner-left edge) AND its
+    Event Filter Node (filterable fields, inner-right edge) share this SAME
+    heap class — pylabview/LabVIEW distinguish them only by which per-frame
+    list references the uid (``dataNodeList`` vs ``filterNodeList`` on the
+    owning ``eventStruct``, see parser/nodes/event.py), not by a separate XML
+    class. Structurally IDENTICAL to ``nMux`` (``dcoAgg`` aggregate + named
+    ``dcoList``/``<i>`` fields via ``nmxDCO`` terminal DCOs) — the parser
+    reuses NMuxHandler's parsing wholesale so field NAMES resolve through the
+    exact same VCTP cluster-field pipeline as a real Bundle/Unbundle By Name,
+    and the render layer draws it with the same small named-rows glyph
+    (see render/nodes.py's ``_CLUSTER_MUX_TYPES``) instead of the old
+    generic-fallback giant box.
+    """
+
+    xml_class = "eventDataNode"
+    display_name = "Event Data Node"
+
+
 class CtlRefConstHandler(NodeTypeHandler):
     """Handler for Control Reference Constant (class="ctlRefConst")."""
 
@@ -1021,6 +1042,7 @@ _HANDLERS: list[NodeTypeHandler] = [
     NMuxHandler(),
     _MuxHandler(),
     _DemuxHandler(),
+    _EventDataNodeHandler(),
     CtlRefConstHandler(),
     GRefHandler(),
     StatVIRefHandler(),

--- a/src/lvkit/parser/node_types.py
+++ b/src/lvkit/parser/node_types.py
@@ -798,10 +798,12 @@ class _EventDataNodeHandler(NMuxHandler):
     class. Structurally IDENTICAL to ``nMux`` (``dcoAgg`` aggregate + named
     ``dcoList``/``<i>`` fields via ``nmxDCO`` terminal DCOs) — the parser
     reuses NMuxHandler's parsing wholesale so field NAMES resolve through the
-    exact same VCTP cluster-field pipeline as a real Bundle/Unbundle By Name,
-    and the render layer draws it with the same small named-rows glyph
-    (see render/nodes.py's ``_CLUSTER_MUX_TYPES``) instead of the old
-    generic-fallback giant box.
+    exact same VCTP cluster-field pipeline as a real Bundle/Unbundle By Name.
+    The render layer draws it with its OWN bespoke named-rows glyph though
+    (``render.glyph.EventDataGlyph``, resolved in ``render/nodes.py``'s
+    ``_CLUSTER_MUX_TYPES`` handling) — a white box with type-colored field
+    names and a side accent band — never the tan Bundle/Unbundle-By-Name look
+    (this isn't a real cluster assemble/disassemble).
     """
 
     xml_class = "eventDataNode"

--- a/src/lvkit/parser/nodes/__init__.py
+++ b/src/lvkit/parser/nodes/__init__.py
@@ -5,6 +5,7 @@ from .case import extract_case_structures, parse_selector_tables
 from .constant import extract_constants
 from .decompose import extract_decompose_structures
 from .disable import extract_disable_structures, is_disable_structure
+from .event import extract_event_structures
 from .loop import extract_loops
 from .sequence import extract_flat_sequences
 
@@ -13,6 +14,7 @@ __all__ = [
     "extract_constants",
     "extract_decompose_structures",
     "extract_disable_structures",
+    "extract_event_structures",
     "extract_flat_sequences",
     "extract_label",
     "extract_loops",

--- a/src/lvkit/parser/nodes/event.py
+++ b/src/lvkit/parser/nodes/event.py
@@ -117,6 +117,7 @@ def _extract_one_event_structure(
         frames=frames,
         tunnels=tunnels,
         displayed_frame=displayed,
+        filter_node_uids=frozenset(u for u in filter_node_uids if u),
     )
 
 

--- a/src/lvkit/parser/nodes/event.py
+++ b/src/lvkit/parser/nodes/event.py
@@ -1,0 +1,205 @@
+"""Event structure parsing.
+
+An Event Structure (heap ``class="eventStruct"``) is structurally close to a
+case structure: one frame ("diag") per registered event, a selector-style
+navigator at the top (``[N] EventName``), and border tunnels threading data
+through every frame. This module mirrors ``case.py``'s frame/tunnel
+extraction shape.
+
+Frame labels: LabVIEW stores a real label for only ONE frame — the one it
+last displayed in the editor (heap ``selString``/``textRec``/``text``, keyed
+by the heap's own ``dIdx``). Unlike a case structure there is no per-frame
+label table in the dataspace (no ``EventSpec``-to-name correlation is
+recoverable without an undocumented internal LabVIEW event-type-ID scheme —
+see the module docstring investigation in task #75). Every OTHER frame gets
+an honest ``"[N]"`` placeholder, matching the fallback ``case.py``/
+``disable.py`` already use when a frame's real label isn't recoverable.
+LabVIEW's own convention BAKES the bracketed index into the label text
+itself (``" [3] "copyrights": Value Change "``), so the displayed frame's
+faithful label and every other frame's placeholder share the same visual
+shape.
+
+Border tunnels: FOUR dco classes carry data across the structure boundary,
+ALL using the identical per-frame-array shape as a case's ``selTun``
+(``[frame0_inner, frame1_inner, ..., outer_self]`` — see
+``base.py::extract_tunnel_mapping``, which self-selects on element count and
+already handles this shape generically):
+
+- ``eventTimeOut`` — the timeout-value input (top-left ⏱).
+- ``eventDynDCO`` (appears twice, an ``otherSide``-linked pair) — the
+  dynamic-event registration refnum passing through top+bottom (green
+  terminals in LabVIEW).
+- ``selTun`` — an ordinary output tunnel (e.g. a loop's "stop" boolean
+  threaded out through every frame).
+
+The Event Data Node / Event Filter Node (heap class ``eventDataNode`` for
+BOTH — distinguished only by which per-frame list references the uid,
+``dataNodeList``/``filterNodeList`` on the ``eventStruct`` element, not by a
+separate XML class) are NOT tunnels — they're ordinary Bundle/Unbundle-By-
+Name-shaped nodes (``nmxDCO`` field terminals, ``dcoAgg``/``dcoList``)
+sitting in the frame's own diagram, parsed by ``_EventDataNodeHandler``
+(node_types.py, a thin ``NMuxHandler`` subclass). This module only needs to
+fold their uids into the frame's ``inner_node_uids`` so the graph layer
+parents/frame-stamps them like any other frame-owned node — see
+``_frame_extra_node_uids``.
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+from lvkit.models import EventFrame, Tunnel
+
+from ..models import ParsedEventStructure
+from ..utils import clean_labview_string
+from .base import extract_tunnel_mapping, frame_inner_node_uids
+
+# dco classes on an eventStruct's OWN termList that carry data across the
+# structure boundary. All four share the SAME per-frame-array shape as a
+# case's selTun (see extract_tunnel_mapping) — no per-class branching needed.
+EVENT_TUNNEL_DCO_CLASSES = ("selTun", "eventDynDCO", "eventTimeOut")
+
+# The heap class an eventStruct frame's data/filter node uses — shared by
+# BOTH the Event Data Node and the Event Filter Node (see module docstring).
+_EVENT_DATA_NODE_CLASS = "eventDataNode"
+
+
+def extract_event_structures(root: ET.Element) -> list[ParsedEventStructure]:
+    """Extract Event Structures with frame mappings.
+
+    Args:
+        root: Block-diagram XML root element.
+
+    Returns:
+        List of ParsedEventStructure, one per ``class="eventStruct"`` element.
+    """
+    structures: list[ParsedEventStructure] = []
+    for elem in root.findall(".//*[@class='eventStruct']"):
+        uid = elem.get("uid")
+        if not uid:
+            continue
+        es = _extract_one_event_structure(elem, uid)
+        if es:
+            structures.append(es)
+    return structures
+
+
+def _extract_one_event_structure(
+    elem: ET.Element, uid: str,
+) -> ParsedEventStructure | None:
+    diag_list = elem.find("diagramList")
+    diag_elems = (
+        diag_list.findall("SL__arrayElement[@class='diag']")
+        if diag_list is not None else []
+    )
+    if not diag_elems:
+        return None
+    num_frames = len(diag_elems)
+
+    tunnels = _extract_event_tunnels(elem)
+    labels, displayed = _resolve_frame_labels(elem, num_frames)
+    data_node_uids = _list_uids(elem.find("dataNodeList"))
+    filter_node_uids = _list_uids(elem.find("filterNodeList"))
+
+    frames: list[EventFrame] = []
+    for idx, diag_elem in enumerate(diag_elems):
+        inner_node_uids = frame_inner_node_uids(diag_elem)
+        inner_node_uids += _frame_extra_node_uids(
+            inner_node_uids, data_node_uids, filter_node_uids, idx,
+        )
+        frames.append(EventFrame(
+            event_label=labels[idx],
+            inner_node_uids=inner_node_uids,
+        ))
+
+    return ParsedEventStructure(
+        uid=uid,
+        frames=frames,
+        tunnels=tunnels,
+        displayed_frame=displayed,
+    )
+
+
+def _extract_event_tunnels(elem: ET.Element) -> list[Tunnel]:
+    """Extract the structure's own boundary tunnels from its ``termList``.
+
+    Same per-frame-array shape as a case structure's ``selTun`` for every
+    dco class involved (see ``EVENT_TUNNEL_DCO_CLASSES``); reuses the shared
+    generic extractor rather than reimplementing it (unlike disable.py,
+    there's no cross-module import cycle here to avoid).
+    """
+    tunnels: list[Tunnel] = []
+    term_list_elem = elem.find("termList")
+    if term_list_elem is None:
+        return tunnels
+    for term_elem in term_list_elem.findall("SL__arrayElement[@class='term']"):
+        dco = term_elem.find("dco")
+        if dco is None:
+            continue
+        dco_class = dco.get("class", "")
+        if dco_class not in EVENT_TUNNEL_DCO_CLASSES:
+            continue
+        tunnels.extend(extract_tunnel_mapping(dco, dco_class))
+    return tunnels
+
+
+def _list_uids(list_elem: ET.Element | None) -> list[str | None]:
+    """Per-frame uid list from ``dataNodeList``/``filterNodeList`` — index i
+    is frame i's data/filter node uid, or ``None`` when the heap's own
+    ``uid="0"`` marks "no node for this frame" (a frame with no event-data
+    fields wired, or that doesn't use the Filter Node at all)."""
+    if list_elem is None:
+        return []
+    uids: list[str | None] = []
+    for e in list_elem.findall("SL__arrayElement"):
+        u = e.get("uid")
+        uids.append(u if u and u != "0" else None)
+    return uids
+
+
+def _frame_extra_node_uids(
+    existing: list[str],
+    data_node_uids: list[str | None],
+    filter_node_uids: list[str | None],
+    idx: int,
+) -> list[str]:
+    """The frame's own Event Data Node / Event Filter Node uid(s), if any and
+    not already picked up by ``frame_inner_node_uids`` (they never are —
+    ``eventDataNode`` isn't a STRUCTURE_NODE_CLASSES member, so the shared
+    zPlaneList structure-scan skips it; listed here explicitly instead, keyed
+    by the authoritative per-frame ``dataNodeList``/``filterNodeList`` heap
+    arrays rather than a generic zPlaneList walk)."""
+    extra: list[str] = []
+    for uids in (data_node_uids, filter_node_uids):
+        if idx < len(uids) and uids[idx] and uids[idx] not in existing:
+            extra.append(uids[idx])  # type: ignore[arg-type]
+    return extra
+
+
+def _resolve_frame_labels(
+    elem: ET.Element, num_frames: int,
+) -> tuple[list[str], int | None]:
+    """Per-frame display labels, faithful for exactly one frame (see module
+    docstring): every frame defaults to ``"[N]"``; the frame LabVIEW last
+    displayed (heap ``dIdx``, omitted when 0 — the same "XML omits a 0
+    field" convention as ``parmIndex``/``paramIdx`` elsewhere in this parser)
+    gets its own precomputed ``selString`` text instead, verbatim (LabVIEW's
+    own rendering already includes the bracketed index, e.g. ``[3]
+    "copyrights": Value Change`` or ``[0] Timeout`` — confirmed against two
+    independent VIs).
+    """
+    labels = [f"[{i}]" for i in range(num_frames)]
+    d_idx_text = elem.findtext("dIdx")
+    displayed = (
+        int(d_idx_text) if d_idx_text and d_idx_text.lstrip("-").isdigit() else 0
+    )
+    if not (0 <= displayed < num_frames):
+        return labels, None
+    sel = elem.find("selString")
+    if sel is not None:
+        text_elem = sel.find("textRec/text")
+        if text_elem is not None and text_elem.text:
+            label = clean_labview_string(text_elem.text).strip()
+            if label:
+                labels[displayed] = label
+    return labels, displayed

--- a/src/lvkit/parser/nodes/event.py
+++ b/src/lvkit/parser/nodes/event.py
@@ -6,18 +6,22 @@ navigator at the top (``[N] EventName``), and border tunnels threading data
 through every frame. This module mirrors ``case.py``'s frame/tunnel
 extraction shape.
 
-Frame labels: LabVIEW stores a real label for only ONE frame — the one it
-last displayed in the editor (heap ``selString``/``textRec``/``text``, keyed
-by the heap's own ``dIdx``). Unlike a case structure there is no per-frame
-label table in the dataspace (no ``EventSpec``-to-name correlation is
-recoverable without an undocumented internal LabVIEW event-type-ID scheme —
-see the module docstring investigation in task #75). Every OTHER frame gets
-an honest ``"[N]"`` placeholder, matching the fallback ``case.py``/
-``disable.py`` already use when a frame's real label isn't recoverable.
-LabVIEW's own convention BAKES the bracketed index into the label text
-itself (``" [3] "copyrights": Value Change "``), so the displayed frame's
-faithful label and every other frame's placeholder share the same visual
-shape.
+Frame labels: LabVIEW stores a real, faithful label for only ONE frame — the
+one it last displayed in the editor (heap ``selString``/``textRec``/``text``,
+keyed by the heap's own ``dIdx``). Every OTHER frame's label is RECONSTRUCTED
+(task #75 follow-up) from that frame's ``EventSpec`` entry
+(``EventNodeEvents/SL__arrayElement[@class='EventSpec']``, keyed by
+``diagramIdx``): ``ddoUID`` names the source control — resolved to its
+caption via the FRONT-PANEL heap (``ddo[@uid=...]``, same
+``extract_label``-on-a-``ddo`` lookup ``vi.py`` already uses for front-panel
+control names) — and ``type`` is the event-type code, matched against
+``_CONFIRMED_EVENT_TYPES`` (a short, clean-room-verified table; an
+unconfirmed code is never guessed at, see ``_format_event_label``). LabVIEW's
+own convention BAKES the bracketed index into the label text itself
+(``" [3] "copyrights": Value Change "``), so the displayed frame's faithful
+label and every reconstructed label share the same visual shape — the
+displayed frame's own heap text is left untouched and used as a
+cross-check (see ``_resolve_frame_labels``).
 
 Border tunnels: FOUR dco classes carry data across the structure boundary,
 ALL using the identical per-frame-array shape as a case's ``selTun``
@@ -47,11 +51,13 @@ parents/frame-stamps them like any other frame-owned node — see
 from __future__ import annotations
 
 import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
 
 from lvkit.models import EventFrame, Tunnel
 
 from ..models import ParsedEventStructure
-from ..utils import clean_labview_string
+from ..utils import clean_labview_string, extract_label
 from .base import extract_tunnel_mapping, frame_inner_node_uids
 
 # dco classes on an eventStruct's OWN termList that carry data across the
@@ -63,29 +69,69 @@ EVENT_TUNNEL_DCO_CLASSES = ("selTun", "eventDynDCO", "eventTimeOut")
 # BOTH the Event Data Node and the Event Filter Node (see module docstring).
 _EVENT_DATA_NODE_CLASS = "eventDataNode"
 
+# EventSpec.type codes confirmed clean-room by cross-checking the
+# reconstructed label against the displayed frame's own faithful heap text
+# (VI Tester About.vi — see module docstring). Add an entry here ONLY once
+# confirmed the same way; an unconfirmed/unmapped code is never guessed at —
+# ``_format_event_label`` just omits the event-type name for it.
+_CONFIRMED_EVENT_TYPES: dict[int, str] = {
+    1073741826: "Value Change",
+    1073741825: "Timeout",
+}
 
-def extract_event_structures(root: ET.Element) -> list[ParsedEventStructure]:
+
+@dataclass(frozen=True)
+class _EventSpec:
+    """One frame's ``EventSpec`` entry: the source control's DDO uid (``None``
+    when ``ddoUID`` is ``0`` — a pane/app/filter event with no control) and
+    the raw event-type code (``None`` if unparseable)."""
+
+    ddo_uid: str | None
+    type_code: int | None
+
+
+def extract_event_structures(
+    root: ET.Element,
+    fp_xml_path: Path | str | None = None,
+) -> list[ParsedEventStructure]:
     """Extract Event Structures with frame mappings.
 
     Args:
         root: Block-diagram XML root element.
+        fp_xml_path: Path to the VI's ``*_FPHb.xml`` (front-panel heap),
+            needed to resolve an ``EventSpec.ddoUID`` to its control's
+            caption when reconstructing non-displayed frames' labels. Frame
+            labels degrade to the bare ``"[N]"``/event-type-only form when
+            omitted (e.g. no front panel available).
 
     Returns:
         List of ParsedEventStructure, one per ``class="eventStruct"`` element.
     """
+    fp_root = _parse_fp_root(fp_xml_path)
     structures: list[ParsedEventStructure] = []
     for elem in root.findall(".//*[@class='eventStruct']"):
         uid = elem.get("uid")
         if not uid:
             continue
-        es = _extract_one_event_structure(elem, uid)
+        es = _extract_one_event_structure(elem, uid, fp_root)
         if es:
             structures.append(es)
     return structures
 
 
+def _parse_fp_root(fp_xml_path: Path | str | None) -> ET.Element | None:
+    """Parse the front-panel heap, or None if unavailable — the caption
+    lookup then degrades gracefully rather than crashing."""
+    if fp_xml_path is None:
+        return None
+    path = Path(fp_xml_path)
+    if not path.exists():
+        return None
+    return ET.parse(path).getroot()
+
+
 def _extract_one_event_structure(
-    elem: ET.Element, uid: str,
+    elem: ET.Element, uid: str, fp_root: ET.Element | None,
 ) -> ParsedEventStructure | None:
     diag_list = elem.find("diagramList")
     diag_elems = (
@@ -97,7 +143,8 @@ def _extract_one_event_structure(
     num_frames = len(diag_elems)
 
     tunnels = _extract_event_tunnels(elem)
-    labels, displayed = _resolve_frame_labels(elem, num_frames)
+    event_specs = _extract_event_specs(elem)
+    labels, displayed = _resolve_frame_labels(elem, num_frames, event_specs, fp_root)
     data_node_uids = _list_uids(elem.find("dataNodeList"))
     filter_node_uids = _list_uids(elem.find("filterNodeList"))
 
@@ -177,19 +224,100 @@ def _frame_extra_node_uids(
     return extra
 
 
+def _extract_event_specs(elem: ET.Element) -> dict[int, _EventSpec]:
+    """Per-frame ``EventSpec`` info, keyed by ``diagramIdx`` — the ONLY heap
+    source correlating a frame to its source control and event-type code
+    (see module docstring). ``EventNodeEvents`` is the eventStruct's own
+    array of ``EventSpec`` elements; absent (or malformed) entries are simply
+    skipped, leaving that frame's reconstruction to degrade to ``"[N]"``.
+    """
+    specs: dict[int, _EventSpec] = {}
+    events_list = elem.find("EventNodeEvents")
+    if events_list is None:
+        return specs
+    for spec_elem in events_list.findall("SL__arrayElement[@class='EventSpec']"):
+        idx_text = spec_elem.findtext("diagramIdx")
+        if idx_text is None or not idx_text.lstrip("-").isdigit():
+            continue
+        ddo_uid = spec_elem.findtext("ddoUID")
+        type_text = spec_elem.findtext("type")
+        specs[int(idx_text)] = _EventSpec(
+            ddo_uid=ddo_uid if ddo_uid and ddo_uid != "0" else None,
+            type_code=(
+                int(type_text)
+                if type_text and type_text.lstrip("-").isdigit()
+                else None
+            ),
+        )
+    return specs
+
+
+def _resolve_control_caption(
+    fp_root: ET.Element | None, ddo_uid: str,
+) -> str | None:
+    """The source control's caption, read from the FRONT-PANEL heap's own
+    ``ddo`` element (keyed by ``EventSpec.ddoUID``) — the same
+    ``extract_label``-on-a-``ddo`` lookup ``vi.py``'s ``_parse_ddo`` already
+    uses for front-panel control names. None if the FP heap is unavailable,
+    the uid isn't found, or the ddo carries no label text (clean-room:
+    degrade rather than guess)."""
+    if fp_root is None:
+        return None
+    ddo = fp_root.find(f".//ddo[@uid='{ddo_uid}']")
+    if ddo is None:
+        return None
+    return extract_label(ddo)
+
+
+def _format_event_label(
+    idx: int, spec: _EventSpec | None, fp_root: ET.Element | None,
+) -> str:
+    """Reconstruct frame ``idx``'s display label from its ``EventSpec``,
+    matching LabVIEW's own displayed-frame format
+    (``[N] "<Control>": <EventType>``) exactly. Degrades gracefully — a
+    control that can't be resolved or a ``type`` code not yet clean-room
+    confirmed (``_CONFIRMED_EVENT_TYPES``) is simply omitted, never
+    fabricated (see module docstring)."""
+    base = f"[{idx}]"
+    if spec is None:
+        return base
+    caption = (
+        _resolve_control_caption(fp_root, spec.ddo_uid) if spec.ddo_uid else None
+    )
+    type_name = (
+        _CONFIRMED_EVENT_TYPES.get(spec.type_code)
+        if spec.type_code is not None
+        else None
+    )
+    if caption and type_name:
+        return f'{base} "{caption}": {type_name}'
+    if caption:
+        return f'{base} "{caption}"'
+    if type_name:
+        return f"{base} {type_name}"
+    return base
+
+
 def _resolve_frame_labels(
-    elem: ET.Element, num_frames: int,
+    elem: ET.Element,
+    num_frames: int,
+    event_specs: dict[int, _EventSpec],
+    fp_root: ET.Element | None,
 ) -> tuple[list[str], int | None]:
-    """Per-frame display labels, faithful for exactly one frame (see module
-    docstring): every frame defaults to ``"[N]"``; the frame LabVIEW last
+    """Per-frame display labels: every frame is RECONSTRUCTED from its
+    ``EventSpec`` (see ``_format_event_label``); the frame LabVIEW last
     displayed (heap ``dIdx``, omitted when 0 — the same "XML omits a 0
     field" convention as ``parmIndex``/``paramIdx`` elsewhere in this parser)
-    gets its own precomputed ``selString`` text instead, verbatim (LabVIEW's
-    own rendering already includes the bracketed index, e.g. ``[3]
-    "copyrights": Value Change`` or ``[0] Timeout`` — confirmed against two
-    independent VIs).
+    then gets its own precomputed ``selString`` text INSTEAD, verbatim —
+    LabVIEW's own rendering already includes the bracketed index, e.g.
+    ``[3] "copyrights": Value Change`` or ``[0] Timeout`` — that faithful
+    text is the ground truth this reconstruction was verified against, and
+    it always wins over the reconstruction for its own frame.
     """
-    labels = [f"[{i}]" for i in range(num_frames)]
+    labels = [
+        _format_event_label(i, event_specs.get(i), fp_root)
+        for i in range(num_frames)
+    ]
     d_idx_text = elem.findtext("dIdx")
     displayed = (
         int(d_idx_text) if d_idx_text and d_idx_text.lstrip("-").isdigit() else 0

--- a/src/lvkit/parser/type_mapping.py
+++ b/src/lvkit/parser/type_mapping.py
@@ -162,6 +162,31 @@ def parse_type_map_rich(xml_path: Path | str) -> dict[int, LVType]:
     return type_map
 
 
+def _field_label(ref_td: ET.Element | None, default_name: str) -> str:
+    """Resolve a cluster field's display name from its own TypeDesc.
+
+    Usually the field's ``Label`` XML attribute (e.g. ``Label="Time"``). But
+    when the field's declared type is itself a bare TypeDef (no ``Label``
+    attribute of its own — a TypeDef instead carries its ``.ctl`` filename via
+    a sibling ``<Label Text="....ctl"/>`` ELEMENT, not an attribute), the real
+    field name lives one level down, on the TypeDef's ``Nested='True'`` inner
+    TypeDesc (e.g. ``eventsource.ctl``'s wrapped ``<TypeDesc ... Label="Source"
+    Nested="True"/>``). Falls back to ``default_name`` when neither is present.
+    """
+    if ref_td is None:
+        return default_name
+    label = ref_td.get("Label")
+    if label:
+        return clean_labview_string(label) or default_name
+    if ref_td.get("Type") == "TypeDef":
+        nested = ref_td.find("TypeDesc[@Nested='True']")
+        if nested is not None:
+            nested_label = nested.get("Label")
+            if nested_label:
+                return clean_labview_string(nested_label) or default_name
+    return default_name
+
+
 def _make_primitive_lvtype(type_name: str) -> LVType:
     """Create an LVType for a primitive type name."""
     # Map LabVIEW type names to kind
@@ -236,12 +261,7 @@ def parse_vctp_types(xml_path: Path | str) -> dict[int, LVType]:
                         # Get field name from the referenced type's label
                         ref_td = flat_types.get(int(nested_type_id))
                         default_name = f"field_{len(fields)}"
-                        # Use 'is not None' - Element bool is based on children count
-                        raw_label = (
-                            ref_td.get("Label", default_name)
-                            if ref_td is not None else default_name
-                        )
-                        field_name = clean_labview_string(raw_label) or default_name
+                        field_name = _field_label(ref_td, default_name)
                         fields.append(ClusterField(name=field_name, type=field_type))
 
             lv_type = LVType(
@@ -304,11 +324,7 @@ def parse_vctp_types(xml_path: Path | str) -> dict[int, LVType]:
                             ft = resolve_type(int(child_tid), visited)
                             ref = flat_types.get(int(child_tid))
                             default = f"field_{len(td_fields)}"
-                            raw = (
-                                ref.get("Label", default)
-                                if ref is not None else default
-                            )
-                            name = clean_labview_string(raw) or default
+                            name = _field_label(ref, default)
                             td_fields.append(
                                 ClusterField(name=name, type=ft),
                             )

--- a/src/lvkit/parser/vi.py
+++ b/src/lvkit/parser/vi.py
@@ -304,7 +304,7 @@ def _parse_block_diagram(
     flat_sequences = extract_flat_sequences(root)
     decompose_structures = extract_decompose_structures(root)
     disable_structures = extract_disable_structures(root)
-    event_structures = extract_event_structures(root)
+    event_structures = extract_event_structures(root, fp_xml)
 
     bd = ParsedBlockDiagram(
         nodes=nodes,

--- a/src/lvkit/parser/vi.py
+++ b/src/lvkit/parser/vi.py
@@ -20,6 +20,7 @@ from lvkit.extractor import extract_vi_xml
 from lvkit.models import LVType
 
 from .constants import (
+    FP_TERMINAL_CLASS,
     MULTI_LABEL_CLASS,
     NODE_CLASS_COMMENT,
     NODE_CLASS_CPD_ARITH,
@@ -541,10 +542,33 @@ def _process_element_terminals(
     wire_sinks: set[str],
     type_map: dict[int, LVType] | None,
     terminal_info: dict[str, ParsedTerminalInfo],
+    fp_term_parent: dict[str, str] | None = None,
 ) -> None:
-    """Extract terminals from a single TERMINAL_CONTAINER_CLASSES element."""
+    """Extract terminals from a single TERMINAL_CONTAINER_CLASSES element.
+
+    ``fp_term_parent`` (optional — record-only, doesn't affect ``term_list``
+    processing below) records the REAL containing element for any
+    ``class="fPTerm"`` child of this element's ``termList`` — e.g. an sRN
+    (shift-register/border-terminal group; ``NODE_CLASS_SHIFT_REG`` is one of
+    ``TERMINAL_CONTAINER_CLASSES``) holds an event structure's registered
+    event-source control this way. An ``fPTerm`` isn't a wireable ``"term"``
+    (it's a whole front-panel control's on-diagram GLYPH), so it's excluded
+    from ``term_list`` below and gets no ``ParsedTerminalInfo`` here — but
+    without this, ``_extract_terminal_info``'s later FP-terminal fallback has
+    no real container to attribute it to and stamps a bogus self-referential
+    ``parent_uid`` (the terminal's own uid), silently losing this control's
+    structure/frame containment for good (task: VI Tester About.vi frame-gating).
+    """
     elem_uid = elem.get("uid") or ""
     elem_class = elem.get("class", "")
+
+    if fp_term_parent is not None:
+        for fp_term in elem.findall(
+            f"./termList/SL__arrayElement[@class='{FP_TERMINAL_CLASS}']",
+        ):
+            fp_uid = fp_term.get("uid")
+            if fp_uid and elem_uid:
+                fp_term_parent.setdefault(fp_uid, elem_uid)
 
     term_list = elem.findall(
         f"./termList/SL__arrayElement[@class='{TERMINAL_CLASS}']",
@@ -694,6 +718,7 @@ def _walk_and_extract_terminals(
     terminal_info: dict[str, ParsedTerminalInfo],
     srn_to_structure: dict[str, str],
     current_structure_uid: str | None,
+    fp_term_parent: dict[str, str] | None = None,
 ) -> None:
     """Walk XML tree, extracting terminals and tracking sRN containment."""
     elem_uid = elem.get("uid")
@@ -715,6 +740,7 @@ def _walk_and_extract_terminals(
                      or _is_generic_operation_node(elem)):
         _process_element_terminals(
             elem, wire_sources, wire_sinks, type_map, terminal_info,
+            fp_term_parent,
         )
 
     # Record sRN → structure containment
@@ -732,6 +758,7 @@ def _walk_and_extract_terminals(
         _walk_and_extract_terminals(
             child, wire_sources, wire_sinks, type_map,
             terminal_info, srn_to_structure, next_structure_uid,
+            fp_term_parent,
         )
 
 
@@ -752,6 +779,12 @@ def _extract_terminal_info(
     terminal_info: dict[str, ParsedTerminalInfo] = {}
     if srn_to_structure is None:
         srn_to_structure = {}
+    # FP terminal (control-on-diagram-glyph) uid -> its REAL containing
+    # element's uid (typically an sRN — see _process_element_terminals).
+    # Used below so an FP terminal placed inside a structure frame (e.g. an
+    # Event Structure's registered event-source control) gets a real
+    # parent_uid instead of a bogus self-reference.
+    fp_term_parent: dict[str, str] = {}
 
     # Build wire connectivity maps for direction inference
     wire_sources: set[str] = {w.from_term for w in wires}
@@ -760,7 +793,7 @@ def _extract_terminal_info(
     # Walk XML hierarchically — preserves structure containment for sRN nodes
     _walk_and_extract_terminals(
         root, wire_sources, wire_sinks, type_map,
-        terminal_info, srn_to_structure, None,
+        terminal_info, srn_to_structure, None, fp_term_parent,
     )
 
     # Constants have a single output terminal
@@ -779,12 +812,16 @@ def _extract_terminal_info(
                 parsed_type=parsed_type,
             )
 
-    # Front panel terminals
+    # Front panel terminals. parent_uid is the REAL containing element
+    # (an sRN, when this control's glyph is placed inside a structure frame
+    # — see fp_term_parent above) — falling back to the terminal's own uid
+    # (the previous, self-referential behavior) only when it was never found
+    # nested in any terminal container's termList.
     for fp_term in fp_terminals:
         if fp_term.uid not in terminal_info:
             terminal_info[fp_term.uid] = ParsedTerminalInfo(
                 uid=fp_term.uid,
-                parent_uid=fp_term.uid,
+                parent_uid=fp_term_parent.get(fp_term.uid, fp_term.uid),
                 index=0,
                 is_output=not fp_term.is_indicator,
                 parsed_type=fp_term.parsed_type,

--- a/src/lvkit/parser/vi.py
+++ b/src/lvkit/parser/vi.py
@@ -57,6 +57,7 @@ from .nodes import (
     extract_constants,
     extract_decompose_structures,
     extract_disable_structures,
+    extract_event_structures,
     extract_flat_sequences,
     extract_loops,
     is_disable_structure,
@@ -302,6 +303,7 @@ def _parse_block_diagram(
     flat_sequences = extract_flat_sequences(root)
     decompose_structures = extract_decompose_structures(root)
     disable_structures = extract_disable_structures(root)
+    event_structures = extract_event_structures(root)
 
     bd = ParsedBlockDiagram(
         nodes=nodes,
@@ -315,6 +317,7 @@ def _parse_block_diagram(
         flat_sequences=flat_sequences,
         decompose_structures=decompose_structures,
         disable_structures=disable_structures,
+        event_structures=event_structures,
         srn_to_structure=srn_to_structure,
     )
     layout = (

--- a/src/lvkit/render/draw.py
+++ b/src/lvkit/render/draw.py
@@ -34,6 +34,7 @@ from .glyph import (
     ClusterConstantGlyph,
     ConstantGlyph,
     ErrorClusterGlyph,
+    EventDataGlyph,
     FormulaNodeGlyph,
     IconImageGlyph,
     InlineSvgGlyph,
@@ -219,10 +220,12 @@ def _inset(bounds, frac: float = 0.075):
 # is never wired/drawn — LabVIEW stores it as a huge negative sentinel rect
 # (e.g. ``(-531, -471, -512, -471)``), which blew the terminal-span union out
 # to hundreds of units and rendered as an oversized, mispositioned box
-# (task #75) before this exemption.
+# (task #75) before this exemption. ``EventDataGlyph`` (the Event Data/Filter
+# Node's own white named-rows glyph, replacing the tan ``BundleByNameGlyph``
+# it used to borrow) inherits the exact same exemption for the same reason.
 _OWN_ASPECT_GLYPHS = (
     IconImageGlyph, InlineSvgGlyph, CenteredSvgGlyph,
-    BundleByNameGlyph, BundleGlyph, UnbundleGlyph,
+    BundleByNameGlyph, BundleGlyph, UnbundleGlyph, EventDataGlyph,
 )
 
 # Floor for the recovered icon footprint: a unary primitive (one input, one
@@ -943,6 +946,46 @@ def _draw_border_terminal(
                      stroke=theme.loop_term, stroke_width=1.5)
         backend.text(cx, cy + 4, kind, 11, fill=theme.loop_term_text, italic=True)
         return
+    if kind == "eventTimeout":
+        # Event Structure timeout terminal: a small box (top-left, the
+        # position a For-Loop's N terminal occupies) holding a blue HOURGLASS
+        # — two triangles apex-to-apex — in the wire-integer color, matching
+        # the reference LabVIEW screenshot's blue timeout glyph. It's a real
+        # wireable INPUT (the timeout value), so it gets the same pale
+        # loop-term fill as N/i, just with its own bespoke symbol instead of
+        # falling through to a generic filled tunnel block.
+        backend.rect(x1, y1, x2, y2, fill=theme.loop_term_fill,
+                     stroke=theme.wire_int, stroke_width=1.2)
+        hw = (x2 - x1) * 0.30
+        hh = (y2 - y1) * 0.34
+        backend.polygon(
+            [(cx - hw, cy - hh), (cx + hw, cy - hh), (cx, cy)],
+            fill=theme.wire_int, stroke=None,
+        )
+        backend.polygon(
+            [(cx - hw, cy + hh), (cx + hw, cy + hh), (cx, cy)],
+            fill=theme.wire_int, stroke=None,
+        )
+        return
+    if kind == "eventDyn":
+        # Event Structure dynamic-event-registration terminal (appears as an
+        # ``otherSide``-linked pair — see parser/nodes/event.py): a small
+        # dark-green box (LabVIEW's own refnum-wire color) at its real heap
+        # position. Per the reference screenshot, BOTH terminals of the pair
+        # (left AND right edge) draw their arrow pointing RIGHT — the dynamic
+        # registration refnum threads left-to-right through the structure (in on
+        # the left, back out on the right), so the glyph follows that flow
+        # direction on both sides rather than mirroring by in/out.
+        col = theme.wire_refnum
+        backend.rect(x1, y1, x2, y2, fill=theme.loop_term_fill, stroke=col,
+                     stroke_width=1.2)
+        aw = (x2 - x1) * 0.22
+        ah = (y2 - y1) * 0.26
+        backend.polygon(
+            [(cx - aw, cy - ah), (cx - aw, cy + ah), (cx + aw, cy)],
+            fill=col, stroke=None,
+        )
+        return
     if kind == "cond":
         # LabVIEW's conditional terminal shows its mode by color: RED for
         # Stop-if-True (the default) and GREEN for Continue-if-True. The mode
@@ -1156,6 +1199,73 @@ def _error_border_color(
     )
 
 
+# Fallback Event Structure border-band width — used ONLY when a structure has
+# no interior content to measure from (an Event Structure with an empty
+# frame). Visually matched to the reference LabVIEW screenshot's hatched-
+# border margin (see ``_event_band_width``'s docstring for how the normal,
+# measured value is derived) — not a guessed generic default.
+_EVENT_BAND_FALLBACK_W = 10.0
+
+
+def _event_band_width(structure: RenderStructure, scene: Scene) -> float:
+    """The Event Structure's border-BAND thickness, MEASURED (never guessed)
+    from the gap LabVIEW's own heap layout already reserves between the
+    structure's outer heap ``bounds`` and its interior content (the Event
+    Data/Filter Node, and every other frame-owned node — ``node.parent`` is
+    this structure's own qualified id, see graph/construction.py's ``_stamp``).
+
+    Checked against real corpus VIs: the structure's own border TERMINALS
+    (``eventTimeOut``, ``eventDynDCO``, a plain passthrough tunnel) sit FLUSH
+    with the outer bounds — they're drawn ON the band, not inset from it — so
+    they measure a gap of ~0 and can't be used. Interior content, however, is
+    reliably inset by the band width on the LEFT and RIGHT edges (confirmed:
+    an Event Data Node's left gap and its paired Event Filter Node's right gap
+    agree exactly in every VI checked). The TOP gap is NOT used — it also
+    includes the ``[N] EventName`` selector bar's own height, which would
+    inflate the measurement — and the BOTTOM gap is noisier (not every frame
+    has content flush to it); LEFT/RIGHT alone give a clean, corroborated
+    measurement, applied uniformly to all four sides (LabVIEW's own hatched
+    border is the same thickness all around)."""
+    x1, _, x2, _ = structure.bounds
+    gaps: list[float] = []
+    for n in scene.nodes:
+        if n.node.parent != structure.node.id:
+            continue
+        nx1, _, nx2, _ = n.bounds
+        gaps.append(nx1 - x1)
+        gaps.append(x2 - nx2)
+    positive = [g for g in gaps if g > 0.5]
+    return min(positive) if positive else _EVENT_BAND_FALLBACK_W
+
+
+def _draw_event_border_band(
+    structure: RenderStructure, scene: Scene, backend: Backend, theme: Theme,
+) -> None:
+    """An Event Structure's border: a WIDE light-yellow BAND between the
+    outer heap bounds and an inner rule inset by the measured band width
+    (``_event_band_width``) — mirroring LabVIEW's own wide hatched-border
+    margin (see the reference screenshot) instead of a thin dashed line, the
+    same way ``_draw_sequence_border`` gives a flat sequence its film-strip
+    rails. Drawn as four abutting filled rects (never overlapping, so there's
+    no double-opacity at the corners) plus the outer + inner edge rules in
+    ``theme.event_border``. This is the one deliberate exception to
+    ``draw_structure``'s "outline only" rule (see its docstring) — the fill is
+    confined to the edge margin the layout already reserves for it, so it
+    never covers an interior wire."""
+    x1, y1, x2, y2 = structure.bounds
+    w = _event_band_width(structure, scene)
+    w = max(2.0, min(w, (x2 - x1) / 2 - 1.0, (y2 - y1) / 2 - 1.0))
+    fill = theme.event_band
+    backend.rect(x1, y1, x2, y1 + w, fill=fill, stroke="none")          # top
+    backend.rect(x1, y2 - w, x2, y2, fill=fill, stroke="none")          # bottom
+    backend.rect(x1, y1 + w, x1 + w, y2 - w, fill=fill, stroke="none")  # left
+    backend.rect(x2 - w, y1 + w, x2, y2 - w, fill=fill, stroke="none")  # right
+    backend.rect(x1, y1, x2, y2, fill="none", stroke=theme.event_border,
+                 stroke_width=1.2)
+    backend.rect(x1 + w, y1 + w, x2 - w, y2 - w, fill="none",
+                 stroke=theme.event_border, stroke_width=1.0)
+
+
 def _draw_frame_border(
     structure: RenderStructure, scene: Scene, backend: Backend, theme: Theme,
 ) -> None:
@@ -1169,27 +1279,21 @@ def _draw_frame_border(
     borders drawn in ``draw_scene`` recolor it as the viewer switches frames."""
     x1, y1, x2, y2 = structure.bounds
     node = structure.node
-    default = scene.default_frame.get(structure.raw_uid, "")
-    color = _error_border_color(scene, structure.raw_uid, default, theme)
-    # A Diagram/Conditional Disable structure draws a DOTTED boundary (LabVIEW's
-    # signature for a disable frame — see reference), distinguishing it from the
-    # solid case/sequence box. An Event Structure draws a DASHED amber/gold
-    # boundary — not LabVIEW's real diagonal hatch (not required for this
-    # slice), just a clearly-different-at-a-glance treatment from a case's
-    # solid black border.
-    if isinstance(node, DisableStructureNode):
-        dash: str | None = "1.5,2.5"
-    elif isinstance(node, EventStructureNode):
-        dash = "5,2.5"
-        color = color or theme.event_border
+    if isinstance(node, EventStructureNode):
+        _draw_event_border_band(structure, scene, backend, theme)
     else:
-        dash = None
-    if color is not None:
-        backend.rect(x1, y1, x2, y2, fill="none", stroke=color, stroke_width=1.6,
-                     stroke_dasharray=dash)
-    else:
-        backend.rect(x1, y1, x2, y2, fill="none", stroke=theme.struct_border,
-                     stroke_width=1.2, stroke_dasharray=dash)
+        default = scene.default_frame.get(structure.raw_uid, "")
+        color = _error_border_color(scene, structure.raw_uid, default, theme)
+        # A Diagram/Conditional Disable structure draws a DOTTED boundary
+        # (LabVIEW's signature for a disable frame — see reference),
+        # distinguishing it from the solid case/sequence box.
+        dash: str | None = "1.5,2.5" if isinstance(node, DisableStructureNode) else None
+        if color is not None:
+            backend.rect(x1, y1, x2, y2, fill="none", stroke=color, stroke_width=1.6,
+                         stroke_dasharray=dash)
+        else:
+            backend.rect(x1, y1, x2, y2, fill="none", stroke=theme.struct_border,
+                         stroke_width=1.2, stroke_dasharray=dash)
 
     # A STACKED sequence shares the flat sequence's top/bottom rails (the
     # film-strip "3D frame" look) — the selector + single-frame layout is all

--- a/src/lvkit/render/draw.py
+++ b/src/lvkit/render/draw.py
@@ -15,6 +15,7 @@ from ..graph.models import (
     AnyGraphNode,
     CaseStructureNode,
     DisableStructureNode,
+    EventStructureNode,
     FormulaNode,
     LocalVariableNode,
     PrimitiveNode,
@@ -27,6 +28,8 @@ from ..primitive_resolver import get_resolver as get_prim_resolver
 from ..vilib_resolver import get_resolver as get_vilib_resolver
 from .backend import Backend, Point
 from .glyph import (
+    BundleByNameGlyph,
+    BundleGlyph,
     CenteredSvgGlyph,
     ClusterConstantGlyph,
     ConstantGlyph,
@@ -34,6 +37,7 @@ from .glyph import (
     FormulaNodeGlyph,
     IconImageGlyph,
     InlineSvgGlyph,
+    UnbundleGlyph,
     VariantGlyph,
     WrappedBoxGlyph,
     fit_label,
@@ -77,6 +81,7 @@ _STRUCTURE_STYLE = {
     # box + subdiagram selector) for now; faithful greyed-out styling of
     # disabled diagrams is a follow-up.
     "commentNode": "case",
+    "eventStruct": "event",
 }
 
 # LabVIEW's array-control terminal icon always shows a 3-row index display
@@ -85,12 +90,13 @@ _ARRAY_INDEX_ROWS = 3
 
 
 def _is_interactive_structure(node: object) -> bool:
-    """Case structures, Disable structures, and STACKED sequences get
-    selector chrome + per-frame ``lv-frame``/``lv-selector`` groups; flat
-    sequences (film-strip, every frame always visible) and loops do not."""
-    return isinstance(node, (CaseStructureNode, DisableStructureNode)) or (
-        isinstance(node, SequenceNode) and node.node_type != "flatSequence"
-    )
+    """Case structures, Disable structures, Event structures, and STACKED
+    sequences get selector chrome + per-frame ``lv-frame``/``lv-selector``
+    groups; flat sequences (film-strip, every frame always visible) and
+    loops do not."""
+    return isinstance(
+        node, (CaseStructureNode, DisableStructureNode, EventStructureNode),
+    ) or (isinstance(node, SequenceNode) and node.node_type != "flatSequence")
 
 
 # A LabVIEW "Not" bubble — a small open circle drawn AT an inverted terminal,
@@ -202,8 +208,22 @@ def _inset(bounds, frac: float = 0.075):
 
 # A primitive whose glyph is drawn as one of these keeps its own aspect ratio
 # (a real extracted raster icon or a declared/procedural SVG designed for a
-# fixed shape) — those are NOT resized to the terminal span.
-_OWN_ASPECT_GLYPHS = (IconImageGlyph, InlineSvgGlyph, CenteredSvgGlyph)
+# fixed shape), or is a cluster-mux drawer whose heap ``bounds`` IS its true
+# drawn size (like a subVI/constant) rather than a shape recovered from
+# terminal-span union — those are NOT resized to the terminal span.
+#
+# The cluster-mux glyphs specifically MUST be exempted: their AGGREGATE
+# terminal's termBounds is a real on-diagram wire endpoint for a normal
+# Bundle/Unbundle, but for an Event Structure's data/filter node (same
+# ``eventDataNode``/nMux shape, see parser/node_types.py) that aggregate face
+# is never wired/drawn — LabVIEW stores it as a huge negative sentinel rect
+# (e.g. ``(-531, -471, -512, -471)``), which blew the terminal-span union out
+# to hundreds of units and rendered as an oversized, mispositioned box
+# (task #75) before this exemption.
+_OWN_ASPECT_GLYPHS = (
+    IconImageGlyph, InlineSvgGlyph, CenteredSvgGlyph,
+    BundleByNameGlyph, BundleGlyph, UnbundleGlyph,
+)
 
 # Floor for the recovered icon footprint: a unary primitive (one input, one
 # output at the same height) has a terminal-span that collapses to a few px in
@@ -1153,8 +1173,17 @@ def _draw_frame_border(
     color = _error_border_color(scene, structure.raw_uid, default, theme)
     # A Diagram/Conditional Disable structure draws a DOTTED boundary (LabVIEW's
     # signature for a disable frame — see reference), distinguishing it from the
-    # solid case/sequence box.
-    dash = "1.5,2.5" if isinstance(node, DisableStructureNode) else None
+    # solid case/sequence box. An Event Structure draws a DASHED amber/gold
+    # boundary — not LabVIEW's real diagonal hatch (not required for this
+    # slice), just a clearly-different-at-a-glance treatment from a case's
+    # solid black border.
+    if isinstance(node, DisableStructureNode):
+        dash: str | None = "1.5,2.5"
+    elif isinstance(node, EventStructureNode):
+        dash = "5,2.5"
+        color = color or theme.event_border
+    else:
+        dash = None
     if color is not None:
         backend.rect(x1, y1, x2, y2, fill="none", stroke=color, stroke_width=1.6,
                      stroke_dasharray=dash)
@@ -1345,13 +1374,13 @@ def draw_structure(
         _draw_for_loop_border(x1, y1, x2, y2, backend, theme)
     elif kind == "whileLoop":
         _draw_while_loop_border(x1, y1, x2, y2, backend, theme)
-    elif kind in ("case", "stackedSequence"):
+    elif kind in ("case", "stackedSequence", "event"):
         _draw_frame_border(structure, scene, backend, theme)
     elif kind == "flatSequence":
         _draw_sequence_border(structure, backend, theme)
     else:
-        # In Place Element Structure, event structure, or anything else —
-        # a plain border (matches the prior renderer).
+        # In Place Element Structure, or anything else — a plain border
+        # (matches the prior renderer).
         backend.rect(x1, y1, x2, y2, fill="none", stroke=theme.struct_border,
                      stroke_width=1.2)
     # Border terminals (N/i/cond, tunnels, shift registers, selector) are NOT

--- a/src/lvkit/render/glyph.py
+++ b/src/lvkit/render/glyph.py
@@ -29,10 +29,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol, runtime_checkable
 
+from ..models import LVType
 from ..parser.layout import Rect
 from .backend import Backend
 from .icons import icon_data_uri
-from .style import Theme
+from .style import Theme, wire_style
 
 
 @runtime_checkable
@@ -740,6 +741,66 @@ class BundleByNameGlyph:
             fill_attr=self.fill_attr, stroke_attr=self.stroke_attr,
             text_attr=self.text_attr, cell_labels=rows, sym_w=arrow_w,
         )
+
+
+@dataclass(frozen=True)
+class EventDataGlyph:
+    """An Event Structure's Event Data Node / Event Filter Node (heap class
+    ``eventDataNode`` for BOTH — see parser/nodes/event.py). Faithful to the
+    reference LabVIEW screenshot: a WHITE box (never the tan Bundle/Unbundle-
+    By-Name look — this isn't a real cluster assemble/disassemble), one row
+    per accessed field, each row's NAME colored by that field's OWN LVType via
+    ``wire_style()`` — the same data-driven table that colors wires (int blue,
+    string pink, refnum green, ...) — never a fixed palette. A single thin
+    vertical accent band marks the node's OUTER edge: the Data Node sits on
+    the frame's data-in side (fields flow OUT of it into the diagram), so its
+    band is on the LEFT; the Filter Node sits on the opposite side (the
+    diagram writes INTO its filterable fields), so its band is on the RIGHT.
+    ``is_filter`` (resolved by the caller from ``EventStructureNode.
+    filter_node_uids`` — same heap class either way, see render/nodes.py)
+    picks which side.
+    """
+
+    rows: tuple[tuple[str, LVType | None], ...]
+    is_filter: bool = False
+    fill_attr: str = "const_fill"     # white
+    stroke_attr: str = "tunnel_border"
+    band_attr: str = "tunnel_border"
+    text_size: float = 7.5
+
+    def draw(self, backend: Backend, bounds: Rect, theme: Theme) -> None:
+        x1, y1, x2, y2 = bounds
+        stroke = getattr(theme, self.stroke_attr)
+        backend.rect(
+            x1, y1, x2, y2, fill=getattr(theme, self.fill_attr),
+            stroke=stroke, stroke_width=1.2,
+        )
+        rows = self.rows or (("", None),)
+        n = len(rows)
+        row_h = (y2 - y1) / n
+        lsize = max(5.0, min(self.text_size, row_h * 0.62))
+
+        band_w = max(2.0, min(5.0, (x2 - x1) * 0.10))
+        band = getattr(theme, self.band_attr)
+        if self.is_filter:
+            backend.rect(x2 - band_w, y1, x2, y2, fill=band, stroke="none")
+            text_x1, text_x2 = x1 + 3.0, x2 - band_w - 3.0
+        else:
+            backend.rect(x1, y1, x1 + band_w, y2, fill=band, stroke="none")
+            text_x1, text_x2 = x1 + band_w + 3.0, x2 - 3.0
+        avail = max(2.0, text_x2 - text_x1)
+
+        for i, (name, lv_type) in enumerate(rows):
+            ry1 = y1 + i * row_h
+            ry2 = ry1 + row_h
+            if i > 0:
+                backend.line(x1, ry1, x2, ry1, stroke=stroke, stroke_width=0.75)
+            color = wire_style(lv_type, theme).color
+            label = fit_label(name, avail, backend, lsize)
+            backend.text(
+                text_x1, (ry1 + ry2) / 2 + lsize * 0.34, label, lsize,
+                anchor="start", fill=color,
+            )
 
 
 # ARRAY family (goal #14 follow-up): a row of small "element boxes" reads as

--- a/src/lvkit/render/nodes.py
+++ b/src/lvkit/render/nodes.py
@@ -34,6 +34,7 @@ from ..graph.core import InMemoryVIGraph
 from ..graph.models import (
     AnyGraphNode,
     ConstantNode,
+    EventStructureNode,
     FormulaNode,
     LocalVariableNode,
     PrimitiveNode,
@@ -62,6 +63,7 @@ from .glyph import (
     ConstantGlyph,
     ConvertGlyph,
     ErrorClusterGlyph,
+    EventDataGlyph,
     FormulaNodeGlyph,
     Glyph,
     IconImageGlyph,
@@ -488,6 +490,59 @@ def _bundle_by_name_glyph(
     return BundleByNameGlyph(names=tuple(names), bundling=bundling)
 
 
+def _event_data_glyph(
+    node: PrimitiveNode, graph: InMemoryVIGraph,
+) -> EventDataGlyph | None:
+    """The Event Data Node / Event Filter Node glyph (see ``EventDataGlyph``).
+    Same ``dcoAgg``/``dcoList`` field shape as ``_bundle_by_name_glyph`` (the
+    parser reuses ``NMuxHandler`` wholesale — see parser/node_types.py's
+    ``_EventDataNodeHandler``), so field NAMES resolve the same way, but each
+    row also keeps its field's own resolved LVType (preferring the field
+    TERMINAL's own type — every DCO gets one from VCTP independent of the
+    cluster-field lookup — and falling back to the cluster field's type only
+    when the terminal's is unresolved) for the type-colored name text.
+
+    ``is_filter`` is read from the owning ``EventStructureNode.
+    filter_node_uids`` (set during graph construction from the eventStruct's
+    ``filterNodeList`` — see parser/nodes/event.py) — the ONLY way to tell an
+    Event Filter Node apart from an Event Data Node, since both share this
+    same heap class. Returns None if there are no field terminals at all
+    (caller falls back to the generic box)."""
+    agg = next((t for t in node.terminals if t.nmux_role == "agg"), None)
+    fields = (
+        graph.get_type_fields(agg.lv_type) or []
+        if agg is not None and agg.lv_type is not None
+        else []
+    )
+    field_terms = sorted(
+        (t for t in node.terminals if t.nmux_role == "list"), key=lambda t: t.index,
+    )
+    if not field_terms:
+        return None
+    rows: list[tuple[str, LVType | None]] = []
+    for t in field_terms:
+        fi = t.nmux_field_index
+        field = fields[fi] if fi is not None and 0 <= fi < len(fields) else None
+        if field is not None and field.name:
+            name = field.name
+        elif t.name:
+            name = t.name
+        elif fi is not None:
+            name = f"[{fi}]"
+        else:
+            name = "[?]"
+        lv_type = t.lv_type if t.lv_type is not None else (
+            field.type if field is not None else None
+        )
+        rows.append((name, lv_type))
+
+    is_filter = False
+    parent = graph.get_graph_node(node.parent) if node.parent else None
+    if isinstance(parent, EventStructureNode):
+        is_filter = node.id in parent.filter_node_uids
+    return EventDataGlyph(rows=tuple(rows), is_filter=is_filter)
+
+
 def _property_node_glyph(node: PrimitiveNode) -> PropertyNodeGlyph | None:
     """A Property Node glyph: one row per accessed property, labelled with the
     property NAME and marked read/write. Names come from ``node.properties``
@@ -646,12 +701,17 @@ class OriginalGlyphResolver:
 
     @staticmethod
     def _cluster_glyph(node: PrimitiveNode, graph: InMemoryVIGraph) -> Glyph | None:
+        # An Event Structure's Event Data Node / Event Filter Node (heap class
+        # ``eventDataNode``) is its OWN bespoke glyph — a white named-rows box
+        # with a side accent band (see ``EventDataGlyph``) — never the tan
+        # Bundle/Unbundle-By-Name look below (it isn't a real cluster
+        # assemble/disassemble, just a structurally-identical DCO shape).
+        if node.node_type == "eventDataNode":
+            return _event_data_glyph(node, graph)
         # nMux is Bundle/Unbundle BY NAME — a box with the accessed field NAMES,
         # resolved from the wired cluster's type (mux/demux are the compact,
         # positional Bundle/Unbundle handled by field count below).
-        # eventDataNode (Event Data/Filter Node) is the SAME named-rows shape —
-        # a small inner-edge terminal cluster, never the compact positional form.
-        if node.node_type in ("nMux", "eventDataNode"):
+        if node.node_type == "nMux":
             named = _bundle_by_name_glyph(node, graph)
             if named is not None:
                 return named

--- a/src/lvkit/render/nodes.py
+++ b/src/lvkit/render/nodes.py
@@ -216,7 +216,13 @@ _CONVERTER_ABBR = {
 # "Node Multiplexer" classes; bundling vs unbundling is read from the FIELD
 # (nmux_role=="list") terminals' direction — inputs = Bundle, outputs =
 # Unbundle. The AGGREGATE (nmux_role=="agg") terminal(s) are never counted.
-_CLUSTER_MUX_TYPES = frozenset({"nMux", "mux", "demux"})
+#
+# ``eventDataNode`` (an Event Structure's Event Data Node / Event Filter Node
+# — same heap class for both) is structurally identical to nMux (dcoAgg +
+# named dcoList/<i> fields via nmxDCO terminal DCOs, see
+# parser/node_types.py::_EventDataNodeHandler) so it shares the same
+# named-rows glyph instead of the old generic-fallback giant box.
+_CLUSTER_MUX_TYPES = frozenset({"nMux", "mux", "demux", "eventDataNode"})
 
 # node_type -> (bundle name, unbundle name), for when direction can't be
 # determined from a ``list``-role terminal (defensive fallback only).
@@ -224,6 +230,7 @@ _MUX_TYPE_DEFAULT_NAMES = {
     "nMux": "Bundle/Unbundle By Name",
     "mux": "Bundle",
     "demux": "Unbundle",
+    "eventDataNode": "Event Data",
 }
 
 _DEFAULT_ICON_SIZE = (24, 24)
@@ -237,6 +244,11 @@ def mux_display_name(node: AnyGraphNode) -> str:
     are outputs -> Unbundle. Falls back to a type-based default if the node
     has no field terminals (defensive; shouldn't happen for a real mux)."""
     node_type = node.node_type
+    # An Event Data/Filter Node isn't a real Bundle/Unbundle — it's always
+    # "Event Data" regardless of field direction (the Filter Node's fields
+    # can be writable, unlike a genuine Unbundle's read-only outputs).
+    if node_type == "eventDataNode":
+        return "Event Data"
     field_terms = [t for t in node.terminals if t.nmux_role == "list"]
     if field_terms:
         bundling = field_terms[0].direction == "input"
@@ -637,7 +649,9 @@ class OriginalGlyphResolver:
         # nMux is Bundle/Unbundle BY NAME — a box with the accessed field NAMES,
         # resolved from the wired cluster's type (mux/demux are the compact,
         # positional Bundle/Unbundle handled by field count below).
-        if node.node_type == "nMux":
+        # eventDataNode (Event Data/Filter Node) is the SAME named-rows shape —
+        # a small inner-edge terminal cluster, never the compact positional form.
+        if node.node_type in ("nMux", "eventDataNode"):
             named = _bundle_by_name_glyph(node, graph)
             if named is not None:
                 return named

--- a/src/lvkit/render/scene.py
+++ b/src/lvkit/render/scene.py
@@ -436,8 +436,10 @@ def _frame_info(
             # Event structure: keyed by frame INDEX (like a stacked sequence,
             # not a case) — the active frame is chosen at runtime by whichever
             # event fires, not a selector wire/value. frame_labels carries
-            # each frame's faithful (or "[N]" placeholder) event_label — see
-            # EventFrame / parser/nodes/event.py.
+            # each frame's event_label — faithful for the displayed frame,
+            # reconstructed from its EventSpec for every other frame (falls
+            # back to "[N]" when unresolvable) — see EventFrame /
+            # parser/nodes/event.py.
             raw = _strip_prefix(node.id, vi_name)
             values = [str(i) for i in range(len(node.frames))]
             frame_values[raw] = values

--- a/src/lvkit/render/scene.py
+++ b/src/lvkit/render/scene.py
@@ -278,6 +278,38 @@ def _frame_path(
     return tuple(segs)
 
 
+def _fp_terminal_frame_path(
+    t: FPTerminal, by_id: dict[str, AnyGraphNode], vi_name: str,
+) -> FramePath | None:
+    """Structural ``FramePath`` for an FP terminal's on-diagram GLYPH, seeded
+    from the terminal's own ``parent``/``frame`` stamp (see
+    ``graph/construction.py``'s FP-terminal frame-attribution pass) instead
+    of a ``GraphNode``'s ``_frame_path`` walk — an ``FPTerminal`` isn't
+    itself a graph node (one ``FPTerminal`` is shared VI-wide, not one per
+    on-diagram placement, since the same control can be referenced from
+    multiple frames), so it can't just BE the ``node`` that walk starts
+    from. This mirrors that walk: the terminal's immediate parent structure
+    is the leaf segment (using the terminal's own ``frame``), then any
+    further ancestors come from that structure's OWN ``_frame_path``.
+
+    Returns ``None`` (never ``()``) when the terminal wasn't stamped (it was
+    never referenced via an sRN inside a frame) so callers can fall back to
+    the wire-connectivity heuristic instead of wrongly treating it as
+    confirmed always-visible base content.
+    """
+    if t.parent is None:
+        return None
+    parent = by_id.get(t.parent)
+    if parent is None:
+        return None
+    segs = list(_frame_path(parent, by_id, vi_name))
+    if isinstance(
+        parent, (CaseStructureNode, DisableStructureNode, EventStructureNode),
+    ) or _is_stacked_sequence(parent):
+        segs.append((_strip_prefix(parent.id, vi_name), str(t.frame)))
+    return tuple(segs)
+
+
 def encode_frame_path(path: FramePath) -> str:
     """``"struct=val;struct2=val2"`` — root->leaf, insertion order (already
     deterministic: built by walking the parent chain of nodes returned in
@@ -924,18 +956,28 @@ def _wire_path(
     terminal belongs to that tunnel's owning frame (the tunnel's node IS the
     structure itself, per construction.py — its own ``_frame_path`` gives
     the structure's ANCESTOR path, to which we append this tunnel's own
-    frame segment). A
-    wire touching an ordinary node belongs to that node's frame path. The
-    most-specific (longest/deepest) endpoint wins — wires never span two
-    sibling frames, they route through the border tunnel, so the shallower
-    endpoint (the tunnel/structure itself) is always a prefix of the other.
+    frame segment). A wire touching an FP terminal (a front-panel control's
+    on-diagram glyph, e.g. an Event Structure's registered event-source
+    control) uses THAT terminal's own structural frame path — its "node" is
+    the whole VI (``by_id`` only holds structural operation/structure nodes,
+    never the VI itself), so it can't go through the ordinary node lookup
+    below at all. A wire touching an ordinary node belongs to that node's
+    frame path. The most-specific (longest/deepest) endpoint wins — wires
+    never span two sibling frames, they route through the border tunnel, so
+    the shallower endpoint (the tunnel/structure itself) is always a prefix
+    of the other.
     """
     cands: list[FramePath] = []
     for end in (w.source, w.dest):
+        term = graph.get_terminal(end.terminal_id)
+        if isinstance(term, FPTerminal):
+            struct_path = _fp_terminal_frame_path(term, by_id, vi_name)
+            if struct_path is not None:
+                cands.append(struct_path)
+                continue
         node = by_id.get(end.node_id)
         if node is None:
             continue
-        term = graph.get_terminal(end.terminal_id)
         if (
             isinstance(term, TunnelTerminal)
             and term.boundary == "inner"
@@ -1450,10 +1492,16 @@ def build_scene(graph: InMemoryVIGraph, vi_name: str) -> Scene | None:
     fp_terminals: list[RenderFPTerminal] = []
     vi_node = graph.get_graph_node(vi_name)
     if vi_node is not None:
-        # Frame membership for FP terminals (they carry no parent/frame): an
-        # indicator/control placed INSIDE a case/sequence frame wires to a node
-        # in that frame — inherit that node's (deepest) frame path so it hides
-        # with the frame instead of rendering in every frame.
+        # Frame membership for FP terminals: PREFER the structural
+        # attribution stamped by graph/construction.py (the terminal's own
+        # ``parent``/``frame`` — set when the heap places its glyph inside a
+        # case/event/disable/stacked-sequence frame via an sRN, e.g. an Event
+        # Structure's registered event-source control). That's exact, from
+        # the heap itself — unlike the WIRE-based fallback below (used only
+        # when a terminal wasn't stamped, e.g. it's genuinely VI-global): an
+        # indicator/control placed INSIDE a frame often wires to a node in
+        # that same frame, so inherit that node's (deepest) frame path too,
+        # so it hides with the frame instead of rendering in every frame.
         fp_ids = {t.id for t in vi_node.terminals if isinstance(t, FPTerminal)}
         fp_frame: dict[str, FramePath] = {}
         for w in graph.get_wires(vi_name, include_internal=True):
@@ -1479,9 +1527,14 @@ def build_scene(graph: InMemoryVIGraph, vi_name: str) -> Scene | None:
                 (bounds[0] + bounds[2]) / 2, (bounds[1] + bounds[3]) / 2,
             ))
             label_visible = raw_uid not in layout.hidden_labels
+            struct_path = _fp_terminal_frame_path(t, by_id, vi_name)
+            frame_path = (
+                struct_path if struct_path is not None
+                else fp_frame.get(t.id, ())
+            )
             fp_terminals.append(RenderFPTerminal(
                 terminal=t, bounds=bounds, center=center,
-                label_visible=label_visible, frame_path=fp_frame.get(t.id, ()),
+                label_visible=label_visible, frame_path=frame_path,
             ))
 
     if missing:

--- a/src/lvkit/render/scene.py
+++ b/src/lvkit/render/scene.py
@@ -565,9 +565,17 @@ def _reposition_mux_aggregates(
 # an optional input wire, SR/auto-index carry real data). "selector" also
 # matches by name because the graph tags it that way (construction.py)
 # rather than always setting tunnel_type="caseSel".
+#
+# "eventTimeout"/"eventDyn" are an Event Structure's own two bespoke border
+# DCOs (see parser/nodes/event.py): the ``eventTimeOut`` value input (top-left
+# HOURGLASS box, in the position a For-Loop's N terminal occupies) and the
+# ``eventDynDCO`` dynamic-event-registration refnum pair (small GREEN boxes at
+# their real heap position — LabVIEW places them top+bottom in some VIs,
+# left+right in others; position is heap geometry, not assumed here).
 _TUNNEL_GLYPH_KIND = {
     "lMax": "N", "lSR": "sr_down", "rSR": "sr_up",
     "lpTun": "autoindex", "caseSel": "selector",
+    "eventTimeOut": "eventTimeout", "eventDynDCO": "eventDyn",
 }
 
 # Border terminals a loop is GUARANTEED to have, purely as a function of
@@ -639,6 +647,17 @@ def _structure_borders(
                 for inner in inner_by_outer.get(t.id, [])
                 if inner.frame is not None and inner.id not in wired_dest
             )
+        # Dynamic-event terminals draw ONLY when toggled on ("Show Dynamic
+        # Event Terminals") — which is exactly when LabVIEW emits real bounds
+        # for them; a hidden pair carries no/degenerate bounds, so skip it.
+        # (Every eventStruct in the current corpus has them on with real
+        # bounds, so this is a defensive no-op there; it is the correct
+        # data-driven gate rather than decoding a version-confounded objFlags
+        # bit — a toggled-off terminal simply has nothing to draw.)
+        if glyph_kind == "eventDyn":
+            gx1, gy1, gx2, gy2 = rect
+            if gx2 - gx1 <= 0 or gy2 - gy1 <= 0:
+                continue
         result.append(
             RenderBorderTerminal(
                 terminal=t, bounds=rect, glyph_kind=glyph_kind, color=color,

--- a/src/lvkit/render/scene.py
+++ b/src/lvkit/render/scene.py
@@ -17,6 +17,7 @@ from ..graph.models import (
     CaseStructureNode,
     ConstantNode,
     DisableStructureNode,
+    EventStructureNode,
     FormulaNode,
     LoopNode,
     SequenceNode,
@@ -268,8 +269,9 @@ def _frame_path(
         parent = by_id.get(cur.parent)
         if parent is None:
             break
-        if isinstance(parent, (CaseStructureNode, DisableStructureNode)) \
-                or _is_stacked_sequence(parent):
+        if isinstance(
+            parent, (CaseStructureNode, DisableStructureNode, EventStructureNode),
+        ) or _is_stacked_sequence(parent):
             segs.append((_strip_prefix(parent.id, vi_name), str(cur.frame)))
         cur = parent
     segs.reverse()
@@ -398,6 +400,25 @@ def _frame_info(
             raw = _strip_prefix(node.id, vi_name)
             frame_values[raw] = [str(i) for i in range(len(node.frames))]
             default_frame[raw] = "0"
+        elif isinstance(node, EventStructureNode) and node.frames:
+            # Event structure: keyed by frame INDEX (like a stacked sequence,
+            # not a case) — the active frame is chosen at runtime by whichever
+            # event fires, not a selector wire/value. frame_labels carries
+            # each frame's faithful (or "[N]" placeholder) event_label — see
+            # EventFrame / parser/nodes/event.py.
+            raw = _strip_prefix(node.id, vi_name)
+            values = [str(i) for i in range(len(node.frames))]
+            frame_values[raw] = values
+            shown_idx = (
+                node.displayed_frame
+                if node.displayed_frame is not None
+                and 0 <= node.displayed_frame < len(node.frames)
+                else 0
+            )
+            default_frame[raw] = str(shown_idx)
+            frame_labels[raw] = {
+                str(i): f.event_label for i, f in enumerate(node.frames)
+            }
     return default_frame, frame_values, frame_labels, error_no_error
 
 

--- a/src/lvkit/render/style.py
+++ b/src/lvkit/render/style.py
@@ -38,6 +38,11 @@ class Theme:
     case_bar_text: str = "#4a4636"
     case_no_error_border: str = "#2e9e3f"  # green — error-cluster "No Error" frame
     case_error_border: str = "#d32f2f"     # red — error-cluster "Error" frame
+    # Event Structure border — a distinct warm amber/gold (LabVIEW's own
+    # diagonal-hatch border uses a similar tan hue), dashed, so an event
+    # structure reads as clearly different from a case's solid black border
+    # at a glance without needing to reproduce the exact hatch pattern.
+    event_border: str = "#b8860b"
     # Translucent wash painted over a DISABLED subdiagram of a Diagram/
     # Conditional Disable structure (every frame except the enabled one), so
     # its greyed-out contents read as inactive — matches LabVIEW. Applied at

--- a/src/lvkit/render/style.py
+++ b/src/lvkit/render/style.py
@@ -39,10 +39,14 @@ class Theme:
     case_no_error_border: str = "#2e9e3f"  # green — error-cluster "No Error" frame
     case_error_border: str = "#d32f2f"     # red — error-cluster "Error" frame
     # Event Structure border — a distinct warm amber/gold (LabVIEW's own
-    # diagonal-hatch border uses a similar tan hue), dashed, so an event
-    # structure reads as clearly different from a case's solid black border
-    # at a glance without needing to reproduce the exact hatch pattern.
+    # diagonal-hatch border uses a similar tan hue): a WIDE filled BAND (not
+    # a thin dashed line) between the structure's outer heap bounds and its
+    # inset inner content, mirroring LabVIEW's own hatched border margin
+    # (see draw.py::_draw_event_border_band). ``event_border`` is the thin
+    # edge-line color (outer + inner rule); ``event_band`` is the band's
+    # light-yellow fill.
     event_border: str = "#b8860b"
+    event_band: str = "#fdf6cf"
     # Translucent wash painted over a DISABLED subdiagram of a Diagram/
     # Conditional Disable structure (every frame except the enabled one), so
     # its greyed-out contents read as inactive — matches LabVIEW. Applied at

--- a/src/lvkit/render/templates/diff_viewer.html
+++ b/src/lvkit/render/templates/diff_viewer.html
@@ -36,12 +36,21 @@
   header{padding:10px 16px;background:var(--panel);border-bottom:1px solid var(--line);
          display:flex;gap:14px;align-items:center;flex-wrap:wrap}
   header b{font-size:15px}
-  .controls{display:flex;gap:6px;align-items:center;flex-wrap:wrap}
+  /* Header = three groups (titles · controls · legend). Each group is nowrap so
+     it never fragments internally; the header's own flex-wrap breaks only
+     BETWEEN groups — one row when there's room, three stacked rows when narrow.
+     .controls.grow fills the gap between titles and legend (Split/Overlay left,
+     zoom/hl/theme right via margin-left:auto); .legend grows just enough to keep
+     its chips right-justified on its own row when stacked. */
+  .titles{display:flex;gap:14px;align-items:center;flex-wrap:nowrap}
+  .controls{display:flex;gap:6px;align-items:center;flex-wrap:nowrap}
+  .controls.grow{flex:100 1 auto}
   button{background:var(--btn);color:var(--fg);border:1px solid var(--line);border-radius:6px;
          padding:5px 10px;cursor:pointer;font:inherit}
   button.active{background:var(--accent);border-color:var(--accent);color:var(--accent-fg)}
   button:disabled{opacity:.45;cursor:default}
-  .legend{margin-left:auto;display:flex;gap:12px;align-items:center;font-size:13px}
+  .legend{display:flex;gap:12px;align-items:center;font-size:13px;
+          flex-wrap:nowrap;justify-content:flex-end;flex:1 0 auto}
   .chip{display:inline-flex;gap:6px;align-items:center}
   .sw{width:12px;height:12px;border-radius:3px}
   .body{display:grid;grid-template-columns:var(--aside-w,290px) 6px 1fr;
@@ -231,15 +240,12 @@
 </style>
 
 <header>
-  <b>VI diff · __TITLE__</b>
-  <span style="opacity:.7">__BEFORE_LABEL__ → __AFTER_LABEL__ · engine change-map</span>
-  <div class="controls">
+  <div class="titles"><b>VI diff · __TITLE__</b><span style="opacity:.7">__BEFORE_LABEL__ → __AFTER_LABEL__ · engine change-map</span></div>
+  <div class="controls grow">
     <button data-mode="split" class="active" title="Before above, after below — scroll and zoom stay in sync">Split</button>
     <button data-mode="overlay">Overlay</button>
     <span id="opWrap" style="display:none"><button type="button" class="op-end" data-op="0" title="show BEFORE only">before</button><input id="op" type="range" min="0" max="100" value="70"><button type="button" class="op-end" data-op="100" title="show AFTER only">after</button></span>
-  </div>
-  <div class="legend">
-    <span class="controls" style="gap:6px;margin-right:2px;font-size:14px">
+    <span class="controls" style="margin-left:auto;gap:6px;font-size:14px">
       <span class="zoomgrp" title="Zoom (+ / − / f, or Ctrl+wheel)"><button id="zoomOut">−</button><button id="zoomIn">+</button><button id="zoomFit">fit</button></span>
       <button id="hlToggle" type="button" class="active"
         style="min-width:30px;padding:5px 9px"
@@ -247,6 +253,8 @@
         aria-pressed="true" aria-label="Toggle change highlights">◉</button>
       __THEME_BTN__
     </span>
+  </div>
+  <div class="legend">
     <span class="chip"><span class="sw" style="background:var(--add)"></span>added __ADD__</span>
     <span class="chip"><span class="sw" style="background:var(--del)"></span>removed __DEL__</span>
     <span class="chip"><span class="sw" style="background:var(--mod)"></span>modified __MOD__</span>

--- a/src/lvkit/render/templates/render_viewer.html
+++ b/src/lvkit/render/templates/render_viewer.html
@@ -32,7 +32,7 @@
   header{padding:10px 16px;background:var(--panel);border-bottom:1px solid var(--line);
          display:flex;gap:14px;align-items:center;flex-wrap:wrap}
   header b{font-size:15px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-  .controls{display:flex;gap:6px;align-items:center;flex-wrap:wrap;margin-left:auto}
+  .controls{display:flex;gap:6px;align-items:center;flex-wrap:nowrap;margin-left:auto}
   button{background:var(--btn);color:var(--fg);border:1px solid var(--line);border-radius:6px;
          padding:5px 10px;cursor:pointer;font:inherit}
   button:hover{background:var(--btn-hover)}

--- a/src/lvkit/render/theme_web.py
+++ b/src/lvkit/render/theme_web.py
@@ -47,6 +47,7 @@ DARK_PALETTE: dict[str, str] = {
     "case_no_error_border": "#46c85a",
     "case_error_border": "#ff5b5b",
     "event_border": "#e0b84a",
+    "event_band": "#3a341f",
     "disabled_mask": "#5a5a5a",
     "selector_stroke": "#7fbf5a",
     "selector_text": "#bfe0a5",

--- a/src/lvkit/render/theme_web.py
+++ b/src/lvkit/render/theme_web.py
@@ -46,6 +46,7 @@ DARK_PALETTE: dict[str, str] = {
     "case_bar_text": "#d8d4c0",
     "case_no_error_border": "#46c85a",
     "case_error_border": "#ff5b5b",
+    "event_border": "#e0b84a",
     "disabled_mask": "#5a5a5a",
     "selector_stroke": "#7fbf5a",
     "selector_text": "#bfe0a5",

--- a/tests/test_event_parser.py
+++ b/tests/test_event_parser.py
@@ -1,19 +1,32 @@
 """Tests for event structure parsing — frame labels and border tunnels.
 
 Mirrors test_case_parser.py's style (minimal synthetic XML), covering the
-two things this parser slice is responsible for: (1) per-frame display
-labels — faithful for the ONE frame LabVIEW last displayed, an honest
-``"[N]"`` placeholder for every other frame (there is no per-frame label
-table in the heap, unlike a case structure's dataspace SelectorTable) — and
-(2) the four dco classes that carry data across the structure boundary,
-all sharing the same per-frame-array tunnel shape.
+three things this parser slice is responsible for: (1) per-frame display
+labels — faithful for the ONE frame LabVIEW last displayed, RECONSTRUCTED
+from that frame's ``EventSpec`` for every other frame (source control
+caption via the front-panel heap + a clean-room-confirmed event-type name),
+degrading to an honest ``"[N]"`` when unresolvable; (2) the four dco classes
+that carry data across the structure boundary, all sharing the same
+per-frame-array tunnel shape; and (3) an end-to-end check against the real
+VI Tester About.vi heap XML (task #75 follow-up).
 """
 
 from __future__ import annotations
 
 import xml.etree.ElementTree as ET
+from pathlib import Path
 
+import pytest
+
+from lvkit.extractor import resolve_extracted
 from lvkit.parser.nodes.event import extract_event_structures
+
+_SAMPLES_ROOT = Path(__file__).parent.parent / ".lvkit" / "cache" / "samples"
+_VI_TESTER_ABOUT_DIR = (
+    _SAMPLES_ROOT
+    / "JKI-VI-Tester/source/User Interfaces/Graphical Test Runner"
+    / "Graphical Test Runner Support"
+)
 
 
 def _build_event_xml(
@@ -25,6 +38,7 @@ def _build_event_xml(
     tunnel_specs: list[tuple[str, str, list[str]]] | None = None,
     data_node_uids: list[str] | None = None,
     filter_node_uids: list[str] | None = None,
+    event_specs: list[tuple[int, str, int]] | None = None,
 ) -> ET.Element:
     """Build minimal XML for an event structure.
 
@@ -38,11 +52,24 @@ def _build_event_xml(
             eventStruct's own boundary terminals.
         data_node_uids: per-frame ``dataNodeList`` uids ("0" = none).
         filter_node_uids: per-frame ``filterNodeList`` uids ("0" = none).
+        event_specs: list of (diagramIdx, ddoUID, type) — the heap's
+            ``EventNodeEvents/EventSpec`` entries used to reconstruct a
+            frame's label (``ddoUID="0"`` means no source control).
     """
     root = ET.Element("root")
     es = ET.SubElement(root, "SL__arrayElement", attrib={
         "class": "eventStruct", "uid": struct_uid,
     })
+
+    if event_specs is not None:
+        events_list = ET.SubElement(es, "EventNodeEvents")
+        for diagram_idx, ddo_uid, type_code in event_specs:
+            spec = ET.SubElement(events_list, "SL__arrayElement", attrib={
+                "class": "EventSpec",
+            })
+            ET.SubElement(spec, "diagramIdx").text = str(diagram_idx)
+            ET.SubElement(spec, "ddoUID").text = ddo_uid
+            ET.SubElement(spec, "type").text = str(type_code)
 
     term_list = ET.SubElement(es, "termList")
     for outer_uid, dco_class, inner_uids in (tunnel_specs or []):
@@ -139,6 +166,122 @@ class TestFrameLabels:
         assert [f.event_label for f in es.frames] == ["[0]", "[1]"]
 
 
+def _build_fp_xml(tmp_path, ddo_captions: dict[str, str]) -> Path:
+    """A minimal front-panel heap with one ``ddo`` per uid, each carrying a
+    ``partsList/label`` caption — same shape ``extract_label`` reads off a
+    real control's ddo (see ``_resolve_control_caption``)."""
+    fp_root = ET.Element("root")
+    for uid, caption in ddo_captions.items():
+        fpdco = ET.SubElement(fp_root, "SL__arrayElement", attrib={
+            "class": "fPDCO", "uid": f"dco_{uid}",
+        })
+        ddo = ET.SubElement(fpdco, "ddo", attrib={"class": "stdBool", "uid": uid})
+        parts_list = ET.SubElement(ddo, "partsList")
+        label = ET.SubElement(parts_list, "SL__arrayElement", attrib={
+            "class": "label",
+        })
+        text_rec = ET.SubElement(label, "textRec")
+        ET.SubElement(text_rec, "text").text = f'"{caption}"'
+    fp_path = tmp_path / "fp.xml"
+    ET.ElementTree(fp_root).write(fp_path)
+    return fp_path
+
+
+class TestEventSpecReconstruction:
+    """Non-displayed frames' labels, reconstructed from ``EventSpec``
+    (``ddoUID`` -> front-panel control caption, ``type`` -> confirmed
+    event-type name) — see event.py module docstring, verified against VI
+    Tester About.vi (task #75 follow-up)."""
+
+    def test_no_fp_heap_omits_unresolvable_control(self):
+        """No FP heap path given at all: the control can't be resolved, but
+        a confirmed event type still isn't withheld — same "omit what can't
+        be known" degrade as an unresolvable ddoUID (test below)."""
+        root = _build_event_xml(
+            "es1", num_frames=1,
+            event_specs=[(0, "55", 1073741826)],
+        )
+        es = extract_event_structures(root)[0]
+        assert es.frames[0].event_label == "[0] Value Change"
+
+    def test_control_and_confirmed_type_with_fp_heap(self, tmp_path):
+        fp_path = _build_fp_xml(tmp_path, {"55": "Cancel"})
+        root = _build_event_xml(
+            "es1", num_frames=1,
+            event_specs=[(0, "55", 1073741826)],
+        )
+        es = extract_event_structures(root, fp_path)[0]
+        assert es.frames[0].event_label == '[0] "Cancel": Value Change'
+
+    def test_no_source_control_ddouid_zero(self, tmp_path):
+        """ddoUID=0 means no source control (pane/app/filter event) — the
+        control name is omitted, never fabricated."""
+        fp_path = _build_fp_xml(tmp_path, {})
+        root = _build_event_xml(
+            "es1", num_frames=1,
+            event_specs=[(0, "0", 1073741825)],
+        )
+        es = extract_event_structures(root, fp_path)[0]
+        assert es.frames[0].event_label == "[0] Timeout"
+
+    def test_unconfirmed_type_code_omitted(self, tmp_path):
+        """A type code not yet clean-room confirmed is never guessed at —
+        the control caption alone is shown when resolvable."""
+        fp_path = _build_fp_xml(tmp_path, {"55": "Cancel"})
+        root = _build_event_xml(
+            "es1", num_frames=1,
+            event_specs=[(0, "55", -2147483645)],
+        )
+        es = extract_event_structures(root, fp_path)[0]
+        assert es.frames[0].event_label == '[0] "Cancel"'
+
+    def test_no_control_and_unconfirmed_type_bare_placeholder(self, tmp_path):
+        """Neither a control nor a confirmed type: bare [N], no fabrication."""
+        fp_path = _build_fp_xml(tmp_path, {})
+        root = _build_event_xml(
+            "es1", num_frames=1,
+            event_specs=[(0, "0", -2147483645)],
+        )
+        es = extract_event_structures(root, fp_path)[0]
+        assert es.frames[0].event_label == "[0]"
+
+    def test_unresolvable_ddo_uid_omits_control(self, tmp_path):
+        """A ddoUID with no matching ddo in the FP heap degrades to omitting
+        the control, rather than crashing or fabricating a name."""
+        fp_path = _build_fp_xml(tmp_path, {"55": "Cancel"})
+        root = _build_event_xml(
+            "es1", num_frames=1,
+            event_specs=[(0, "9999", 1073741826)],
+        )
+        es = extract_event_structures(root, fp_path)[0]
+        assert es.frames[0].event_label == "[0] Value Change"
+
+    def test_displayed_frame_faithful_text_wins_over_reconstruction(
+        self, tmp_path,
+    ):
+        """The displayed frame's own heap selString always wins, even if its
+        EventSpec would reconstruct to the same thing (cross-check, not a
+        source of truth)."""
+        fp_path = _build_fp_xml(tmp_path, {"775": "copyrights"})
+        root = _build_event_xml(
+            "es1", num_frames=1, d_idx=0,
+            sel_string='" [0] "copyrights": Value Change "',
+            event_specs=[(0, "775", 1073741826)],
+        )
+        es = extract_event_structures(root, fp_path)[0]
+        assert es.frames[0].event_label == '[0] "copyrights": Value Change'
+
+    def test_frame_with_no_event_spec_falls_back_to_placeholder(self):
+        """A frame index missing from EventNodeEvents (malformed heap) keeps
+        the honest [N] placeholder instead of crashing."""
+        root = _build_event_xml(
+            "es1", num_frames=2,
+            event_specs=[(0, "55", 1073741826)],
+        )
+        es = extract_event_structures(root)[0]
+        assert es.frames[1].event_label == "[1]"
+
+
 class TestBorderTunnels:
     def test_all_four_event_tunnel_dco_classes_extracted(self):
         """selTun, both eventDynDCO instances (registration in/out), and
@@ -228,3 +371,38 @@ class TestNoEventStructures:
             "class": "eventStruct", "uid": "es1",
         })
         assert extract_event_structures(root) == []
+
+
+def _has_vi_tester_about() -> bool:
+    return (_VI_TESTER_ABOUT_DIR / "VI Tester About.vi").exists()
+
+
+@pytest.mark.skipif(
+    not _has_vi_tester_about(), reason="JKI-VI-Tester sample not present",
+)
+class TestViTesterAboutFixture:
+    """End-to-end reconstruction against the real VI Tester About.vi heap
+    XML (task #75 follow-up) -- proven ground truth:
+
+    - frame 0: ddoUID 55 -> "Cancel", type 1073741826 (Value Change)
+    - frame 1: ddoUID 1124 -> "Website Button", type 1073741826
+    - frame 2: ddoUID 0 (no control), type -2147483645 (NOT confirmed)
+    - frame 3: ddoUID 775 -> "copyrights", type 1073741826 -- matches the
+      DISPLAYED frame's own faithful heap text exactly (cross-check)
+    """
+
+    def test_reconstructed_labels_match_ground_truth(self):
+        vi_path = _VI_TESTER_ABOUT_DIR / "VI Tester About.vi"
+        bd_xml, fp_xml, _ = resolve_extracted(vi_path)
+        bd_root = ET.parse(bd_xml).getroot()
+
+        structures = extract_event_structures(bd_root, fp_xml)
+        assert len(structures) == 1
+        es = structures[0]
+        labels = [f.event_label for f in es.frames]
+
+        assert labels[0] == '[0] "Cancel": Value Change'
+        assert labels[1] == '[1] "Website Button": Value Change'
+        assert labels[2] == "[2]"  # ddoUID 0 + unconfirmed type -> no fabrication
+        assert labels[3] == '[3] "copyrights": Value Change'
+        assert es.displayed_frame == 3

--- a/tests/test_event_parser.py
+++ b/tests/test_event_parser.py
@@ -1,0 +1,230 @@
+"""Tests for event structure parsing — frame labels and border tunnels.
+
+Mirrors test_case_parser.py's style (minimal synthetic XML), covering the
+two things this parser slice is responsible for: (1) per-frame display
+labels — faithful for the ONE frame LabVIEW last displayed, an honest
+``"[N]"`` placeholder for every other frame (there is no per-frame label
+table in the heap, unlike a case structure's dataspace SelectorTable) — and
+(2) the four dco classes that carry data across the structure boundary,
+all sharing the same per-frame-array tunnel shape.
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+from lvkit.parser.nodes.event import extract_event_structures
+
+
+def _build_event_xml(
+    struct_uid: str,
+    *,
+    num_frames: int = 2,
+    d_idx: int | None = None,
+    sel_string: str | None = None,
+    tunnel_specs: list[tuple[str, str, list[str]]] | None = None,
+    data_node_uids: list[str] | None = None,
+    filter_node_uids: list[str] | None = None,
+) -> ET.Element:
+    """Build minimal XML for an event structure.
+
+    Args:
+        struct_uid: UID for the eventStruct element.
+        num_frames: number of diagram frames to create.
+        d_idx: heap ``dIdx`` (displayed-frame index), omitted if None.
+        sel_string: raw ``selString/textRec/text`` content (heap wraps the
+            whole thing in literal quote characters, e.g. ``'" [1] Timeout "'``).
+        tunnel_specs: list of (outer_uid, dco_class, [inner_uid, ...]) — the
+            eventStruct's own boundary terminals.
+        data_node_uids: per-frame ``dataNodeList`` uids ("0" = none).
+        filter_node_uids: per-frame ``filterNodeList`` uids ("0" = none).
+    """
+    root = ET.Element("root")
+    es = ET.SubElement(root, "SL__arrayElement", attrib={
+        "class": "eventStruct", "uid": struct_uid,
+    })
+
+    term_list = ET.SubElement(es, "termList")
+    for outer_uid, dco_class, inner_uids in (tunnel_specs or []):
+        term = ET.SubElement(term_list, "SL__arrayElement", attrib={
+            "class": "term", "uid": outer_uid,
+        })
+        dco = ET.SubElement(term, "dco", attrib={"class": dco_class})
+        dco_tl = ET.SubElement(dco, "termList")
+        for iu in inner_uids:
+            ET.SubElement(dco_tl, "SL__arrayElement", attrib={"uid": iu})
+        # Outer face is the LAST element in the dco's own termList.
+        ET.SubElement(dco_tl, "SL__arrayElement", attrib={"uid": outer_uid})
+
+    diag_list = ET.SubElement(es, "diagramList")
+    for i in range(num_frames):
+        ET.SubElement(diag_list, "SL__arrayElement", attrib={
+            "class": "diag", "uid": f"diag_{i}",
+        })
+
+    if d_idx is not None:
+        ET.SubElement(es, "dIdx").text = str(d_idx)
+
+    if sel_string is not None:
+        sel = ET.SubElement(es, "selString")
+        text_rec = ET.SubElement(sel, "textRec")
+        ET.SubElement(text_rec, "text").text = sel_string
+
+    if data_node_uids is not None:
+        dnl = ET.SubElement(es, "dataNodeList")
+        for u in data_node_uids:
+            ET.SubElement(dnl, "SL__arrayElement", attrib={"uid": u})
+
+    if filter_node_uids is not None:
+        fnl = ET.SubElement(es, "filterNodeList")
+        for u in filter_node_uids:
+            ET.SubElement(fnl, "SL__arrayElement", attrib={"uid": u})
+
+    return root
+
+
+class TestFrameLabels:
+    def test_frames_default_to_bracket_index_placeholder(self):
+        """No dIdx/selString at all -- every frame gets an honest [N]."""
+        root = _build_event_xml("es1", num_frames=3)
+        es = extract_event_structures(root)[0]
+        assert [f.event_label for f in es.frames] == ["[0]", "[1]", "[2]"]
+        assert es.displayed_frame == 0
+
+    def test_displayed_frame_gets_faithful_selstring_label(self):
+        """LabVIEW's own bracketed rendering (heap wraps it in quote chars)
+        is used verbatim for the displayed frame; every other frame keeps
+        its placeholder."""
+        root = _build_event_xml(
+            "es1", num_frames=3, d_idx=1,
+            sel_string='" [1] Timeout "',
+        )
+        es = extract_event_structures(root)[0]
+        assert es.displayed_frame == 1
+        assert es.frames[0].event_label == "[0]"
+        assert es.frames[1].event_label == "[1] Timeout"
+        assert es.frames[2].event_label == "[2]"
+
+    def test_quoted_control_name_label_preserved(self):
+        """A control-sourced event's label keeps its quoted control name
+        AND the bracketed index, e.g. LabVIEW's own
+        ``[3] "copyrights": Value Change`` (VI Tester About.vi, task #75)."""
+        root = _build_event_xml(
+            "es1", num_frames=4, d_idx=3,
+            sel_string='" [3] "copyrights": Value Change "',
+        )
+        es = extract_event_structures(root)[0]
+        assert es.frames[3].event_label == '[3] "copyrights": Value Change'
+
+    def test_missing_didx_defaults_to_frame_0(self):
+        """Heap omits dIdx when it's 0 (same convention as parmIndex/
+        paramIdx elsewhere in this parser)."""
+        root = _build_event_xml(
+            "es1", num_frames=2, sel_string='" [0] Timeout "',
+        )
+        es = extract_event_structures(root)[0]
+        assert es.displayed_frame == 0
+        assert es.frames[0].event_label == "[0] Timeout"
+        assert es.frames[1].event_label == "[1]"
+
+    def test_out_of_range_didx_ignored(self):
+        """A dIdx pointing past the frame count never crashes and never
+        mislabels — displayed_frame is None, every frame keeps its
+        placeholder."""
+        root = _build_event_xml(
+            "es1", num_frames=2, d_idx=5, sel_string='" [5] Bogus "',
+        )
+        es = extract_event_structures(root)[0]
+        assert es.displayed_frame is None
+        assert [f.event_label for f in es.frames] == ["[0]", "[1]"]
+
+
+class TestBorderTunnels:
+    def test_all_four_event_tunnel_dco_classes_extracted(self):
+        """selTun, both eventDynDCO instances (registration in/out), and
+        eventTimeOut all share the same per-frame-array shape -- N inner
+        tunnels per outer, for N frames."""
+        root = _build_event_xml(
+            "es1", num_frames=3,
+            tunnel_specs=[
+                ("dyn_in", "eventDynDCO", ["dyn_in_f0", "dyn_in_f1", "dyn_in_f2"]),
+                ("dyn_out", "eventDynDCO", ["dyn_out_f0", "dyn_out_f1", "dyn_out_f2"]),
+                ("timeout", "eventTimeOut", ["to_f0", "to_f1", "to_f2"]),
+                ("stop", "selTun", ["stop_f0", "stop_f1", "stop_f2"]),
+            ],
+        )
+        es = extract_event_structures(root)[0]
+        assert len(es.tunnels) == 12
+        by_type: dict[str, list[str]] = {}
+        for t in es.tunnels:
+            by_type.setdefault(t.tunnel_type, []).append(t.inner_terminal_uid)
+        assert by_type["eventDynDCO"] == [
+            "dyn_in_f0", "dyn_in_f1", "dyn_in_f2",
+            "dyn_out_f0", "dyn_out_f1", "dyn_out_f2",
+        ]
+        assert by_type["eventTimeOut"] == ["to_f0", "to_f1", "to_f2"]
+        assert by_type["selTun"] == ["stop_f0", "stop_f1", "stop_f2"]
+        assert all(t.outer_terminal_uid == "timeout"
+                   for t in es.tunnels if t.tunnel_type == "eventTimeOut")
+
+    def test_non_event_tunnel_dco_class_ignored(self):
+        """A dco class this structure doesn't recognize as a boundary tunnel
+        (e.g. a plain constant DCO) produces no tunnel."""
+        root = _build_event_xml(
+            "es1", num_frames=2,
+            tunnel_specs=[("x", "bDConstDCO", ["x_f0", "x_f1"])],
+        )
+        es = extract_event_structures(root)[0]
+        assert es.tunnels == []
+
+    def test_no_tunnels_when_termlist_empty(self):
+        root = _build_event_xml("es1", num_frames=2)
+        es = extract_event_structures(root)[0]
+        assert es.tunnels == []
+
+
+class TestDataAndFilterNodeUids:
+    def test_data_node_uid_folded_into_frame_inner_node_uids(self):
+        root = _build_event_xml(
+            "es1", num_frames=2,
+            data_node_uids=["dn0", "dn1"],
+        )
+        es = extract_event_structures(root)[0]
+        assert "dn0" in es.frames[0].inner_node_uids
+        assert "dn1" in es.frames[1].inner_node_uids
+
+    def test_zero_uid_means_no_node_for_that_frame(self):
+        """Heap uid="0" marks "no data/filter node for this frame" -- must
+        not be folded in as a real node reference."""
+        root = _build_event_xml(
+            "es1", num_frames=2,
+            data_node_uids=["0", "dn1"],
+            filter_node_uids=["fn0", "0"],
+        )
+        es = extract_event_structures(root)[0]
+        assert es.frames[0].inner_node_uids == ["fn0"]
+        assert es.frames[1].inner_node_uids == ["dn1"]
+
+    def test_both_data_and_filter_node_on_same_frame(self):
+        root = _build_event_xml(
+            "es1", num_frames=1,
+            data_node_uids=["dn0"],
+            filter_node_uids=["fn0"],
+        )
+        es = extract_event_structures(root)[0]
+        assert set(es.frames[0].inner_node_uids) == {"dn0", "fn0"}
+
+
+class TestNoEventStructures:
+    def test_no_eventstruct_elements_returns_empty(self):
+        root = ET.Element("root")
+        assert extract_event_structures(root) == []
+
+    def test_eventstruct_without_diagrams_skipped(self):
+        """An eventStruct with no diagramList/diag children is malformed --
+        skip it rather than emit a frameless structure."""
+        root = ET.Element("root")
+        ET.SubElement(root, "SL__arrayElement", attrib={
+            "class": "eventStruct", "uid": "es1",
+        })
+        assert extract_event_structures(root) == []

--- a/tests/test_queue_codegen.py
+++ b/tests/test_queue_codegen.py
@@ -1,5 +1,7 @@
-"""Tests for Queue Operations code generation (Obtain/Enqueue/Dequeue/
-Get Queue Status).
+"""Tests for Queue Operations code generation (Obtain/Enqueue/Dequeue).
+
+Get Queue Status (9110) and Release Queue (9109) codegen is deferred to the
+queue-runtime design work (see codegen/nodes/queue_ops.py) -- not tested here.
 
 Mirrors the pattern in tests/test_array_ops_codegen.py: build
 PrimitiveOperation + CodeGenContext by hand for each node in a small
@@ -20,7 +22,6 @@ from lvkit.labview_queue import (
     dequeue_element,
     enqueue_element,
     enqueue_element_at_opposite_end,
-    get_queue_status,
     obtain_queue,
 )
 from lvkit.models import PrimitiveOperation, Terminal
@@ -40,7 +41,6 @@ _RUNTIME_GLOBALS = {
     "enqueue_element": enqueue_element,
     "enqueue_element_at_opposite_end": enqueue_element_at_opposite_end,
     "dequeue_element": dequeue_element,
-    "get_queue_status": get_queue_status,
 }
 
 
@@ -130,29 +130,12 @@ def _dequeue_op(node_id: str = "dequeue") -> PrimitiveOperation:
     )
 
 
-def _status_op(node_id: str = "status") -> PrimitiveOperation:
-    terminals = [
-        _terminal(f"{node_id}.queue", 0, "input"),
-        _terminal(f"{node_id}.return_elements", 2, "input"),
-        _terminal(f"{node_id}.name", 8, "output"),
-        _terminal(f"{node_id}.elements", 9, "output"),
-    ]
-    return PrimitiveOperation(
-        id=node_id,
-        name="Get Queue Status",
-        labels=["Prim"],
-        node_type="prim",
-        primResID=9109,
-        terminals=terminals,
-    )
-
-
 class TestDispatch:
     """queue_ops.generate() is reachable via the primResID dispatch guard
-    in nodes/__init__.py, not via node_type (all five ops share the
+    in nodes/__init__.py, not via node_type (all four ops share the
     generic ``class="prim"`` XML node_type)."""
 
-    def test_dispatch_guard_covers_all_five_prim_ids(self):
+    def test_dispatch_guard_covers_all_prim_ids(self):
         from lvkit.codegen.nodes import generate as generate_node
 
         for prim_id, op in (
@@ -160,7 +143,6 @@ class TestDispatch:
             (9111, _enqueue_op("enq")),
             (9129, _enqueue_op("enq", opposite_end=True)),
             (9113, _dequeue_op()),
-            (9109, _status_op()),
         ):
             assert op.primResID == prim_id
             ctx = make_ctx(*(t.id for t in op.terminals))
@@ -220,78 +202,6 @@ class TestObtainEnqueueDequeueRoundTrip:
         assert enqueue_frag.bindings["enqueue.queue_out"] == queue_var
         # Only the enqueue_element(...) call itself, no extra "queue_out = queue" line.
         assert len(enqueue_frag.statements) == 1
-
-
-class TestGetQueueStatus:
-    """Get Queue Status's `elements` output is the only wired terminal
-    that reflects queue contents -- pending count is len(elements)."""
-
-    def test_status_count_reflects_pending_items(self):
-        obtain = _obtain_op()
-        enq1 = _enqueue_op("enq1")
-        enq2 = _enqueue_op("enq2")
-        status = _status_op()
-
-        ops = (obtain, enq1, enq2, status)
-        ids = [t.id for op in ops for t in op.terminals]
-        ctx = make_ctx(*ids)
-
-        obtain_frag = queue_ops.generate(obtain, ctx)
-        queue_var = obtain_frag.bindings["obtain.queue_out"]
-
-        ctx.bind("enq1.queue", queue_var)
-        ctx.bind("enq1.element", "'a'")
-        enq1_frag = queue_ops.generate(enq1, ctx)
-
-        ctx.bind("enq2.queue", enq1_frag.bindings["enq1.queue_out"])
-        ctx.bind("enq2.element", "'b'")
-        enq2_frag = queue_ops.generate(enq2, ctx)
-
-        ctx.bind("status.queue", enq2_frag.bindings["enq2.queue_out"])
-        ctx.bind("status.return_elements", "True")
-        status_frag = queue_ops.generate(status, ctx)
-
-        statements = (
-            obtain_frag.statements
-            + enq1_frag.statements
-            + enq2_frag.statements
-            + status_frag.statements
-        )
-        result = _compile_and_run(statements, {})
-
-        elements = result[status_frag.bindings["status.elements"]]
-        assert len(elements) == 2
-        assert elements == ["a", "b"]
-
-    def test_return_elements_false_yields_empty_list(self):
-        """NI docs default for 'return elements?' is FALSE -- the elements
-        output is then empty even with items pending (count is
-        unavailable via this terminal in that case)."""
-        obtain = _obtain_op()
-        enq = _enqueue_op("enq")
-        status = _status_op()
-
-        ops = (obtain, enq, status)
-        ids = [t.id for op in ops for t in op.terminals]
-        ctx = make_ctx(*ids)
-
-        obtain_frag = queue_ops.generate(obtain, ctx)
-        queue_var = obtain_frag.bindings["obtain.queue_out"]
-
-        ctx.bind("enq.queue", queue_var)
-        ctx.bind("enq.element", "'a'")
-        enq_frag = queue_ops.generate(enq, ctx)
-
-        ctx.bind("status.queue", enq_frag.bindings["enq.queue_out"])
-        # return_elements left unwired -> default False
-        status_frag = queue_ops.generate(status, ctx)
-
-        statements = (
-            obtain_frag.statements + enq_frag.statements + status_frag.statements
-        )
-        result = _compile_and_run(statements, {})
-
-        assert result[status_frag.bindings["status.elements"]] == []
 
 
 class TestEnqueueTimeout:


### PR DESCRIPTION
Adds LabVIEW **Event Structure** support (parse → graph → render) and resolves the **event-family primitives** the surrounding VIs use, so real event-driven VIs (JKI VI-Tester, DAQmx, PCO) render, describe, and diff faithfully instead of as unknown boxes. Codegen for these stays deferred (honest placeholders).

## Commits

**1. `event structures: parse + graph + render support`**
- New `parser/nodes/event.py` — `extract_event_structures()` mirrors the case-structure pipeline (frames per registered event, border tunnels, per-frame labels).
- `eventDataNode` added to `OPERATION_NODE_CLASSES` (was falling through the generic-node path — the giant-box render bug); Event Data / Filter Node reuses `NMuxHandler`.
- New `EventStructureNode` / `EventOperation`; registered everywhere `CaseOperation` is enumerated (operations, netlist, describe, diff) so frame contents are walked, not dropped.
- Render: fixed the giant-box bug (`_glyph_bounds()` no longer unions the aggregate terminal's sentinel rect), dashed distinct-colored `event_border`, reuses the case-struct selector chrome, `eventDataNode` draws as inner named rows.
- 13 new parser tests.

**2. `viewer: three-group nowrap header`**
- Shared diff/render viewer header split into titles · controls · legend, each nowrap, collapsing to three rows when narrow; zoom/highlight/theme moved out of the legend into their own controls group.

**3. `primitives: resolve event-family + fix codegen coupling`**
- Resolved 14 primResIDs across the 119 event VIs → named glyphs: User Event (Create/Destroy/Unregister), EventReg (Merge/Register), Flush Queue, Menu ops, To U64, Two Button Dialog, Decimal String To Number. Identities read from real per-terminal types + refnum `ref_type`, confirmed against NI public docs.
- **9109/9110 correction**: 9109 was mislabeled "Get Queue Status" — its 6-terminal pane (no queue_out) is Release Queue per NI docs; the real 11-terminal Get Queue Status is 9110. Both deferred to placeholders; mismapped `get_queue_status` handler + tests removed.
- **`class_builder.py` bug**: `simple_prim_ids` (accessor-classification whitelist) held 4 stale ids (1340/1302/2075/2076 → One Button Dialog / Wait / Destroy User Event / Unregister), so real Merge Errors (2401) was never recognized. Corrected. Bundle/Unbundle are `nMux` node-classes, never affected.
- Dropped two unsound codegen templates (hardcoded dialog result; inline `__import__`).
- Audited the sibling queue prims (9108/9111/9113/9129): observed pane = entry = NI doc for all four — 9109 was the only mislabel.

## Verification
- `pytest`: 1188 passed / 0 failed / 29 skipped · ruff + pyright clean.
- Rendered event VIs (DAQ AO, VI Tester About): event structure draws with border + event-case selector; event-family prims render as named glyphs; no unknown boxes.

## Deferred (tracked on #75)
- Codegen for event structures + the event/menu/queue-status prims (queue-status needs the design-gated queue-runtime work).
- EventSpec type/source decoding for non-displayed frame labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)