### PR TITLE
Add Codex skill support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ For a global install: `pipx install lvkit` or `uv tool install lvkit`.
 
 `lvkit setup` creates a `.lvkit/` resolution store and installs AI agent skills:
 
-- Auto-detects Claude Code (`CLAUDE.md` / `.claude/`) and Copilot (`.github/copilot-instructions.md` / `.github/instructions/` / `.github/agents.md`)
-- Pass `claude`, `copilot`, or `all` to be explicit
+- Auto-detects Claude Code (`CLAUDE.md` / `.claude/`), Copilot (`.github/copilot-instructions.md` / `.github/instructions/` / `.github/agents.md`), and Codex (`AGENTS.md` / `AGENTS.override.md` / `.agents/` / `.codex/`)
+- Pass `claude`, `copilot`, `codex`, or `all` to be explicit
 - Use `--no-skills` to create the `.lvkit/` store without installing any skills
 
 | Command | Description |
@@ -110,13 +110,14 @@ The CLI works standalone from any terminal or CI script. For deeper integration,
 
 **VS Code extension** — [**LVKit** on the Marketplace](https://marketplace.visualstudio.com/items?itemName=pragmatest.lvkit). Opening a `.vi` renders its block diagram inline instead of the "binary file" placeholder, and clicking a SubVI opens it. **Open Visual Diff** — right-click a changed `.vi` in Source Control, the Explorer, or the editor tab — shows a before/after block-diagram diff for code review. It ships a bundled lvkit, so it works with no separate install; point the `lvkit.path` setting at a project venv or a PATH install to use your own instead. `.vi` files only today.
 
-**AI agent skills** — install lvkit's built-in workflows into Claude Code or Copilot so your AI agent can describe VIs, convert them, and resolve unknowns without you writing prompts. All five workflows call the CLI under the hood — no MCP server required.
+**AI agent skills** — install lvkit's built-in workflows into Claude Code, GitHub Copilot, or OpenAI Codex so your AI agent can describe VIs, convert them, and resolve unknowns without you writing prompts. All five workflows call the CLI under the hood — no MCP server required.
 
 ```bash
 lvkit setup           # auto-detect from project layout
 lvkit setup claude    # installs .claude/skills/lvkit-*
 lvkit setup copilot   # installs .github/prompts/ + router instruction
-lvkit setup all       # both
+lvkit setup codex     # installs .agents/skills/lvkit-*
+lvkit setup all       # Claude Code, Copilot, and Codex
 ```
 
 Five workflows ship: `lvkit-describe`, `lvkit-convert`, `lvkit-resolve-primitive`, `lvkit-resolve-vilib`, `lvkit-idiomatic`.

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -63,6 +63,18 @@ Add lvkit as an MCP server in your agent's configuration:
 }
 ```
 
+For Codex, add the server to the trusted project's `.codex/config.toml`:
+
+```toml
+[mcp_servers.lvkit]
+command = "uvx"
+args = ["--from", "lvkit", "lvkit-mcp"]
+```
+
+The ChatGPT desktop app, Codex CLI, and Codex IDE extension share this
+project-scoped MCP configuration. `lvkit setup codex` installs workflow
+skills only; it deliberately does not create or modify `.codex/config.toml`.
+
 The agent's runtime starts the server itself over stdio and issues tool calls
 against it — you don't run `lvkit mcp` / `lvkit-mcp` by hand.
 

--- a/docs/reference/setup.md
+++ b/docs/reference/setup.md
@@ -1,13 +1,13 @@
 # setup
 
 Create the project-local `.lvkit/` resolution store, and optionally install AI
-editor skills so an agent (Claude Code, Copilot) can help resolve unknown
-primitives and vi.lib VIs as it works.
+editor skills so an agent (Claude Code, GitHub Copilot, or OpenAI Codex) can
+help resolve unknown primitives and vi.lib VIs as it works.
 
 ## Synopsis
 
 ```bash
-lvkit setup [directory] [{claude,copilot,all}] [options]
+lvkit setup [directory] [{claude,copilot,codex,all}] [options]
 ```
 
 ## Arguments
@@ -15,7 +15,7 @@ lvkit setup [directory] [{claude,copilot,all}] [options]
 | Argument | Description |
 |----------|-------------|
 | `directory` | Directory in which to create `.lvkit/`. Must already exist — `setup` does not create it. Defaults to the current directory. |
-| `{claude,copilot,all}` | Which AI agent to install skills for. `all` installs both the Claude Code and Copilot skill sets. Omit to auto-detect from project layout: `CLAUDE.md` / `.claude/` for Claude Code, `.github/copilot-instructions.md` / `.github/instructions/` / `.github/agents.md` for Copilot. |
+| `{claude,copilot,codex,all}` | Which AI agent to install skills for. `all` installs Claude Code, Copilot, and Codex skill sets. Omit to auto-detect from project layout: `CLAUDE.md` / `.claude/` for Claude Code, `.github/copilot-instructions.md` / `.github/instructions/` / `.github/agents.md` for Copilot, and `AGENTS.md` / `AGENTS.override.md` / `.agents/` / `.codex/` for Codex. |
 
 ## Options
 
@@ -48,15 +48,28 @@ Installed 5 Claude Code skill(s):
 This auto-detects the project's AI agent from its layout, creates `.lvkit/` in
 the current directory, and installs the matching editor skills. Re-running
 with nothing changed prints "Claude Code skills already up to date." instead
-of rewriting the files. If auto-detection finds neither a Claude Code marker
-nor a Copilot marker, `setup` still creates `.lvkit/`, prints "No AI agent
-detected...", and exits `0` with no skills installed.
+of rewriting the files. If auto-detection finds no Claude Code, Copilot, or
+Codex marker, `setup` still creates `.lvkit/`, prints "No AI agent detected...",
+and exits `0` with no skills installed.
 
 To target a specific directory and agent explicitly:
 
 ```bash
 lvkit setup . claude
 ```
+
+For the ChatGPT desktop app, Codex CLI, or the Codex IDE extension:
+
+```bash
+lvkit setup codex
+```
+
+This installs the same five workflows under
+`.agents/skills/<name>/SKILL.md`. ChatGPT and Codex can activate them
+implicitly from their descriptions. In the ChatGPT desktop app, type `@` to
+select a skill. In Codex CLI or the IDE extension, use `$lvkit-describe`,
+`$lvkit-convert`, or another installed skill name. `setup` does not create
+or modify `AGENTS.md` or `.codex/config.toml`.
 
 ## Notes
 
@@ -80,7 +93,9 @@ lvkit setup . claude
   `lvkit-resolve-primitive`, `lvkit-resolve-vilib`, `lvkit-idiomatic`. Copilot
   gets the same five workflows as `.github/prompts/<name>.prompt.md` slash
   commands, plus a single `.github/instructions/lvkit.instructions.md` router
-  that auto-loads into every chat and suggests the right one.
+  that auto-loads into every chat and suggests the right one. Codex gets one
+  Agent Skill per workflow in `.agents/skills/<name>/SKILL.md`; its native
+  skill discovery provides both automatic and explicit invocation.
 - Neither a local LabVIEW install nor a prior [`detect`](detect.md) run is
   required — `setup` creates `.lvkit/` empty regardless. `.lvkit/vilib/` fills
   in later, as `generate`/`render` resolve vi.lib VIs against whatever

--- a/src/lvkit/cli.py
+++ b/src/lvkit/cli.py
@@ -26,6 +26,7 @@ from .project_store import (
     find_project_store,
     init_project_store,
     install_claude_skills,
+    install_codex_skills,
     install_copilot_skills,
 )
 
@@ -462,13 +463,14 @@ def main() -> int:
     setup_parser.add_argument(
         "skills",
         nargs="?",
-        choices=["claude", "copilot", "all"],
+        choices=["claude", "copilot", "codex", "all"],
         default=None,
         help=(
-            "AI agent to install skills for: claude, copilot, or all. "
+            "AI agent to install skills for: claude, copilot, codex, or all. "
             "Omit to auto-detect from project layout (CLAUDE.md / .claude/ "
             "for Claude Code; .github/copilot-instructions.md / "
-            ".github/instructions/ / .github/agents.md for Copilot)."
+            ".github/instructions/ / .github/agents.md for Copilot; "
+            "AGENTS.md / AGENTS.override.md / .agents/ / .codex/ for Codex)."
         ),
     )
     setup_parser.add_argument(
@@ -763,6 +765,13 @@ def _detect_ai_editors(root: Path) -> list[str]:
         or (root / ".github" / "agents.md").is_file()
     ):
         editors.append("copilot")
+    if (
+        (root / "AGENTS.md").is_file()
+        or (root / "AGENTS.override.md").is_file()
+        or (root / ".agents").is_dir()
+        or (root / ".codex").is_dir()
+    ):
+        editors.append("codex")
     return editors
 
 
@@ -772,7 +781,8 @@ def cmd_setup(args: argparse.Namespace) -> int:
     # `lvkit setup copilot` binds "copilot" to `directory`. If the only
     # positional given is a skills choice, treat it as the skills target in
     # the current directory (the obvious intent).
-    if args.skills is None and args.directory in ("claude", "copilot", "all"):
+    skill_choices = ("claude", "copilot", "codex", "all")
+    if args.skills is None and args.directory in skill_choices:
         args.skills = args.directory
         args.directory = "."
 
@@ -790,8 +800,8 @@ def cmd_setup(args: argparse.Namespace) -> int:
     # Resolve which editors to install for
     explicit = args.skills
     if explicit == "all":
-        editors = ["claude", "copilot"]
-    elif explicit in ("claude", "copilot"):
+        editors = ["claude", "copilot", "codex"]
+    elif explicit in ("claude", "copilot", "codex"):
         editors = [explicit]
     else:
         # Auto-detect from project layout
@@ -799,8 +809,9 @@ def cmd_setup(args: argparse.Namespace) -> int:
         if not editors:
             print(
                 "No AI agent detected. If you add one later, run `lvkit setup` again. "
-                "If you have one that wasn't detected, run `lvkit setup claude` or "
-                "`lvkit setup copilot` to install skills explicitly."
+                "If you have one that wasn't detected, run `lvkit setup claude`, "
+                "`lvkit setup copilot`, or `lvkit setup codex` to install skills "
+                "explicitly."
             )
             return 0
 
@@ -829,6 +840,18 @@ def cmd_setup(args: argparse.Namespace) -> int:
                 print(f"  {p}")
         else:
             print("Copilot files already up to date.")
+    if "codex" in editors:
+        try:
+            codex_written = install_codex_skills(root, force=force)
+        except FileExistsError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            return 1
+        if codex_written:
+            print(f"Installed {len(codex_written)} Codex skill(s):")
+            for p in codex_written:
+                print(f"  {p}")
+        else:
+            print("Codex skills already up to date.")
 
     return 0
 

--- a/src/lvkit/project_store.py
+++ b/src/lvkit/project_store.py
@@ -19,9 +19,9 @@ The store is a parallel layout to lvkit's bundled data:
 
 Resolvers load `.lvkit/` first, then fall back to lvkit's bundled data.
 
-This module also installs Claude Code skills and Copilot instructions
-from the packaged templates so downstream users can run lvkit's resolve
-workflows in their own LLM-enabled editor.
+This module also installs Claude Code, GitHub Copilot, and OpenAI Codex
+workflows from the packaged templates so downstream users can run lvkit's
+resolve workflows in their own LLM-enabled editor.
 """
 
 from __future__ import annotations
@@ -92,7 +92,8 @@ mapping and write it here.
 
 If you use Claude Code, run `lvkit init --skills claude` to install
 resolution skills into your project's `.claude/skills/`. For Copilot or
-Cursor, use `lvkit init --skills copilot`.
+Cursor, use `lvkit init --skills copilot`. For Codex, run
+`lvkit setup codex`; skills are installed into `.agents/skills/`.
 """
 
 
@@ -165,9 +166,9 @@ def init_project_store(root: Path) -> Path:
 # lvkit ships user-facing skill templates as package data under
 # `src/lvkit/skill_templates/lvkit-<name>/SKILL.md`. The functions below
 # install them into a downstream user's project so the user's LLM
-# editor (Claude Code, Copilot, Cursor) can run lvkit's workflows.
+# editor (Claude Code, GitHub Copilot, OpenAI Codex) can run lvkit's workflows.
 #
-# Two install targets:
+# Three install targets:
 #
 # - install_claude_skills(): copies SKILL.md files to .claude/skills/
 #   one-for-one. Claude Code reads them as auto-launchable skills.
@@ -177,6 +178,10 @@ def init_project_store(root: Path) -> Path:
 #   .github/instructions/lvkit.instructions.md router that auto-loads
 #   into every chat with a short list of available prompts. This dual
 #   pattern matches Claude Code's auto + explicit skill semantics.
+#
+# - install_codex_skills(): writes Agent Skills to .agents/skills/. Codex
+#   natively supports both description-based implicit activation and explicit
+#   $<name> mentions, so it does not need a separate router file.
 
 # Marker comment lvkit embeds in every generated Copilot file so users
 # (and re-installs) can recognize a lvkit-managed file.
@@ -360,6 +365,60 @@ def install_copilot_skills(
     return written
 
 
+def install_codex_skills(target_dir: Path, force: bool = False) -> list[Path]:
+    """Install lvkit's workflows as repository-scoped Codex skills.
+
+    Each packaged ``SKILL.md`` is converted to the Agent Skills shape Codex
+    consumes and written to
+    ``<target_dir>/.agents/skills/<name>/SKILL.md``. The conversion preserves
+    the portable ``name`` and ``description`` metadata, drops the
+    Claude-specific ``allowed-tools`` field, and rewrites cross-skill slash
+    commands to Codex's explicit ``$skill-name`` mention syntax.
+
+    Atomic with respect to local-edit detection: every destination is
+    validated before any skill file is written.
+
+    Args:
+        target_dir: Project root. The ``.agents/skills/`` tree is created
+            under this directory.
+        force: Overwrite existing files even if they have local edits.
+
+    Returns:
+        List of paths that were written or overwritten. Empty when all
+        installed skills are already up to date.
+    """
+    plan: list[tuple[Path, str]] = []
+    conflicts: list[Path] = []
+
+    for skill_dir in _iter_skill_templates():
+        template_file = skill_dir.joinpath("SKILL.md")
+        if not template_file.is_file():
+            raise ValueError(
+                f"Skill template directory {skill_dir.name!r} is missing"
+                " its SKILL.md — packaging or sync error."
+            )
+        skill_content = _build_codex_skill(
+            template_file.read_text(encoding="utf-8")
+        )
+        dest = target_dir / ".agents" / "skills" / skill_dir.name / "SKILL.md"
+        _stage_write(dest, skill_content, force, plan, conflicts)
+
+    if conflicts:
+        names = "\n  ".join(str(p) for p in conflicts)
+        raise FileExistsError(
+            f"{len(conflicts)} Codex skill file(s) have local edits and would"
+            f" be overwritten:\n  {names}\n"
+            "Re-run with force=True to overwrite."
+        )
+
+    written: list[Path] = []
+    for dest, new_content in plan:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(new_content, encoding="utf-8")
+        written.append(dest)
+    return written
+
+
 def _stage_write(
     dest: Path,
     new_content: str,
@@ -369,8 +428,8 @@ def _stage_write(
 ) -> None:
     """Add (dest, content) to plan, or to conflicts if local-edited.
 
-    Shared by ``install_claude_skills`` and ``install_copilot_skills``
-    for their atomic phase splits: phase 1 calls this for every
+    Shared by all skill installers for their atomic phase splits: phase 1
+    calls this for every
     destination so phase 2 can either commit everything in one pass or
     raise a single error listing every conflict. Files that already
     match the new content are silently skipped (not added to plan,
@@ -405,6 +464,47 @@ def _build_copilot_prompt(skill_md: str) -> str:
         f"description: {_yaml_quote(description)}\n"
         "---\n"
         f"{_COPILOT_MANAGED_MARKER}\n"
+        "\n"
+        f"{body.lstrip()}"
+    )
+
+
+def _build_codex_skill(skill_md: str) -> str:
+    """Build a Codex-compatible Agent Skill from a packaged SKILL.md.
+
+    Codex only needs the portable skill metadata and reads repository skills
+    from ``.agents/skills``. Internal references use ``$name`` because Codex
+    exposes explicit skill invocation through skill mentions rather than
+    per-skill slash commands. Obsolete CLI commands are removed or updated in
+    the Codex copy without changing the shared templates.
+    """
+    fm, body = _split_frontmatter(skill_md)
+    name = _yaml_get(fm, "name")
+    description = _yaml_get(fm, "description")
+    if not name or not description:
+        raise ValueError("Codex skill templates require name and description")
+
+    for skill_name in _SKILL_ORDER:
+        body = body.replace(f"/{skill_name}", f"${skill_name}")
+    body = body.replace("lvkit init", "lvkit setup")
+    body = "".join(
+        line
+        for line in body.splitlines(keepends=True)
+        if not line.lstrip().startswith(("lvkit llm-generate ", "lvkit check "))
+    )
+    if "python3 -c" in body or "grep -" in body:
+        body = (
+            "> **Shell compatibility:** Examples below use POSIX syntax. On "
+            "Windows, run them in WSL or Git Bash, or use equivalent "
+            "PowerShell commands.\n\n"
+            f"{body.lstrip()}"
+        )
+
+    return (
+        "---\n"
+        f"name: {name}\n"
+        f"description: {_yaml_quote(description)}\n"
+        "---\n"
         "\n"
         f"{body.lstrip()}"
     )

--- a/src/lvkit/skill_templates/__init__.py
+++ b/src/lvkit/skill_templates/__init__.py
@@ -3,10 +3,9 @@
 lvkit ships these as package data so `lvkit init --skills` can install
 them into a downstream user's project via importlib.resources. Each
 skill lives under `<name>/SKILL.md` directly under this package — they
-are the canonical source of truth for both the Claude Code install
-path AND the Copilot install path. (Copilot's install builds a single
-file dynamically from these templates; see
-``project_store._build_copilot_section``.)
+are the canonical source of truth for the Claude Code, Copilot, and
+Codex install paths. Copilot prompts and Codex skills are built
+dynamically from these templates; see ``lvkit.project_store``.
 
 The in-repo `.claude/skills/` copies of these skills are byte-identical
 mirrors kept in sync by `scripts/sync_skills.sh`. The two maintainer-

--- a/tests/test_project_store.py
+++ b/tests/test_project_store.py
@@ -232,6 +232,7 @@ def test_cli_setup_creates_project_store(tmp_path: Path) -> None:
     assert (tmp_path / ".lvkit" / "README.md").exists()
     assert (tmp_path / ".lvkit" / "vilib" / "_index.json").exists()
     assert not (tmp_path / ".claude").exists()
+    assert not (tmp_path / ".agents").exists()
 
 
 def test_cli_setup_skills_choice_is_not_a_directory(tmp_path: Path) -> None:
@@ -249,6 +250,55 @@ def test_cli_setup_skills_choice_is_not_a_directory(tmp_path: Path) -> None:
     assert "Not a directory" not in result.stderr
     assert (tmp_path / ".lvkit").is_dir()
     assert (tmp_path / ".github" / "prompts").is_dir()   # copilot skills, in CWD
+
+
+def test_cli_setup_codex_choice_is_not_a_directory(tmp_path: Path) -> None:
+    """`lvkit setup codex` installs Codex skills in CWD."""
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [sys.executable, "-m", "lvkit.cli", "setup", "codex"],
+        cwd=tmp_path, capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Not a directory" not in result.stderr
+    assert (tmp_path / ".lvkit").is_dir()
+    assert (tmp_path / ".agents" / "skills" / "lvkit-convert").is_dir()
+
+
+def test_cli_setup_auto_detects_codex(tmp_path: Path) -> None:
+    """A Codex project marker makes bare `lvkit setup` install Codex skills."""
+    import subprocess
+    import sys
+
+    (tmp_path / "AGENTS.md").write_text("# Project instructions\n")
+    result = subprocess.run(
+        [sys.executable, "-m", "lvkit.cli", "setup"],
+        cwd=tmp_path, capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Installed 5 Codex skill(s)" in result.stdout
+    assert (
+        tmp_path / ".agents" / "skills" / "lvkit-describe" / "SKILL.md"
+    ).is_file()
+
+
+def test_cli_setup_without_agent_marker_installs_no_skills(tmp_path: Path) -> None:
+    """Bare setup remains successful when no supported agent is configured."""
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [sys.executable, "-m", "lvkit.cli", "setup"],
+        cwd=tmp_path, capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "No AI agent detected" in result.stdout
+    assert (tmp_path / ".lvkit").is_dir()
+    assert not (tmp_path / ".agents").exists()
+    assert not (tmp_path / ".claude").exists()
+    assert not (tmp_path / ".github").exists()
 
 
 # ============================================================
@@ -511,6 +561,116 @@ def test_install_copilot_skills_force_overwrites(tmp_path: Path) -> None:
     assert "mode: agent" in edited.read_text()
 
 
+# ============================================================
+# Codex install: 5 repository-scoped Agent Skills
+# ============================================================
+
+
+def test_install_codex_skills_writes_agent_skills(tmp_path: Path) -> None:
+    """Codex gets all workflows under .agents/skills with portable metadata."""
+    from lvkit.project_store import install_codex_skills
+
+    written = install_codex_skills(tmp_path)
+    assert len(written) == len(_LVKIT_SKILLS)
+
+    skills_dir = tmp_path / ".agents" / "skills"
+    for skill in _LVKIT_SKILLS:
+        path = skills_dir / skill / "SKILL.md"
+        assert path.is_file(), f"missing {path}"
+        text = path.read_text()
+        assert text.startswith("---\n")
+        assert f"name: {skill}" in text
+        assert "description:" in text
+        assert "allowed-tools:" not in text
+        assert f"/{skill}" not in text
+        assert "lvkit init" not in text
+        assert "lvkit llm-generate" not in text
+        assert "lvkit check" not in text
+
+    convert = (skills_dir / "lvkit-convert" / "SKILL.md").read_text()
+    assert "$lvkit-resolve-primitive" in convert
+    assert "$lvkit-resolve-vilib" in convert
+    assert "$lvkit-idiomatic" in convert
+    assert "lvkit setup" in convert
+
+    primitive = (
+        skills_dir / "lvkit-resolve-primitive" / "SKILL.md"
+    ).read_text()
+    assert "Shell compatibility" in primitive
+    assert "PowerShell" in primitive
+
+
+def test_install_codex_skills_is_idempotent(tmp_path: Path) -> None:
+    """Reinstalling unchanged Codex skills does not rewrite them."""
+    from lvkit.project_store import install_codex_skills
+
+    install_codex_skills(tmp_path)
+    second = install_codex_skills(tmp_path)
+    assert second == []
+
+
+def test_install_codex_skills_atomic_on_conflict(tmp_path: Path) -> None:
+    """A locally edited Codex skill aborts the whole install."""
+    from lvkit.project_store import install_codex_skills
+
+    skills_dir = tmp_path / ".agents" / "skills"
+    conflict = skills_dir / "lvkit-convert" / "SKILL.md"
+    conflict.parent.mkdir(parents=True)
+    conflict.write_text("LOCAL EDIT\n")
+
+    with pytest.raises(FileExistsError, match="local edits"):
+        install_codex_skills(tmp_path)
+
+    for skill in _LVKIT_SKILLS:
+        path = skills_dir / skill / "SKILL.md"
+        if skill == "lvkit-convert":
+            assert path.read_text() == "LOCAL EDIT\n"
+        else:
+            assert not path.exists()
+
+
+def test_install_codex_skills_force_overwrites(tmp_path: Path) -> None:
+    """--force replaces locally edited Codex skills."""
+    from lvkit.project_store import install_codex_skills
+
+    install_codex_skills(tmp_path)
+    edited = tmp_path / ".agents" / "skills" / "lvkit-convert" / "SKILL.md"
+    edited.write_text("LOCAL EDIT\n")
+
+    install_codex_skills(tmp_path, force=True)
+    text = edited.read_text()
+    assert "LOCAL EDIT" not in text
+    assert "name: lvkit-convert" in text
+
+
+@pytest.mark.parametrize(
+    "marker",
+    ["AGENTS.md", "AGENTS.override.md", ".agents", ".codex"],
+)
+def test_detect_ai_editors_recognizes_codex_markers(
+    tmp_path: Path, marker: str,
+) -> None:
+    """Every supported Codex project marker enables Codex auto-detection."""
+    from lvkit.cli import _detect_ai_editors
+
+    path = tmp_path / marker
+    if marker.startswith("."):
+        path.mkdir()
+    else:
+        path.write_text("# Codex instructions\n")
+    assert _detect_ai_editors(tmp_path) == ["codex"]
+
+
+def test_detect_ai_editors_can_return_all_agents(tmp_path: Path) -> None:
+    """Auto-detection installs every agent configured in a mixed project."""
+    from lvkit.cli import _detect_ai_editors
+
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".github" / "instructions").mkdir(parents=True)
+    (tmp_path / ".agents").mkdir()
+    assert _detect_ai_editors(tmp_path) == ["claude", "copilot", "codex"]
+
+
 def test_cli_setup_skills_claude(tmp_path: Path) -> None:
     """`lvkit setup claude` installs Claude Code skills."""
     import subprocess
@@ -531,8 +691,28 @@ def test_cli_setup_skills_claude(tmp_path: Path) -> None:
     ).is_file()
 
 
+def test_cli_setup_skills_codex(tmp_path: Path) -> None:
+    """`lvkit setup codex` installs repository-scoped Codex skills."""
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "lvkit.cli", "setup",
+            str(tmp_path), "codex",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert "Installed 5 Codex skill(s)" in result.stdout
+    assert (
+        tmp_path / ".agents" / "skills" / "lvkit-convert" / "SKILL.md"
+    ).is_file()
+
+
 def test_cli_setup_skills_all(tmp_path: Path) -> None:
-    """`lvkit setup all` installs both Claude and Copilot."""
+    """`lvkit setup all` installs Claude, Copilot, and Codex."""
     import subprocess
     import sys
 
@@ -547,6 +727,7 @@ def test_cli_setup_skills_all(tmp_path: Path) -> None:
     )
     assert "Installed 5 Claude Code skill(s)" in result.stdout
     assert "Installed 6 Copilot file(s)" in result.stdout  # 5 prompts + router
+    assert "Installed 5 Codex skill(s)" in result.stdout
     assert (
         tmp_path / ".claude" / "skills" / "lvkit-resolve-primitive" / "SKILL.md"
     ).is_file()
@@ -555,6 +736,9 @@ def test_cli_setup_skills_all(tmp_path: Path) -> None:
     ).is_file()
     assert (
         tmp_path / ".github" / "instructions" / "lvkit.instructions.md"
+    ).is_file()
+    assert (
+        tmp_path / ".agents" / "skills" / "lvkit-convert" / "SKILL.md"
     ).is_file()
 
 


### PR DESCRIPTION
## Summary

- add `lvkit setup codex` and Codex project auto-detection
- install the five existing workflows under `.agents/skills`
- document skill invocation and project-level MCP configuration

## Scope

This adds Codex support alongside the existing Claude Code and GitHub Copilot setup behavior. It does not modify the shared skill templates, create `AGENTS.md`, or write `.codex/config.toml`.

## Validation

- `tests/test_project_store.py`: 47 passed
- `ruff check .`: passed
- `python -m pyright src/`: 0 errors, 0 warnings
- packaged, non-editable tool install with `PYTHONUTF8` unset: passed
- `lvkit setup codex` against a Unicode target path: installed 5 skills
- full suite: 1090 passed, 213 skipped, 8 failed; the same 8 failures reproduce on unmodified upstream `main` in this Windows/Python 3.10 environment (seven Python exec-scope cases and one installed-LabVIEW assumption)