### PR TITLE
Fix SubVI linking for own-library/class calls (complex namespaces) (#29)

### DIFF
--- a/src/lvkit/render/nodes.py
+++ b/src/lvkit/render/nodes.py
@@ -384,6 +384,46 @@ class SubVISource:
     project_local: bool
 
 
+def _resolve_caller_relative_vi(node: VINode) -> Path | None:
+    """Resolve a SubVI's ``qualified_path`` RELATIVE TO THE CALLER, per LabVIEW's
+    LinkSavePathRef convention: each leading empty token (a leading ``/``) is one
+    ``..`` from the caller file, then the remaining tokens are appended. The
+    caller file is the ``vi_key`` prefix of this node's id (``vi_key::uid``).
+
+    This is what correctly places a call to a VI in the caller's OWN library/
+    class, which LabVIEW stores as a bare local ref (``/Do.vi`` -> the caller's
+    sibling) rather than a fully-qualified one — a root-relative or bare-name
+    lookup collides it with a same-named VI in another library (#29). A
+    ``<vilib>``/``<userlib>`` token is skipped here (resolved separately).
+    Returns the on-disk ``.vi`` if it exists, else ``None`` (fall through)."""
+    qp = node.qualified_path
+    if not qp:
+        return None
+    tokens = qp.replace("\\", "/").split("/")
+    if not tokens or tokens[0] in ("<vilib>", "<userlib>"):
+        return None
+    node_id = node.id
+    if "::" not in node_id:
+        return None
+    caller_file = Path(node_id.split("::", 1)[0])
+    if not caller_file.exists():
+        return None
+    empties = 0
+    for tok in tokens:
+        if tok == "":
+            empties += 1
+        else:
+            break
+    base = caller_file
+    for _ in range(empties):
+        base = base.parent
+    rest = [tok for tok in tokens[empties:] if tok]
+    if not rest:
+        return None
+    candidate = base.joinpath(*rest)
+    return candidate if candidate.is_file() else None
+
+
 def resolve_subvi_source(
     node: VINode,
     graph: InMemoryVIGraph,
@@ -415,6 +455,17 @@ def resolve_subvi_source(
     name = node.name
     if not name:
         return None
+
+    # Caller-RELATIVE path resolution first: a SubVI's qualified_path is a
+    # LabVIEW LinkSavePathRef token string whose leading empties (leading '/'s)
+    # are '..' hops from the CALLER file, then the rest append. A same-library/
+    # class call is stored as a bare LOCAL ref ("/Do.vi" -> the caller's own
+    # sibling); resolving that against the search ROOT (or by bare name) collides
+    # it with a same-named VI in another library (#29). Resolving from the caller
+    # places it correctly.
+    src = _resolve_caller_relative_vi(node)
+    if src is not None:
+        return SubVISource(src, project_local=True)
 
     # Pass qualified_path so two SubVIs that share a bare filename across
     # libraries (Lib1/Do.vi vs Lib2/Do.vi) each resolve to their OWN file — a

--- a/tests/test_subvi_nav.py
+++ b/tests/test_subvi_nav.py
@@ -100,6 +100,39 @@ def test_locate_vi_file_disambiguates_same_name_across_libraries(tmp_path: Path)
     )
 
 
+def test_caller_relative_subvi_resolves_same_library_local_ref(tmp_path: Path):
+    """A SubVI call to a VI in the CALLER's OWN library/class is stored by
+    LabVIEW as a bare LOCAL ref (``/Do.vi``), not a fully-qualified path. It must
+    resolve to the caller's own sibling — not collide with a same-named VI in
+    another library (#29). Cross-library refs (``///Lib1/Class/Do.vi``, whose
+    leading empties are ``..`` hops from the caller file) still resolve too."""
+    from types import SimpleNamespace
+    from typing import cast
+
+    from lvkit.graph.models import VINode
+    from lvkit.render.nodes import _resolve_caller_relative_vi
+
+    for top in ("Lib1", "Lib2"):
+        (tmp_path / top / "Class").mkdir(parents=True)
+        (tmp_path / top / "Class" / "Do.vi").write_bytes(b"")
+    caller = tmp_path / "Lib2" / "Class" / "Test.vi"
+    caller.write_bytes(b"")
+
+    def node(qp: str) -> VINode:
+        # a SubVI call node: only .qualified_path and .id (vi_key::uid) are read
+        return cast(VINode, SimpleNamespace(qualified_path=qp, id=f"{caller}::42"))
+
+    # same-class local ref -> the caller's OWN sibling (Lib2), NOT Lib1
+    assert _resolve_caller_relative_vi(node("/Do.vi")) == tmp_path / "Lib2/Class/Do.vi"
+    # cross-library ref: 3 '..' from the caller file reach the root, then descend
+    assert (
+        _resolve_caller_relative_vi(node("///Lib1/Class/Do.vi"))
+        == tmp_path / "Lib1/Class/Do.vi"
+    )
+    # a <vilib> token is not caller-relative -> None (resolved elsewhere)
+    assert _resolve_caller_relative_vi(node("<vilib>/Utility/error.llb/Foo.vi")) is None
+
+
 def test_locate_vi_file_resolves_full_path_not_just_tail(tmp_path: Path):
     """Resolution keys on the WHOLE project-relative path, not a parent/name tail:
     two VIs sharing filename AND parent-dir name but different full paths


### PR DESCRIPTION
Closes #29.

Follow-up to the cross-library SubVI-icon fix (`381284e`). That fix disambiguated two same-named SubVIs across libraries by resolving `qualified_path` against the search **root**. But a call to a VI in the **caller's own library/class** is stored by LabVIEW as a **bare local `LinkSavePathRef`** (`qualified_path='/Do.vi'`), not a fully-qualified project path like a cross-library call (`'///Lib1/Class/Do.vi'`). Root-relative resolution turns `/Do.vi` into `root/Do.vi` (missing) → bare-name fallback → **collides** with a same-named VI in another library.

### Repro (from the issue)
`Lib1.lvlib:Class.lvclass:Do.vi` and `Lib2.lvlib:Class.lvclass:Do.vi` — same class name, same VI name. Caller `Lib2/Class/Test.vi` calls both; the same-class one (`/Do.vi`) rendered **Lib1**'s icon.

### Fix
Resolve `qualified_path` **caller-relatively** first, per LabVIEW's convention: each leading empty (`/`) is one `..` from the **caller file** (recovered from the node's `vi_key::uid` id), then the remaining tokens append — the same algorithm as `ParsedDependencyRef.resolve_against`. So `/Do.vi` from `Lib2/Class/Test.vi` → its sibling `Lib2/Class/Do.vi`, and `///Lib1/Class/Do.vi` → `root/Lib1/Class/Do.vi`. This **subsumes** the earlier root-relative fix (all prior cases still resolve).

### Verified
- The two SubVIs now render **CLASS1** vs **CLASS2** icons (were both CLASS1).
- Hermetic regression test `test_caller_relative_subvi_resolves_same_library_local_ref`.
- Full suite green (pre-commit hook: ruff + pyright + pytest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)