### PR TITLE
fix: positionally-named primitive inputs are on the wrong slots (Divide, Subtract, ordered comparisons)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 lvkit follows semantic versioning.
 
+## [Unreleased]
+- **Fixed: `Divide`, `Subtract`, the ordered comparisons and the shift/scale
+  primitives had their two inputs swapped.** `describe` reported the operands
+  the wrong way round, and generated Python computed the inverse — `Divide`
+  returned the reciprocal, `Subtract` flipped sign, `Less?`/`Greater?` inverted.
+  19 entries are corrected. The connector-pane index space runs Bottom→Top, so
+  the documented upper input `x` takes the *higher* index; these entries had
+  been filled in from NI-doc listing order against ascending index. Commutative
+  entries (`Add`, `Multiply`, `And`, `Or`, `Exclusive Or`, `Equal?`,
+  `Not Equal?`) were affected too but showed no symptom, which is why this
+  survived. **If you have generated Python from a VI using any of the
+  non-commutative primitives, re-generate it.** A new gate
+  (`tests/test_primitive_positional_order.py`) makes the invariant permanent.
+
 ## [0.5.7]
 - **Re-opening or re-diffing a VI is now near-instant.** `render` and `diff`
   cache their output, so an unchanged VI skips the rebuild (render ~1.6 s →

--- a/src/lvkit/data/primitives.json
+++ b/src/lvkit/data/primitives.json
@@ -83,25 +83,25 @@
         {
           "index": 1,
           "direction": "in",
-          "name": "x",
+          "name": "y",
           "type": "polymorphic",
           "default_value": "0"
         },
         {
           "index": 2,
           "direction": "in",
-          "name": "y",
+          "name": "x",
           "type": "polymorphic",
           "default_value": "0"
         }
       ],
       "python_code": {
-        "x_greater_than_y": "in_1 > in_2"
+        "x_greater_than_y": "in_2 > in_1"
       },
       "inline": true,
       "verified": true,
       "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/greater.html",
-      "note": "Same as 1102 but for arrays/clusters. Same semantics."
+      "note": "Same as 1102 but for arrays/clusters. Same semantics. | Input names moved onto the slots their names imply: the index space is Bottom->Top, so the documented upper input `x` takes the HIGHER index. Was entered in doc-listing order against ascending index."
     },
     "1054": {
       "name": "Absolute Value",
@@ -140,13 +140,13 @@
         {
           "index": 1,
           "direction": "in",
-          "name": "x",
+          "name": "y",
           "type": "boolean"
         },
         {
           "index": 2,
           "direction": "in",
-          "name": "y",
+          "name": "x",
           "type": "boolean"
         }
       ],
@@ -157,7 +157,8 @@
         "result": "in_1 & in_2"
       },
       "inline": true,
-      "verified": true
+      "verified": true,
+      "note": "Input names moved onto the slots their names imply: the index space is Bottom->Top, so the documented upper input `x` takes the HIGHER index. Was entered in doc-listing order against ascending index."
     },
     "1062": {
       "name": "Or",
@@ -173,13 +174,13 @@
         {
           "index": 1,
           "direction": "in",
-          "name": "x",
+          "name": "y",
           "type": "boolean"
         },
         {
           "index": 2,
           "direction": "in",
-          "name": "y",
+          "name": "x",
           "type": "boolean"
         }
       ],
@@ -190,7 +191,8 @@
         "result": "in_1 | in_2"
       },
       "inline": true,
-      "verified": true
+      "verified": true,
+      "note": "Input names moved onto the slots their names imply: the index space is Bottom->Top, so the documented upper input `x` takes the HIGHER index. Was entered in doc-listing order against ascending index."
     },
     "1063": {
       "name": "Exclusive Or",
@@ -206,13 +208,13 @@
         {
           "index": 1,
           "direction": "in",
-          "name": "x",
+          "name": "y",
           "type": "polymorphic"
         },
         {
           "index": 2,
           "direction": "in",
-          "name": "y",
+          "name": "x",
           "type": "polymorphic"
         }
       ],
@@ -224,7 +226,7 @@
       },
       "inline": true,
       "verified": true,
-      "note": "Polymorphic over Boolean AND integers (bitwise). Corpus only ever shows numeric use; python_code=boolean, python_code_int=bitwise."
+      "note": "Polymorphic over Boolean AND integers (bitwise). Corpus only ever shows numeric use; python_code=boolean, python_code_int=bitwise. | Input names moved onto the slots their names imply: the index space is Bottom->Top, so the documented upper input `x` takes the HIGHER index. Was entered in doc-listing order against ascending index."
     },
     "1051": {
       "name": "Subtract",
@@ -239,22 +241,23 @@
         {
           "index": 1,
           "direction": "in",
-          "name": "x",
+          "name": "y",
           "type": "numeric"
         },
         {
           "index": 2,
           "direction": "in",
-          "name": "y",
+          "name": "x",
           "type": "numeric"
         }
       ],
       "python_code": {
-        "difference": "in_1 - in_2"
+        "difference": "in_2 - in_1"
       },
       "inline": true,
       "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/subtract.html"
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/subtract.html",
+      "note": "Input names moved onto the slots their names imply: the index space is Bottom->Top, so the documented upper input `x` takes the HIGHER index. Was entered in doc-listing order against ascending index."
     },
     "1141": {
       "name": "To Word Integer",
@@ -350,13 +353,13 @@
         {
           "index": 1,
           "direction": "in",
-          "name": "x",
+          "name": "y",
           "type": "polymorphic"
         },
         {
           "index": 2,
           "direction": "in",
-          "name": "y",
+          "name": "x",
           "type": "polymorphic"
         }
       ],
@@ -365,7 +368,8 @@
       },
       "inline": true,
       "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/add.html"
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/add.html",
+      "note": "Input names moved onto the slots their names imply: the index space is Bottom->Top, so the documented upper input `x` takes the HIGHER index. Was entered in doc-listing order against ascending index."
     },
     "1052": {
       "name": "Multiply",
@@ -380,13 +384,13 @@
         {
           "index": 1,
           "direction": "in",
-          "name": "x",
+          "name": "y",
           "type": "polymorphic"
         },
         {
           "index": 2,
           "direction": "in",
-          "name": "y",
+          "name": "x",
           "type": "polymorphic"
         }
       ],
@@ -395,7 +399,8 @@
       },
       "inline": true,
       "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/multiply.html"
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/multiply.html",
+      "note": "Input names moved onto the slots their names imply: the index space is Bottom->Top, so the documented upper input `x` takes the HIGHER index. Was entered in doc-listing order against ascending index."
     },
     "1057": {
       "name": "Absolute Value",
@@ -472,24 +477,25 @@
         {
           "index": 1,
           "direction": "in",
-          "name": "x",
+          "name": "y",
           "type": "polymorphic",
           "default_value": "0"
         },
         {
           "index": 2,
           "direction": "in",
-          "name": "y",
+          "name": "x",
           "type": "polymorphic",
           "default_value": "0"
         }
       ],
       "python_code": {
-        "greater_or_equal": "in_1 >= in_2"
+        "greater_or_equal": "in_2 >= in_1"
       },
       "inline": true,
       "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/greater-or-equal.html"
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/greater-or-equal.html",
+      "note": "Input names moved onto the slots their names imply: the index space is Bottom->Top, so the documented upper input `x` takes the HIGHER index. Was entered in doc-listing order against ascending index."
     },
     "1112": {
       "name": "Empty String/Path?",
@@ -1108,24 +1114,25 @@
         {
           "index": 1,
           "direction": "in",
-          "name": "x",
+          "name": "y",
           "type": "polymorphic",
           "default_value": "0"
         },
         {
           "index": 2,
           "direction": "in",
-          "name": "y",
+          "name": "x",
           "type": "polymorphic",
           "default_value": "0"
         }
       ],
       "python_code": {
-        "result": "in_1 < in_2"
+        "result": "in_2 < in_1"
       },
       "inline": true,
       "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/less.html"
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/less.html",
+      "note": "Input names moved onto the slots their names imply: the index space is Bottom->Top, so the documented upper input `x` takes the HIGHER index. Was entered in doc-listing order against ascending index."
     },
     "1108": {
       "name": "Quotient & Remainder",
@@ -1145,23 +1152,24 @@
         {
           "index": 2,
           "direction": "in",
-          "name": "x",
+          "name": "y",
           "type": "polymorphic"
         },
         {
           "index": 3,
           "direction": "in",
-          "name": "y",
+          "name": "x",
           "type": "polymorphic"
         }
       ],
       "python_code": {
-        "remainder": "in_2 % in_3",
-        "quotient": "in_2 // in_3"
+        "remainder": "in_3 % in_2",
+        "quotient": "in_3 // in_2"
       },
       "inline": true,
       "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/quotient-remainder.html"
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/quotient-remainder.html",
+      "note": "Input names moved onto the slots their names imply: the index space is Bottom->Top, so the documented upper input `x` takes the HIGHER index. Was entered in doc-listing order against ascending index."
     },
     "1105": {
       "name": "Not Equal?",
@@ -1176,14 +1184,14 @@
         {
           "index": 1,
           "direction": "in",
-          "name": "x",
+          "name": "y",
           "type": "polymorphic",
           "default_value": "0"
         },
         {
           "index": 2,
           "direction": "in",
-          "name": "y",
+          "name": "x",
           "type": "polymorphic",
           "default_value": "0"
         }
@@ -1193,7 +1201,8 @@
       },
       "inline": true,
       "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/not-equal.html"
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/not-equal.html",
+      "note": "Input names moved onto the slots their names imply: the index space is Bottom->Top, so the documented upper input `x` takes the HIGHER index. Was entered in doc-listing order against ascending index."
     },
     "1114": {
       "name": "Greater Or Equal To 0?",
@@ -1256,23 +1265,23 @@
         {
           "index": 1,
           "direction": "in",
-          "name": "x",
+          "name": "y",
           "type": "polymorphic"
         },
         {
           "index": 2,
           "direction": "in",
-          "name": "y",
+          "name": "x",
           "type": "NumInt32"
         }
       ],
       "python_code": {
-        "shifted": "(in_1 << in_2) if in_2 >= 0 else (in_1 >> -in_2)"
+        "shifted": "(in_2 << in_1) if in_1 >= 0 else (in_2 >> -in_1)"
       },
       "inline": true,
       "verified": true,
       "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/logical-shift.html",
-      "note": "primIndex=101. Polymorphic on x (any int type). y = shift count: positive=left, negative=right (LabVIEW semantics; Python `<<` only does left)."
+      "note": "primIndex=101. Polymorphic on x (any int type). y = shift count: positive=left, negative=right (LabVIEW semantics; Python `<<` only does left). | Input names moved onto the slots their names imply: the index space is Bottom->Top, so the documented upper input `x` takes the HIGHER index. Was entered in doc-listing order against ascending index."
     },
     "1053": {
       "name": "Divide",
@@ -1287,23 +1296,23 @@
         {
           "index": 1,
           "direction": "in",
-          "name": "x",
+          "name": "y",
           "type": "polymorphic"
         },
         {
           "index": 2,
           "direction": "in",
-          "name": "y",
+          "name": "x",
           "type": "polymorphic"
         }
       ],
       "python_code": {
-        "quotient": "in_1 / in_2"
+        "quotient": "in_2 / in_1"
       },
       "inline": true,
       "verified": true,
       "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/divide.html",
-      "note": "primIndex=106. Polymorphic. Per docs: int/int produces Float64 (matches our 22+ observed instances of NumInt32/NumInt32 -> NumFloat64). Python `/` operator has same semantics."
+      "note": "primIndex=106. Polymorphic. Per docs: int/int produces Float64 (matches our 22+ observed instances of NumInt32/NumInt32 -> NumFloat64). Python `/` operator has same semantics. | Input names moved onto the slots their names imply: the index space is Bottom->Top, so the documented upper input `x` takes the HIGHER index. Was entered in doc-listing order against ascending index."
     },
     "1111": {
       "name": "Less Or Equal?",
@@ -1318,23 +1327,23 @@
         {
           "index": 1,
           "direction": "in",
-          "name": "x",
+          "name": "y",
           "type": "polymorphic"
         },
         {
           "index": 2,
           "direction": "in",
-          "name": "y",
+          "name": "x",
           "type": "polymorphic"
         }
       ],
       "python_code": {
-        "x_less_or_equal_y": "in_1 <= in_2"
+        "x_less_or_equal_y": "in_2 <= in_1"
       },
       "inline": true,
       "verified": true,
       "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/less-or-equal.html",
-      "note": "primIndex=114. Polymorphic numeric comparison. 7 observed signatures across all integer/float type pairs."
+      "note": "primIndex=114. Polymorphic numeric comparison. 7 observed signatures across all integer/float type pairs. | Input names moved onto the slots their names imply: the index space is Bottom->Top, so the documented upper input `x` takes the HIGHER index. Was entered in doc-listing order against ascending index."
     },
     "8056": {
       "name": "Delete",
@@ -1898,14 +1907,14 @@
         {
           "index": 1,
           "direction": "in",
-          "name": "x",
+          "name": "y",
           "type": "polymorphic",
           "default_value": "0"
         },
         {
           "index": 2,
           "direction": "in",
-          "name": "y",
+          "name": "x",
           "type": "polymorphic",
           "default_value": "0"
         }
@@ -1915,7 +1924,8 @@
       },
       "inline": true,
       "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/equal.html"
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/equal.html",
+      "note": "Input names moved onto the slots their names imply: the index space is Bottom->Top, so the documented upper input `x` takes the HIGHER index. Was entered in doc-listing order against ascending index."
     },
     "1116": {
       "name": "Unresolved primitive 1116",
@@ -1970,7 +1980,7 @@
       },
       "inline": true,
       "verified": false,
-      "note": "1in/2out array\u2192array+array. Could be Split Number or type-specific split. Unconfirmed."
+      "note": "1in/2out array→array+array. Could be Split Number or type-specific split. Unconfirmed."
     },
     "1503": {
       "name": "Replace Substring",
@@ -4686,13 +4696,13 @@
         {
           "index": 1,
           "direction": "in",
-          "name": "x",
+          "name": "n",
           "type": "NumFloat64"
         },
         {
           "index": 2,
           "direction": "in",
-          "name": "n",
+          "name": "x",
           "type": "NumInt32"
         },
         {
@@ -4703,9 +4713,10 @@
         }
       ],
       "python_code": {
-        "result": "in_1 * (2.0 ** in_2)"
+        "result": "in_2 * (2.0 ** in_1)"
       },
-      "verified": true
+      "verified": true,
+      "note": "Input names moved onto the slots their names imply: the index space is Bottom->Top, so the documented upper input `x` takes the HIGHER index. Was entered in doc-listing order against ascending index."
     },
     "1181": {
       "name": "Number To Hexadecimal String",
@@ -4846,13 +4857,13 @@
         {
           "index": 1,
           "direction": "in",
-          "name": "x",
+          "name": "n",
           "type": "NumUInt32"
         },
         {
           "index": 2,
           "direction": "in",
-          "name": "n",
+          "name": "x",
           "type": "NumInt32"
         },
         {
@@ -4863,9 +4874,9 @@
         }
       ],
       "python_code": {
-        "x_shifted": "((in_1 << in_2) if in_2 >= 0 else (in_1 >> -in_2)) & 0xFFFFFFFF"
+        "x_shifted": "((in_2 << in_1) if in_1 >= 0 else (in_2 >> -in_1)) & 0xFFFFFFFF"
       },
-      "note": "positive n = shift left, negative = right, zero-fill; masked to source width (U32 here). MD5 builds its circular rotate from this.",
+      "note": "positive n = shift left, negative = right, zero-fill; masked to source width (U32 here). MD5 builds its circular rotate from this. | Input names moved onto the slots their names imply: the index space is Bottom->Top, so the documented upper input `x` takes the HIGHER index. Was entered in doc-listing order against ascending index.",
       "verified": false
     },
     "1188": {
@@ -4899,13 +4910,13 @@
         {
           "index": 1,
           "direction": "in",
-          "name": "x",
+          "name": "y",
           "type": "Boolean"
         },
         {
           "index": 2,
           "direction": "in",
-          "name": "y",
+          "name": "x",
           "type": "Boolean"
         },
         {
@@ -4920,7 +4931,7 @@
       },
       "inline": true,
       "verified": true,
-      "note": "Valid Path: inputs are Empty String/Path? (1112) and Not A Number/Path/Refnum? (1128) - both badness predicates - and the output is validity, so valid = NOT(empty OR not-a-path) = NOR. And/Or/Xor/Not (1061-1064) are already claimed, and only NOR satisfies that truth table. Commutative, so operand order is irrelevant."
+      "note": "Valid Path: inputs are Empty String/Path? (1112) and Not A Number/Path/Refnum? (1128) - both badness predicates - and the output is validity, so valid = NOT(empty OR not-a-path) = NOR. And/Or/Xor/Not (1061-1064) are already claimed, and only NOR satisfies that truth table. Commutative, so operand order is irrelevant. | Input names moved onto the slots their names imply: the index space is Bottom->Top, so the documented upper input `x` takes the HIGHER index. Was entered in doc-listing order against ascending index."
     },
     "1425": {
       "name": "VI Library",
@@ -5043,13 +5054,13 @@
         {
           "index": 1,
           "direction": "in",
-          "name": "x",
+          "name": "y",
           "type": "polymorphic"
         },
         {
           "index": 2,
           "direction": "in",
-          "name": "y",
+          "name": "x",
           "type": "polymorphic"
         },
         {
@@ -5060,11 +5071,11 @@
         }
       ],
       "python_code": {
-        "x_to_the_y": "in_1 ** in_2"
+        "x_to_the_y": "in_2 ** in_1"
       },
       "inline": true,
       "verified": false,
-      "note": "Algorithm-forced: every call-site is 1213 -> Multiply -> Less? -> Select against a PCO_GetCameraDescription field (clamping a time to a camera limit). idx1 is fed by a constant decoding to 1000 whose DDO label is literally \"x\"; idx2 by a Subtract of timebase indices. PCO timebases are ns/us/ms, so value * 1000^dTB is the SDK unit conversion. Logarithm Base X excluded: log1000(dTB) is -inf at 0. Operand order follows the SHIPPED convention - see task #115, unresolved."
+      "note": "Algorithm-forced: every call-site is 1213 -> Multiply -> Less? -> Select against a PCO_GetCameraDescription field (clamping a time to a camera limit). idx1 is fed by a constant decoding to 1000 whose DDO label is literally \"x\"; idx2 by a Subtract of timebase indices. PCO timebases are ns/us/ms, so value * 1000^dTB is the SDK unit conversion. Logarithm Base X excluded: log1000(dTB) is -inf at 0. Operand order follows the SHIPPED convention - see task #115, unresolved. | Input names moved onto the slots their names imply: the index space is Bottom->Top, so the documented upper input `x` takes the HIGHER index. Was entered in doc-listing order against ascending index."
     },
     "1340": {
       "name": "One Button Dialog",

--- a/tests/test_primitive_positional_order.py
+++ b/tests/test_primitive_positional_order.py
@@ -1,0 +1,92 @@
+"""Gate: a positionally-named input pair must sit on the slots its names imply.
+
+Why this exists: ``connector_geometry``'s index space runs Right->Left,
+Bottom->Top (idx0 = bottom-right), so on a two-input primitive the UPPER
+terminal carries the HIGHER index. NI documents the upper input of the dyadic
+arithmetic, comparison and logic primitives as ``x`` and the lower as ``y``
+(``n`` for the shift/scale pair). So ``x`` must always hold the higher index.
+
+Nineteen entries had it backwards, because the names were filled in from
+NI-doc LISTING order (x first) against ASCENDING index -- which is bottom-up,
+so ``x`` landed on the lower slot. That is the same bug class as the
+Clear-Errors fix in 2f71ff2 (doc listing order mistaken for pane geometry),
+in the one variant ``connector_geometry_profile.audit_primitive`` explicitly
+cannot catch: both terminals share a type family, so a per-index direction/
+type diff sees nothing wrong either way round.
+
+For this family the doc-image half of the auditor is not needed, because the
+NAMES themselves encode the geometry. That makes the invariant checkable as
+pure data, which is what this test does.
+
+Consequence of getting it wrong: ``python_code`` operands bind to the wrong
+wires, so every non-commutative primitive silently computes the inverse --
+``Divide`` returns the reciprocal, ``Subtract`` flips sign, the ordered
+comparisons invert. Commutative entries (Add, Multiply, And, Or, Xor, Equal?,
+Not Equal?) show no symptom, which is why this survived.
+
+SCOPE -- the SHIPPED catalog only, matching test_primitive_name_uniqueness.py.
+A project-local ``.lvkit/primitives.json`` override is the designed escape
+hatch and must never be scanned here.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+PRIMS = Path(__file__).resolve().parents[1] / "src/lvkit/data/primitives.json"
+
+# Input-name sets whose ordering is fixed by NI's documented pane layout.
+# First element is the DOCUMENTED UPPER terminal -> must hold the higher index.
+POSITIONAL_PAIRS: tuple[tuple[str, str], ...] = (
+    ("x", "y"),
+    ("x", "n"),
+)
+
+
+def _entries() -> dict[str, dict]:
+    return json.loads(PRIMS.read_text(encoding="utf-8"))["primitives"]
+
+
+def _positional_two_input_entries():
+    """Yield (prim_id, entry, upper_name, lower_name) for each pair entry."""
+    for prim_id, entry in _entries().items():
+        ins = [t for t in entry.get("terminals", []) if t.get("direction") == "in"]
+        if len(ins) != 2:
+            continue
+        names = {t.get("name") for t in ins}
+        for upper, lower in POSITIONAL_PAIRS:
+            if names == {upper, lower}:
+                yield prim_id, entry, upper, lower
+                break
+
+
+def _input_indices(entry: dict) -> dict[str, int]:
+    return {
+        t["name"]: t["index"]
+        for t in entry["terminals"]
+        if t.get("direction") == "in"
+    }
+
+
+def test_positional_upper_input_has_higher_index() -> None:
+    """``x`` sits above ``y``/``n``, so it must carry the higher slot index."""
+    offenders = []
+    for prim_id, entry, upper, lower in _positional_two_input_entries():
+        idx = _input_indices(entry)
+        if idx[upper] < idx[lower]:
+            offenders.append(
+                f"{prim_id} {entry.get('name')}: "
+                f"{upper}=idx{idx[upper]} must sit ABOVE {lower}=idx{idx[lower]}, "
+                f"but the index space is bottom-up so it needs the HIGHER index"
+            )
+    assert not offenders, (
+        "positionally-named inputs on the wrong slots:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_gate_is_actually_covering_something() -> None:
+    """Guard against the gate silently matching zero entries."""
+    found = list(_positional_two_input_entries())
+    assert len(found) >= 15, (
+        f"expected the dyadic arithmetic/comparison/logic family, got {len(found)}"
+    )

--- a/tests/test_primitive_resolutions.py
+++ b/tests/test_primitive_resolutions.py
@@ -64,10 +64,15 @@ def test_key_python_code_semantics():
     assert "127" in str(res.resolve(prim_id=1140).python_code)
     # 2-input arithmetic: Add / Subtract / Multiply / Divide (operators give
     # LV's type coercion for free; Divide is true division -> always float).
+    # Operand order follows the connector pane, not the NI doc listing: the
+    # index space is Bottom->Top, so `x` (the documented UPPER input) is in_2
+    # and `y` is in_1 -- hence `in_2 - in_1` for x-y. Add and Multiply are
+    # commutative, so their formulas keep their original operand order.
+    # See tests/test_primitive_positional_order.py for the invariant.
     assert "in_1 + in_2" in str(res.resolve(prim_id=1050).python_code)
-    assert "in_1 - in_2" in str(res.resolve(prim_id=1051).python_code)
+    assert "in_2 - in_1" in str(res.resolve(prim_id=1051).python_code)
     assert "in_1 * in_2" in str(res.resolve(prim_id=1052).python_code)
-    assert "in_1 / in_2" in str(res.resolve(prim_id=1053).python_code)
+    assert "in_2 / in_1" in str(res.resolve(prim_id=1053).python_code)
 
 
 def test_paren_if_compound_preserves_operand_precedence():


### PR DESCRIPTION
## Issue

I was using `lvkit describe` to review a VI. The netlist showed the divide inverted compared to what I saw on the diagram. 

Claude help then to figure out what was going wrong.

## The bug

`lvkit.connector_geometry` documents the index space:

> `index`: the connector-pane slot index in LabVIEW's OWN numbering — Right->Left, **Bottom->Top**; idx0 = bottom-right (project reference #38).

NI documents `x` as the **upper** input of the dyadic arithmetic, comparison and logic primitives. Upper means higher index. But these entries were filled in from doc-*listing* order (`x` first) against *ascending* index — which is bottom-up — so `x` landed on the lower slot:

```json
"1053": {
  "name": "Divide",
  "terminals": [
    {"index": 0, "direction": "out", "name": "quotient"},
    {"index": 1, "direction": "in",  "name": "x"},   // actually the LOWER input
    {"index": 2, "direction": "in",  "name": "y"}    // actually the UPPER input
  ],
  "python_code": { "quotient": "in_1 / in_2" },      // computes y / x
  "verified": true
}
```

19 entries are affected. For the 11 non-commutative ones lvkit computed the inverse — `Divide` returned the reciprocal, `Subtract` flipped sign, the ordered comparisons inverted. Nothing failed loudly, because an inverted divide still returns plausible finite numbers.

This is the bug class fixed by hand in 2f71ff2, in the one variant `connector_geometry_profile.audit_primitive` documents that it cannot catch:

> It CANNOT catch a same-type swap — two terminals of the SAME type family trading names/positions […] both "look right" to this diff either way round.

`x` and `y` are both polymorphic inputs, so the per-index direction/type diff sees nothing wrong either way round.

## Why the doc-image phase isn't needed here

The module docstring says this class "needs the doc-image half of the auditor (a later phase, not built here)". For **positionally-named** terminals it doesn't: the names themselves encode the geometry. `x` is always the upper input of a dyadic primitive, so the invariant is checkable as pure data, with no image parsing and no corpus.

That's what `tests/test_primitive_positional_order.py` does — it asserts `x` holds the higher index than `y`/`n` for every two-input entry named that way, and includes a guard against the gate silently matching zero entries. This closes the same-type-swap gap for this family permanently. The general case (e.g. Insert Menu Items' `item_names` / `item_tags`) still needs the doc-image phase.

## Changes

| | |
|---|---|
| `src/lvkit/data/primitives.json` | Input names moved onto the correct slots on 19 entries; `python_code` / `python_code_int` operands remapped on the 11 non-commutative ones. Each entry's `note` records the reasoning. |
| `tests/test_primitive_positional_order.py` | New permanent gate. |
| `tests/test_primitive_resolutions.py` | Two assertions in `test_key_python_code_semantics` pinned the old inverted `Subtract` and `Divide` formulas. Updated, with a comment explaining the operand order. |
| `CHANGELOG.md` | Entry under `## [Unreleased]`. Move or drop it if that doesn't match your release flow — 0.5.8 has no section yet and I didn't want to guess. |

Corrected: `Divide` (1053), `Subtract` (1051), `Less?` (1110), `Less Or Equal?` (1111), `Greater?` (1104), `Greater Or Equal?` (1103), `Quotient & Remainder` (1108), `Logical Shift` (1081, 1082), `Scale By Power Of 2` (1074), `Power Of X` (1213), plus the commutative `Add` (1050), `Multiply` (1052), `And` (1061), `Or` (1062), `Exclusive Or` (1063), `Not Or` (1072), `Equal?` (1102), `Not Equal?` (1105).

Commutative formulas are deliberately left in their original operand order, so the diff carries no semantically inert churn — only the names move.

## Testing

`uv run pytest`: 1109 passed. 8 failures are pre-existing on my machine and unrelated — I confirmed them against a stashed baseline. They're environmental: `test_lv_detect` asserts LabVIEW is *absent* (it's installed here), three `test_project_store` tests hit a `cp1252` `UnicodeDecodeError` reading prompt files on Windows, and the cache tests trip over an existing global `~/.lvkit`.

`uv run ruff check` clean on the new file.

## Provenance

Cleanroom per `PROVENANCE.md`. The derivation uses exactly the two permitted inputs: lvkit's own documented index convention (`connector_geometry`) and the public ni.com function reference pages for the terminal roles. No NI software, source, or non-public material was consulted for the derivation, and no third-party VI content is included in this PR.

Disclosure for completeness: I *validated* the conclusion against a private VI corpus on a machine that does have LabVIEW installed, by reading `termBounds` out of the pylabview XML — every affected primitive's geometry agreed, with no variation across instances. None of that data is contributed here, and none of it is load-bearing for the fix: the bug follows from your own documented convention plus the public docs alone. Flagging it so you can judge rather than discovering it later.

## Possible follow-ups, not in this PR

Two entries declare input indices that don't appear in the geometry I observed: `String Subset` (1166) declares `[0, 1, 3]` where instances show `[0, 1, 2]`, and `Replace Substring` (1503) declares `[1, 2, 3, 4]` where instances show `[0, 1, 2, 3]`. My scan mapped the no-`parmIndex` terminal to key 0, so these may be an artifact of that rather than real. Worth a look with your own auditor.

Also, `1053`'s `note` records that operand *types* were checked against 22+ instances and the entry is marked `"verified": true`. Type-checking can't catch operand order, so the flag read as stronger than it was. It might be worth distinguishing "names and types checked against the docs" from "terminal positions checked against real pane geometry".
