### PR TITLE
release: 0.5.2 — fix the version lvkit reports about itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 lvkit follows semantic versioning.
 
+## [0.5.2]
+- **Fix: lvkit reported the wrong version.** The 0.5.1 release bumped
+  `pyproject.toml` but not the hardcoded `__version__` string, so the published
+  package's metadata said `0.5.1` while `lvkit --version` and
+  `lvkit.__version__` both reported `0.5.0`. Anyone checking which lvkit they
+  were running — or gating on it, as the VS Code extension does — got a stale
+  answer. All three version sites (`pyproject.toml`, `src/lvkit/__init__.py`,
+  `uv.lock`) are now synchronized, and `test_version` asserts the code and the
+  installed metadata agree.
+
+  No functional changes to parsing, rendering, diffing, or codegen.
+
 ## [0.5.1]
 - **Event structures:** lvkit now parses, renders, describes, diffs, and
   netlists LabVIEW Event Structures — the border band + timeout hourglass, the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lvkit"
-version = "0.5.1"
+version = "0.5.2"
 description = "Understand and convert LabVIEW VIs to Python without a LabVIEW license"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/lvkit/__init__.py
+++ b/src/lvkit/__init__.py
@@ -1,6 +1,6 @@
 """lvkit - Convert LabVIEW VIs to Python code."""
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 
 from .graph.models import Constant as GraphConstant
 from .graph.models import Wire as GraphWire

--- a/uv.lock
+++ b/uv.lock
@@ -548,7 +548,7 @@ wheels = [
 
 [[package]]
 name = "lvkit"
-version = "0.5.0"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
Patch release. **No functional changes** to parsing, rendering, diffing, or
codegen.

## The bug

0.5.1 bumped `pyproject.toml` but not the hardcoded `__version__` string, so the
package published to PyPI has metadata saying `0.5.1` while `lvkit --version`
and `lvkit.__version__` both report **`0.5.0`**. Anyone checking which lvkit
they're running — or gating on it, as the VS Code extension does via
`MIN_LVKIT` — gets a stale answer.

## Why the test didn't catch it

`tests/test_lvpy.py::test_version` asserts `lvkit.__version__ ==
version("lvkit")`. It passed only because the local editable install's metadata
was *equally* stale at 0.5.0, so both sides of the comparison agreed on the
wrong value. Reinstalling refreshed metadata to 0.5.1 and immediately exposed
the mismatch.

## The fix

A version bump has **three** synchronized sites; this release brings all of them
to 0.5.2:

| Site | Was | Now |
|---|---|---|
| `pyproject.toml` | 0.5.1 | 0.5.2 |
| `src/lvkit/__init__.py` | 0.5.1 | 0.5.2 |
| `uv.lock` | **0.5.0** | 0.5.2 |

Note the lockfile had never been updated for 0.5.1 at all.

Verified after a clean reinstall — metadata, `__version__`, and `lvkit
--version` all report 0.5.2, and the full suite is green (1213 passed, 29
skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)