### PR TITLE
vscode: rename to pragmatest.lvkit + fix Windows build

### DIFF
--- a/editors/vscode/.gitignore
+++ b/editors/vscode/.gitignore
@@ -6,7 +6,11 @@ bin/
 *.vsix
 node_modules/
 
-# PyInstaller work dirs (if ever created in-tree)
+# PyInstaller work dirs. .pyi-work is now DELIBERATELY in-tree: PyInstaller
+# resolves the entry script relative to --specpath, and on Windows that fails
+# across drives ("path is on mount 'D:', start on mount 'C:'"), which is exactly
+# what a system temp dir causes on GitHub's runners. See build/build-binary.sh.
+build/.pyi-work/
 build/*.spec
 build/dist/
 build/__pycache__/

--- a/editors/vscode/build/build-binary.sh
+++ b/editors/vscode/build/build-binary.sh
@@ -13,6 +13,13 @@ REPO="$(cd "$HERE/../../.." && pwd)"
 cd "$REPO"
 
 PYI="${PYINSTALLER:-pyinstaller}"
+# Keep work/spec dirs INSIDE the repo. PyInstaller does
+# os.path.relpath(entry_script, start=specpath), and on Windows that raises
+# "path is on mount 'D:', start on mount 'C:'" whenever the two land on
+# different drives — which is exactly what happens on GitHub's windows runners:
+# the checkout is on D:, but Git Bash has no TMPDIR so "${TMPDIR:-/tmp}" resolves
+# to C:\...\Temp. A repo-relative path is always on the same drive as the source.
+WORK="editors/vscode/build/.pyi-work"
 "$PYI" --onedir --name lvkit --noconfirm \
   --collect-data lvkit \
   --collect-submodules lvkit \
@@ -20,8 +27,8 @@ PYI="${PYINSTALLER:-pyinstaller}"
   --collect-submodules networkx \
   --exclude-module tkinter --exclude-module matplotlib \
   --distpath editors/vscode/bin \
-  --workpath "${TMPDIR:-/tmp}/pyi-work" \
-  --specpath "${TMPDIR:-/tmp}/pyi-work" \
+  --workpath "$WORK" \
+  --specpath "$WORK" \
   editors/vscode/build/lvkit_entry.py
 
 BIN="editors/vscode/bin/lvkit/lvkit"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "lvkit-vi",
+  "name": "lvkit",
   "displayName": "lvkit — LabVIEW VI Viewer & Diff",
   "description": "View LabVIEW .vi block diagrams and see visual before/after diffs in VS Code — no LabVIEW license required.",
   "version": "0.1.0",


### PR DESCRIPTION
Two fixes surfaced by the aborted `ext-v0.1.0` publish run.

## 1. Rename `lvkit-vi` → `lvkit`

The Marketplace identifier becomes **`pragmatest.lvkit`**, matching the PyPI
package, the CLI, and the brand mark.

On the Marketplace a suffix signals **authorship, not disambiguation** — tool
authors publish under the bare name, third-party wrappers add a suffix:

| Identifier | Suffix | Published by |
|---|---|---|
| `charliermarsh.ruff` | no | Ruff's own author |
| `ms-python.python` | no | Microsoft, owns it |
| `esbenp.prettier-vscode` | yes | *not* the Prettier team |
| `dbaeumer.vscode-eslint` | yes | *not* the ESLint org |

PragmaTest owns lvkit, so the bare name is the accurate signal; `-vi` implied a
third-party wrapper. Publisher namespacing means there was nothing to
disambiguate from anyway (the `vscode-` convention is inherited from npm's flat
global namespace).

`displayName` is unchanged — Marketplace search weights displayName/description/
tags, not the identifier, so it keeps carrying "LabVIEW", "VI", and "diff".

## 2. Fix the Windows build

The win32-x64 job failed before compiling anything:

```
ValueError: path is on mount 'D:', start on mount 'C:'
```

PyInstaller resolves the entry script relative to `--specpath`, and the script
pointed spec/work dirs at `"${TMPDIR:-/tmp}"`. Git Bash on GitHub's Windows
runners has no `TMPDIR`, so that became `C:\...\Temp` while the checkout sits on
`D:` — and `os.path.relpath` cannot cross drives.

Both dirs now live inside the repo, which is by definition on the checkout's
drive. Verified locally end-to-end (binary builds and reports `lvkit 0.5.1`);
the new work dir is gitignored.

## Not addressed here

The macos-14 job failed with `Error occurred while scanning secrets (files)` —
a Marketplace-side scanner error, not our packaging. Possibly aggravated by two
runners publishing the same version concurrently. The next run will show whether
it reproduces; if it does, the fix is to serialize the matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)