### PR TITLE
Fix localized LabVIEW text decoding

### DIFF
--- a/src/lvkit/extractor.py
+++ b/src/lvkit/extractor.py
@@ -36,6 +36,10 @@ from lvkit.cache_paths import (  # noqa: E402
     meta_fresh,
     migrate_legacy_extract,
 )
+from lvkit.text_encoding import (  # noqa: E402
+    labview_text_encoding,
+    normalize_extracted_xml,
+)
 
 
 def _cache_target(vi_path: Path) -> Path:
@@ -56,6 +60,7 @@ def _write_cache_meta(vi_path: Path, meta_path: Path) -> None:
     write_meta(
         vi_path, meta_path,
         source=source, tool="pylabview", extracted_at=time.time(),
+        text_encoding=labview_text_encoding(),
     )
 
 
@@ -98,6 +103,13 @@ def _extract_in_process(vi_path: Path, output_dir: Path, vi_stem: str) -> None:
     tree = _lv_xml.ElementTree(root)
     with open(xml_path, "wb") as xml_fh:
         tree.write(xml_fh, encoding="utf-8", xml_declaration=True)
+    for path in output_dir.iterdir():
+        belongs_to_vi = (
+            path.name == f"{vi_stem}.xml"
+            or path.name.startswith(f"{vi_stem}_")
+        )
+        if path.suffix == ".xml" and belongs_to_vi:
+            normalize_extracted_xml(path)
 
 
 def extract_vi_xml(
@@ -140,7 +152,15 @@ def extract_vi_xml(
 
     # Cache hit: XML present and the recorded content-hash (or mtime/size
     # fast-path) still matches the VI.
-    if not force and bd_xml.exists() and meta_fresh(vi_path, meta_path):
+    if (
+        not force
+        and bd_xml.exists()
+        and meta_fresh(
+            vi_path,
+            meta_path,
+            extra={"text_encoding": labview_text_encoding()},
+        )
+    ):
         return (
             bd_xml,
             fp_xml if fp_xml.exists() else None,
@@ -222,7 +242,11 @@ def _open_llb_vi(llb_path: Path) -> Any:
         store_as_data_above=4095,
     )
     with open(llb_path, "rb") as fh:
-        vi = lvrsrc.VI(po, rsrc_fh=fh, text_encoding="mac_roman")
+        vi = lvrsrc.VI(
+            po,
+            rsrc_fh=fh,
+            text_encoding=labview_text_encoding(),
+        )
     return vi
 
 
@@ -319,5 +343,4 @@ def extract_llb(llb_path: Path) -> Path:
         pass
 
     return cache_dir
-
 

--- a/src/lvkit/output_cache.py
+++ b/src/lvkit/output_cache.py
@@ -16,8 +16,9 @@ Addressing mirrors extraction (see :mod:`lvkit.cache_paths`):
   flat ``<cache>/render/adhoc/<sha>.<ext>`` and swept by TTL.
 
 Freshness = the VI-content signal ``cache_paths.meta_fresh`` already uses PLUS
-the lvkit ``version`` and an ``options`` tag — so a VI edit, an lvkit upgrade, or
-a different ``--format``/``--theme`` is a miss.
+the lvkit ``version``, text encoding, and an ``options`` tag — so a VI edit, an
+lvkit upgrade, a system-code-page change, or different ``--format``/``--theme``
+is a miss.
 """
 
 from __future__ import annotations
@@ -27,6 +28,7 @@ import time
 from pathlib import Path
 
 from lvkit import cache_paths
+from lvkit.text_encoding import labview_text_encoding
 
 # The genuinely-growing surfaces get an access-time TTL (a diff/adhoc entry is
 # worthless once its inputs move on — regenerate on demand). Path-addressed
@@ -149,7 +151,11 @@ def lookup_render(
     body_path, meta_path, _adhoc = _render_paths(input_path, fmt)
     return _read_if_fresh(
         input_path, body_path, meta_path,
-        {"lvkit_version": version, "options": options},
+        {
+            "lvkit_version": version,
+            "options": options,
+            "text_encoding": labview_text_encoding(),
+        },
     )
 
 
@@ -160,7 +166,12 @@ def store_render(
     body_path, meta_path, _adhoc = _render_paths(input_path, fmt)
     _write(
         body_path, meta_path, input_path, body,
-        {"lvkit_version": version, "options": options, "kind": "render"},
+        {
+            "lvkit_version": version,
+            "options": options,
+            "kind": "render",
+            "text_encoding": labview_text_encoding(),
+        },
     )
     return body_path
 
@@ -174,7 +185,12 @@ def lookup_diff(
     )
     return _read_if_fresh(
         after_path, body_path, meta_path,
-        {"lvkit_version": version, "options": options, "before_sha": before_sha},
+        {
+            "lvkit_version": version,
+            "options": options,
+            "before_sha": before_sha,
+            "text_encoding": labview_text_encoding(),
+        },
     )
 
 
@@ -191,6 +207,7 @@ def store_diff(
         {
             "lvkit_version": version, "options": options,
             "before_sha": before_sha, "kind": "diff",
+            "text_encoding": labview_text_encoding(),
         },
     )
     return body_path

--- a/src/lvkit/parser/metadata.py
+++ b/src/lvkit/parser/metadata.py
@@ -8,6 +8,8 @@ import xml.etree.ElementTree as ET
 from pathlib import Path
 from typing import Any
 
+from lvkit.text_encoding import decode_labview_text
+
 from .models import ParsedDependencyRef
 from .type_resolution import parse_typedef_refs
 
@@ -231,7 +233,7 @@ def parse_iuse_from_libd(libd_path: Path) -> dict[str, str]:
            [PTH0 path-to-VI] [...] \\x00\\x00\\x00\\x01 [4-byte iUse UID]
            [PTH0 path-to-class]
 
-    Both names are pascal strings: 1-byte length prefix + data (mac_roman).
+    Both names are Pascal strings: 1-byte length prefix + native text data.
     The \\x00\\x02 is a 2-item count sentinel that appears within the first
     8 bytes after the IUVI tag.
     """
@@ -263,7 +265,7 @@ def parse_iuse_from_libd(libd_path: Path) -> dict[str, str]:
         p += 1
         if p + class_len > record_end:
             continue
-        class_name = data[p : p + class_len].decode("mac_roman", errors="replace")
+        class_name = decode_labview_text(data[p : p + class_len])
         p += class_len
 
         # Pascal string 2: VI name (e.g. "TestCase_Init.vi")
@@ -273,7 +275,7 @@ def parse_iuse_from_libd(libd_path: Path) -> dict[str, str]:
         p += 1
         if p + vi_len > record_end or not vi_len:
             continue
-        vi_name = data[p : p + vi_len].decode("mac_roman", errors="replace")
+        vi_name = decode_labview_text(data[p : p + vi_len])
 
         if not vi_name.endswith(".vi"):
             continue  # sanity check — skip malformed records

--- a/src/lvkit/parser/nodes/case.py
+++ b/src/lvkit/parser/nodes/case.py
@@ -6,6 +6,7 @@ import re
 import xml.etree.ElementTree as ET
 
 from lvkit.models import CaseFrame, SelectorRange, Tunnel
+from lvkit.text_encoding import decode_labview_text
 
 from ..constants import TERMINAL_CLASS
 from ..models import ParsedCaseStructure, ParsedTerminalInfo, SelectorTable
@@ -238,9 +239,9 @@ def _extract_one_case_structure(
                 hex_text = item.text or ""
                 try:
                     string_labels.append(
-                        bytes.fromhex(hex_text).decode("utf-8")
+                        decode_labview_text(bytes.fromhex(hex_text))
                     )
-                except (ValueError, UnicodeDecodeError):
+                except ValueError:
                     string_labels.append(hex_text)
 
     # Detect default case: SelectDefaultCase holds the hex diagram index of

--- a/src/lvkit/parser/vi.py
+++ b/src/lvkit/parser/vi.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 from lvkit.extractor import extract_vi_xml
 from lvkit.models import LVType
+from lvkit.text_encoding import decode_labview_text
 
 from .constants import (
     FP_TERMINAL_CLASS,
@@ -1072,7 +1073,7 @@ def _decode_path_default(data: bytes) -> str | None:
             str_len = data[idx]
             idx += 1
             if str_len > 0 and idx + str_len <= len(data):
-                part = data[idx:idx + str_len].decode('latin-1', errors='replace')
+                part = decode_labview_text(data[idx : idx + str_len])
                 parts.append(part)
                 idx += str_len
             else:
@@ -1092,10 +1093,10 @@ def _decode_string_default(data: bytes) -> str | None:
             return None
         length = int.from_bytes(data[:4], 'big')
         if len(data) >= 4 + length:
-            string_val = data[4:4 + length].decode('latin-1')
+            string_val = decode_labview_text(data[4 : 4 + length])
             escaped = string_val.replace('\\', '\\\\').replace('"', '\\"')
             return f'"{escaped}"'
-    except (ValueError, UnicodeDecodeError):
+    except ValueError:
         pass
     return None
 
@@ -1144,7 +1145,7 @@ def _decode_element(data: bytes, elem_type: LVType | None) -> tuple[str | None, 
         str_len = int.from_bytes(data[:4], 'big')
         if len(data) < 4 + str_len:
             return None, 0
-        string_val = data[4:4 + str_len].decode('latin-1', errors='replace')
+        string_val = decode_labview_text(data[4 : 4 + str_len])
         escaped = string_val.replace('\\', '\\\\').replace("'", "\\'")
         return f"'{escaped}'", 4 + str_len
 
@@ -1264,5 +1265,4 @@ def _get_numeric_size(type_name: str) -> int:
     elif "64" in type_name:
         return 8
     return 4  # Default
-
 

--- a/src/lvkit/text_encoding.py
+++ b/src/lvkit/text_encoding.py
@@ -1,0 +1,83 @@
+"""Text encoding helpers for LabVIEW resource data."""
+
+from __future__ import annotations
+
+import locale
+import os
+import re
+import sys
+from pathlib import Path
+
+_PYLABVIEW_ENCODING = "mac_roman"
+_XML_TOKEN_RE = re.compile(
+    r"(<!\[CDATA\[.*?\]\]>|<!--.*?-->|<[^>]*>)",
+    re.DOTALL,
+)
+_XML_QUOTED_RE = re.compile(r"""(["'])(.*?)\1""", re.DOTALL)
+
+
+def _windows_ansi_encoding() -> str:
+    import ctypes
+
+    try:
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        get_acp = kernel32.GetACP
+        get_acp.restype = ctypes.c_uint
+        return f"cp{get_acp()}"
+    except (AttributeError, OSError):
+        return "mbcs"
+
+
+def labview_text_encoding() -> str:
+    """Return the native text encoding used by LabVIEW on this platform."""
+    if sys.platform == "win32":
+        return _windows_ansi_encoding()
+    if sys.platform == "darwin":
+        return _PYLABVIEW_ENCODING
+    return locale.getpreferredencoding(False) or "utf-8"
+
+
+def decode_labview_text(data: bytes, encoding: str | None = None) -> str:
+    """Decode a LabVIEW byte string without discarding the surrounding data."""
+    return data.decode(encoding or labview_text_encoding(), errors="replace")
+
+
+def _transcode_fragment(text: str, target: str) -> str:
+    raw = text.encode(_PYLABVIEW_ENCODING, errors="xmlcharrefreplace")
+    return raw.decode(target, errors="replace")
+
+
+def _transcode_xml_token(token: str, target: str) -> str:
+    if token.startswith("<![CDATA["):
+        return f"<![CDATA[{_transcode_fragment(token[9:-3], target)}]]>"
+    if token.startswith("<!--"):
+        return f"<!--{_transcode_fragment(token[4:-3], target)}-->"
+    if token.startswith("<"):
+        return _XML_QUOTED_RE.sub(
+            lambda match: (
+                match.group(1)
+                + _transcode_fragment(match.group(2), target)
+                + match.group(1)
+            ),
+            token,
+        )
+    return _transcode_fragment(token, target)
+
+
+def normalize_extracted_xml(path: Path, encoding: str | None = None) -> None:
+    """Convert pylabview's lossless Mac Roman byte mapping to native text."""
+    target = encoding or labview_text_encoding()
+    if target == _PYLABVIEW_ENCODING:
+        return
+
+    text = path.read_text(encoding="utf-8")
+    normalized = "".join(
+        _transcode_xml_token(token, target)
+        for token in _XML_TOKEN_RE.split(text)
+        if token
+    )
+    normalized = normalized.replace('Encoding="mac_roman"', f'Encoding="{target}"')
+
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(normalized, encoding="utf-8")
+    os.replace(tmp, path)

--- a/src/lvkit/text_encoding.py
+++ b/src/lvkit/text_encoding.py
@@ -71,6 +71,9 @@ def normalize_extracted_xml(path: Path, encoding: str | None = None) -> None:
         return
 
     text = path.read_text(encoding="utf-8")
+    # Pure ASCII is identical under mac_roman, nothing to transcode.
+    if text.isascii():
+        return
     normalized = "".join(
         _transcode_xml_token(token, target)
         for token in _XML_TOKEN_RE.split(text)

--- a/src/lvkit/text_encoding.py
+++ b/src/lvkit/text_encoding.py
@@ -30,6 +30,10 @@ def _windows_ansi_encoding() -> str:
 
 def labview_text_encoding() -> str:
     """Return the native text encoding used by LabVIEW on this platform."""
+    # Override for a VI saved in a different locale than the reader's machine.
+    override = os.environ.get("LVKIT_TEXT_ENCODING")
+    if override:
+        return override
     if sys.platform == "win32":
         return _windows_ansi_encoding()
     if sys.platform == "darwin":

--- a/tests/test_case_parser.py
+++ b/tests/test_case_parser.py
@@ -163,6 +163,24 @@ class TestStringSelector:
         assert cs.frames[1].selector_value == "beta"
         assert cs.frames[2].selector_value == "gamma"
 
+    def test_string_uses_labview_code_page(self, monkeypatch):
+        monkeypatch.setattr(
+            "lvkit.text_encoding.labview_text_encoding",
+            lambda: "gbk",
+        )
+        root = _build_case_xml(
+            "cs1",
+            "sel1",
+            select_ranges=[(0, 0)],
+            string_array=["初始化".encode("gbk").hex()],
+            num_diags=1,
+        )
+        ti = _make_terminal_info("sel1", "String")
+
+        cases = extract_case_structures(root, ti)
+
+        assert cases[0].frames[0].selector_value == "初始化"
+
     def test_string_without_terminal_info_falls_back(self):
         """Without terminal_info, string cases get raw integer values."""
         root = _build_case_xml(

--- a/tests/test_extraction_cache.py
+++ b/tests/test_extraction_cache.py
@@ -205,6 +205,28 @@ class TestLegacyMigration:
 
 
 class TestCacheFreshness:
+    def test_text_encoding_change_invalidates(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        vi = tmp_path / "x.vi"
+        vi.write_bytes(b"same bytes")
+        meta = tmp_path / "x.meta.json"
+        monkeypatch.setattr(extractor, "labview_text_encoding", lambda: "gbk")
+        extractor._write_cache_meta(vi, meta)
+
+        assert cache_paths.meta_fresh(
+            vi,
+            meta,
+            extra={"text_encoding": "gbk"},
+        )
+        assert not cache_paths.meta_fresh(
+            vi,
+            meta,
+            extra={"text_encoding": "cp1252"},
+        )
+
     def test_touch_hits_fastpath_content_edit_invalidates(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_output_cache.py
+++ b/tests/test_output_cache.py
@@ -63,6 +63,22 @@ class TestRenderCache:
         output_cache.store_render(vi, "html", OPT, V, "OUT")
         assert output_cache.lookup_render(vi, "html", "svg|dark", V) is None
 
+    def test_text_encoding_change_invalidates(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        vi = _project_vi(tmp_path)
+        monkeypatch.setattr(output_cache, "labview_text_encoding", lambda: "gbk")
+        output_cache.store_render(vi, "html", OPT, V, "OUT")
+        monkeypatch.setattr(
+            output_cache,
+            "labview_text_encoding",
+            lambda: "cp1252",
+        )
+
+        assert output_cache.lookup_render(vi, "html", OPT, V) is None
+
     def test_overwrite_in_place_one_slot(self, tmp_path: Path) -> None:
         """A path-addressed VI has exactly ONE render slot; a re-store after an
         edit overwrites it (no accumulation)."""

--- a/tests/test_text_encoding.py
+++ b/tests/test_text_encoding.py
@@ -1,0 +1,119 @@
+"""Regression tests for localized LabVIEW text."""
+
+from __future__ import annotations
+
+import struct
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+
+from lvkit.models import LVType
+from lvkit.parser.metadata import parse_iuse_from_libd
+from lvkit.parser.vi import _decode_default_data, _decode_element
+from lvkit.text_encoding import (
+    decode_labview_text,
+    labview_text_encoding,
+    normalize_extracted_xml,
+)
+
+
+def _byte_entities(data: bytes) -> str:
+    return "".join(f"&#x{value:02X};" for value in data)
+
+
+def test_normalize_extracted_xml_restores_native_text(tmp_path: Path) -> None:
+    path = tmp_path / "中文.xml"
+    mojibake = "当前状态".encode("gbk").decode("mac_roman")
+    path.write_text(
+        f'<RSRC Encoding="mac_roman"><Name>{mojibake}</Name><Note>🙂</Note></RSRC>',
+        encoding="utf-8",
+    )
+
+    normalize_extracted_xml(path, "gbk")
+
+    root = ET.parse(path).getroot()
+    assert root.get("Encoding") == "gbk"
+    assert root.findtext("Name") == "当前状态"
+    assert root.findtext("Note") == "🙂"
+
+
+def test_normalize_resets_decoder_at_xml_boundaries(tmp_path: Path) -> None:
+    path = tmp_path / "binary.xml"
+    dangling_lead_byte = b"\x81".decode("mac_roman")
+    path.write_text(
+        f"<Root><Value><![CDATA[{dangling_lead_byte}]]></Value>"
+        "<Next>intact</Next></Root>",
+        encoding="utf-8",
+    )
+
+    normalize_extracted_xml(path, "gbk")
+
+    root = ET.parse(path).getroot()
+    assert root.findtext("Value") == "�"
+    assert root.findtext("Next") == "intact"
+
+
+def test_decode_labview_text_uses_requested_code_page() -> None:
+    assert decode_labview_text("打开连接".encode("gbk"), "gbk") == "打开连接"
+
+
+def test_windows_uses_active_ansi_code_page(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("lvkit.text_encoding.sys.platform", "win32")
+    monkeypatch.setattr(
+        "lvkit.text_encoding._windows_ansi_encoding",
+        lambda: "cp936",
+    )
+    assert labview_text_encoding() == "cp936"
+
+
+def test_string_defaults_and_constants_use_labview_encoding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "lvkit.text_encoding.labview_text_encoding",
+        lambda: "gbk",
+    )
+    encoded = "打开连接".encode("gbk")
+    data = len(encoded).to_bytes(4, "big") + encoded
+
+    assert (
+        _decode_default_data(
+            _byte_entities(data),
+            "stdString",
+        )
+        == '"打开连接"'
+    )
+    assert _decode_element(
+        data,
+        LVType(kind="primitive", underlying_type="String"),
+    ) == ("'打开连接'", len(data))
+
+
+def test_libd_names_use_labview_encoding(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "lvkit.text_encoding.labview_text_encoding",
+        lambda: "gbk",
+    )
+    class_name = "流场控制.lvclass".encode("gbk")
+    vi_name = "初始化.vi".encode("gbk")
+    uid = 42
+    data = (
+        b"IUVI\x00\x02"
+        + bytes([len(class_name)])
+        + class_name
+        + bytes([len(vi_name)])
+        + vi_name
+        + b"\x00\x00\x00\x01"
+        + struct.pack(">I", uid)
+        + b"PTH0"
+    )
+    path = tmp_path / "sample_LIbd.bin"
+    path.write_bytes(data)
+
+    assert parse_iuse_from_libd(path) == {str(uid): "流场控制.lvclass:初始化.vi"}


### PR DESCRIPTION
## Summary

- decode LabVIEW resource text with the platform-native code page instead of treating every VI as Mac Roman
- retain pylabview's lossless single-byte extraction path, then normalize XML text without allowing multibyte decoding to cross XML, attribute, or CDATA boundaries
- use the same encoding for string/path constants, case labels, LIbd names, and LLB members
- invalidate extraction and render/diff caches when the active code page changes

## Testing

- affected suite: 110 passed, 4 skipped
- encoding regressions: 9 passed
- `uv run pyright src`: 0 errors
- Ruff checks on all changed files: passed
- Windows CP936 smoke tests: `lvkit describe` and `lvkit docs` preserved Chinese VI names, terminals, state labels, SubVI names, and string constants with no observed mojibake

The complete local suite reached 1082 passed and 213 skipped. Its remaining 11 failures are outside this patch: existing array-codegen execution tests, cache classification assumptions affected by markers in the local user profile, and a LabVIEW-detection test that assumes LabVIEW is not installed.