### PR TITLE
Fix #37: structure tunnel wire bends (+ byte-exact string constants)

### DIFF
--- a/src/lvkit/_pylabview_patches.py
+++ b/src/lvkit/_pylabview_patches.py
@@ -44,6 +44,7 @@ with warnings.catch_warnings():
     warnings.simplefilter("ignore", SyntaxWarning)
     import pylabview.LVblock as _lv_block  # type: ignore[import-untyped]
     import pylabview.LVdatatype as _lv_datatype  # type: ignore[import-untyped]
+    import pylabview.LVheap as _lv_heap  # type: ignore[import-untyped]
     import pylabview.LVmisc as _lv_misc  # type: ignore[import-untyped]
     import pylabview.LVrsrcontainer as _lv_rsrc  # type: ignore[import-untyped]
     import pylabview.LVxml as _lv_xml  # type: ignore[import-untyped]
@@ -282,5 +283,47 @@ def install_pylabview_patches() -> None:
 
     _resilient_tdlist.__wrapped__ = _orig_tdlist  # type: ignore[attr-defined]
     _lv_block.VCTP.exportXMLTypeDescList = _resilient_tdlist
+
+    # (7) HeapNodeString.prepareContentXML — byte-EXACT binary DefaultData.
+    # pylabview serializes every string heap value by decoding the raw bytes
+    # through a text codec (``self.content.decode(self.vi.textEncoding)``). For a
+    # binary ``DefaultData`` value — a constant's FLATTENED bytes: a 4-byte
+    # big-endian length prefix + content — any byte >= 0x80 is not representable
+    # in the mac_roman -> native transcode (``normalize_extracted_xml``) and
+    # collapses to U+FFFD, which our ``decode_xml_entities_to_bytes`` recovers as
+    # 0xFD. So a 250-byte string whose length prefix is ``00 00 00 FA`` reads back
+    # as 253, and the constant decodes to an EMPTY string (the whole 22-line
+    # dictionary constant renders as a blank box). LabVIEW display TEXT
+    # (labels / node & method names / format strings) legitimately rides the
+    # mac_roman + normalize path and must stay literal, so we rewrite ONLY the
+    # binary ``OF__DefaultData`` tag: emit each byte as a printable-ASCII literal
+    # or an ``&#xNN;`` entity of the byte value — exactly the byte-entity form the
+    # constant reader and the text-encoding tests already expect. Entities are
+    # ASCII, so ``normalize_extracted_xml`` leaves them untouched and the reader
+    # recovers each byte; the value's final code page is then applied by
+    # ``decode_labview_text`` (so a CJK string constant still decodes correctly).
+    _default_data_tag = _lv_heap.OBJ_FIELD_TAGS.OF__DefaultData
+    _orig_prep = _lv_heap.HeapNodeString.prepareContentXML
+
+    def _byte_exact_default_data(self, fname_base):  # type: ignore[no-untyped-def]
+        content = self.content
+        if (
+            self.tagEn != _default_data_tag
+            or content is None
+            or isinstance(content, bool)
+        ):
+            return _orig_prep(self, fname_base)
+        out = []
+        for b in content:
+            # printable ASCII (minus the wrapping quote and XML/CDATA-special
+            # bytes) stays literal; everything else -> exact byte entity, so the
+            # value round-trips byte-for-byte through CDATA + normalize.
+            if 0x20 <= b <= 0x7E and b not in (0x22, 0x26, 0x3C, 0x3E):
+                out.append(chr(b))
+            else:
+                out.append(f"&#x{b:02x};")
+        return '"' + "".join(out) + '"'
+
+    _lv_heap.HeapNodeString.prepareContentXML = _byte_exact_default_data
 
     _installed = True

--- a/src/lvkit/cache_paths.py
+++ b/src/lvkit/cache_paths.py
@@ -256,6 +256,41 @@ def source_fingerprint() -> str:
     return h.hexdigest()
 
 
+# The ONLY modules that determine pylabview's emitted XML: the in-process
+# monkeypatches (which alter what pylabview writes), the extraction driver (read
+# options + the normalize call), and the text-encoding helpers (textcp choice +
+# ``normalize_extracted_xml``). Deliberately a tiny INCLUDE list, not the
+# package-wide ``source_fingerprint`` exclude list: extraction output does NOT
+# depend on parser/graph/render, so re-running pylabview over the whole corpus
+# on every unrelated edit would be pathologically slow. Extraction changes
+# rarely (basically only when a monkeypatch changes), so this invalidates rarely.
+_EXTRACTION_CODE_FILES = (
+    "_pylabview_patches.py",
+    "extractor.py",
+    "text_encoding.py",
+)
+
+
+@functools.lru_cache(maxsize=1)
+def extraction_fingerprint() -> str:
+    """A hash of ONLY the extraction code (``_EXTRACTION_CODE_FILES``), so the
+    extraction cache rebuilds when HOW we extract changes — a new/edited
+    pylabview monkeypatch, a read option, the normalize pass — but NOT when
+    post-extraction code (parser/graph/render, keyed on ``source_fingerprint``)
+    changes. Kept separate from ``source_fingerprint`` on purpose: extraction is
+    the expensive, rarely-changing stage."""
+    import lvkit
+
+    pkg = Path(lvkit.__file__).resolve().parent
+    h = hashlib.sha256()
+    for rel in _EXTRACTION_CODE_FILES:
+        h.update(rel.encode())
+        h.update(b"\0")
+        h.update((pkg / rel).read_bytes())
+        h.update(b"\0")
+    return h.hexdigest()
+
+
 def meta_fresh(vi_path: Path, meta_path: Path, extra: dict | None = None) -> bool:
     """True if the cached artifact described by ``meta_path`` is still valid for
     ``vi_path``.

--- a/src/lvkit/extractor.py
+++ b/src/lvkit/extractor.py
@@ -37,6 +37,7 @@ from lvkit.cache_paths import (  # noqa: E402
     _slug,
     classify,
     cleanup_legacy_cache,
+    extraction_fingerprint,
     global_cache_root,
     meta_fresh,
 )
@@ -138,6 +139,7 @@ def _write_cache_meta(vi_path: Path, meta_path: Path) -> None:
         tool="pylabview",
         extracted_at=time.time(),
         text_encoding=labview_text_encoding(),
+        extraction_fingerprint=extraction_fingerprint(),
     )
     os.replace(tmp, meta_path)
 
@@ -267,7 +269,16 @@ def extract_vi_xml(
         and meta_fresh(
             vi_path,
             meta_path,
-            extra={"text_encoding": labview_text_encoding()},
+            extra={
+                "text_encoding": labview_text_encoding(),
+                # Invalidate ONLY when the extraction code changes (a pylabview
+                # monkeypatch / read option / the normalize pass — see
+                # extraction_fingerprint), NOT on unrelated parser/render edits.
+                # Without it an extraction-behaviour change silently serves stale
+                # XML; with source_fingerprint it would needlessly re-run
+                # pylabview over the whole corpus on every edit.
+                "extraction_fingerprint": extraction_fingerprint(),
+            },
         )
     ):
         return (

--- a/src/lvkit/graph/diff.py
+++ b/src/lvkit/graph/diff.py
@@ -98,8 +98,9 @@ class ElementChange:
     element: str | None = None
     # ── Faithful wire geometry (increment 2a) ────────────────────────────
     # The rendered wire's polyline — the SAME points render/scene.py draws:
-    # [source-terminal center, *Layout.wire_by_uid[sink], sink-terminal center],
-    # in absolute SVG-viewBox pixels. Set on WIRE changes so the viewer overlays
+    # LabVIEW's complete decoded polyline (Layout.wire_by_uid[sink], which runs
+    # source center -> bends -> sink center) verbatim, in absolute SVG-viewBox
+    # pixels. Set on WIRE changes so the viewer overlays
     # the real colored wire (not a pin). None when layout is absent. For an
     # added/modified wire it's the HEAD routing; for a removed wire the BASE.
     path: list[Point] | None = None
@@ -560,26 +561,30 @@ def _wire_path(
     sink_uid: str,
 ) -> list[Point] | None:
     """The FAITHFUL polyline of the drawn wire INTO ``sink_uid`` (a raw sink
-    terminal uid) — the exact points ``render/scene.py`` draws:
-    ``[source center, *Layout.wire_by_uid[sink], sink center]``.
+    terminal uid) — the exact points ``render/scene.py`` draws.
 
     Uses the IMMEDIATE non-internal wire whose destination is ``sink_uid`` (the
     actual drawn wire), NOT any contracted effective source — this overlay must
-    trace the real wire. ``wire_by_uid`` supplies the recorded intermediate
-    bends; when absent the polyline is just the two endpoint centers (a straight
-    segment — the renderer would auto-route, which is fine for an overlay).
-    Returns None when layout is absent or an endpoint center is missing (an
-    input terminal takes exactly one wire, so the first match is the wire)."""
+    trace the real wire. ``Layout.wire_by_uid`` supplies LabVIEW's COMPLETE
+    decoded polyline (source center -> recorded bends -> sink center), used
+    VERBATIM — the same geometry scene.py draws. When it is absent (the decode
+    failed / auto-route fallback) the polyline is just the two endpoint centers
+    (a straight segment — fine for an overlay). Returns None when layout is
+    absent or an endpoint center is missing (an input terminal takes exactly one
+    wire, so the first match is the wire)."""
     if layout is None:
         return None
     for w in wires:
         if _uid_of(w.dest.terminal_id) != sink_uid:
             continue
+        full = layout.wire_by_uid.get(sink_uid)
+        if full is not None:
+            return list(full)
         src_center = layout.terminal_centers.get(_uid_of(w.source.terminal_id))
         sink_center = layout.terminal_centers.get(sink_uid)
         if src_center is None or sink_center is None:
             return None
-        return [src_center, *layout.wire_by_uid.get(sink_uid, []), sink_center]
+        return [src_center, sink_center]
     return None
 
 

--- a/src/lvkit/parser/layout.py
+++ b/src/lvkit/parser/layout.py
@@ -546,15 +546,20 @@ class _LayoutBuilder:
 
     def _resolve_wire_geometry(self) -> dict[str, list[tuple[float, float]]]:
         """Decode every ``raw_signal`` into ``Layout.wire_by_uid``: each branch's
-        intermediate bend points keyed by its SINK terminal uid.
+        FULL polyline (LabVIEW's own source anchor + bend points + sink anchor)
+        keyed by its SINK terminal uid.
 
         One pass over both 2-endpoint and fan-out signals — ``decode_signal``
         handles both (a 2-endpoint wire is the 1-leaf case). It needs the source
         and ALL sink centers (a tree can't be decoded one branch at a time), then
         each resulting branch is stored under its sink uid so ``scene.py`` can
         look it up per drawn wire by exact identity — no center rounding, no
-        proximity tolerance. Signals with an unresolved terminal, or that don't
-        decode exactly, are skipped and fall back to the auto-router.
+        proximity tolerance. The stored polyline is the wire's ACTUAL block-
+        diagram geometry, drawn verbatim: the endpoints are the heap terminal
+        centers the decode was anchored to, so the renderer never re-anchors it
+        to a separately-computed terminal coordinate. Signals with an unresolved
+        terminal, or that don't decode exactly, are skipped and fall back to the
+        auto-router (the ONLY case autoroute runs).
         """
         from .wire_table import decode_signal
 
@@ -570,7 +575,8 @@ class _LayoutBuilder:
             if mids is None:
                 continue
             for sink_uid, mid in zip(sink_uids, mids):
-                by_uid[sink_uid] = mid
+                # Full wire: source anchor -> decoded bends -> sink anchor.
+                by_uid[sink_uid] = [src, *mid, self.terminal_centers[sink_uid]]
         return by_uid
 
     def _visit(self, elem: ET.Element, ox: float, oy: float) -> None:

--- a/src/lvkit/render/lane_pass.py
+++ b/src/lvkit/render/lane_pass.py
@@ -67,6 +67,14 @@ OVERLAP_TOL = 2.0
 
 _EPS = 1e-6
 
+# A single-segment near-straight wire whose two terminal centers differ by a
+# SUB-PIXEL amount off-axis (e.g. a tunnel's 9px-tall termBounds center at .5
+# vs a front-panel terminal's 16px-tall center at .0 -> 0.5px) is drawn STRAIGHT
+# rather than bent into a mid-Z jog to force strict orthogonality. LabVIEW draws
+# such a wire straight; a jag under ~1px is a visible defect, not fidelity. Only
+# an off-axis gap of at least this many px earns an actual orthogonal jog.
+_STRAIGHT_TOL = 1.0
+
 
 @dataclass(frozen=True)
 class _Segment:
@@ -93,6 +101,13 @@ class BranchCtx:
     # free to separate.
     src_border: bool = False
     dst_border: bool = False
+    # Whether this branch's geometry came from LabVIEW's OWN decoded wire table
+    # (``compressedWireTable``) rather than our fallback auto-router. Lanes are
+    # an auto-route concept — separating wires OUR router might stack on one
+    # track. A decoded wire already carries LabVIEW's real, already-separated
+    # geometry, so it bypasses this pass ENTIRELY: no snap, no slice, no
+    # re-track, no rebuild. Only auto-routed branches are lane candidates.
+    faithful: bool = False
 
 
 def _snap_orthogonal(pts: list[Point]) -> list[Point]:
@@ -345,14 +360,14 @@ def _rebuild_branch(
     # terminal faces stay correct.
     if n == 1 and seg_idxs[0] not in new_track:
         if orients[0] == "H":
-            if abs(src[1] - dst[1]) <= _EPS:
+            if abs(src[1] - dst[1]) <= _STRAIGHT_TOL:
                 return _compress([src, dst], tol=_EPS)
             midx = (src[0] + dst[0]) / 2
             return _compress(
                 [src, (midx, src[1]), (midx, dst[1]), dst],
                 tol=_EPS,
             )
-        if abs(src[0] - dst[0]) <= _EPS:
+        if abs(src[0] - dst[0]) <= _STRAIGHT_TOL:
             return _compress([src, dst], tol=_EPS)
         midy = (src[1] + dst[1]) / 2
         return _compress([src, (src[0], midy), (dst[0], midy), dst], tol=_EPS)
@@ -508,6 +523,13 @@ def apply_lane_pass(
             net_id = _net_id(net, ni)
             for bi, branch in enumerate(net.branches):
                 ctx = ctx_map.get((ni, bi), BranchCtx())
+                if ctx.faithful:
+                    # Decoded wire: LabVIEW already placed it. Bypass the pass
+                    # entirely — keep its geometry verbatim and contribute NO
+                    # segments, so it is invisible to lane assignment and never
+                    # snapped/rebuilt (which would jag a sub-pixel diagonal).
+                    rebuilt[(ni, bi)] = list(branch)
+                    continue
                 snapped = _snap_orthogonal(branch)
                 idxs: list[int] = []
                 for seg in _slice_branch(snapped, net_id):

--- a/src/lvkit/render/scene.py
+++ b/src/lvkit/render/scene.py
@@ -1523,21 +1523,26 @@ def _build_wire_nets(
             src_route_owner = None if src_border else src_owner
             dst_route_owner = None if dst_border else dst_owner
             # FAITHFUL_WIRE_TABLE: when a signal's compressedWireTable heap blob
-            # decoded (in layout, by exact known endpoints), use LabVIEW's own
-            # routed geometry instead of the auto-router. The geometry is keyed
-            # by the DESTINATION terminal uid — the graph and the heap agree on
-            # that uid exactly, so this is a pure identity lookup, no center
-            # rounding or tolerance. src_out/dst_in are still computed above
-            # regardless — the coercion-dot placement below (_entry_edge_point)
-            # needs dst_in even in the faithful case. Default False -> this lookup
-            # never runs, so `mid` is always `router.route(...)`.
+            # decoded (in layout, by exact known endpoints), draw LabVIEW's OWN
+            # full wire polyline VERBATIM — its own source/sink anchors and bends,
+            # the wire's actual block-diagram geometry. NO terminal-center
+            # override, NO stub, NO auto-router: the decode IS the wire, and the
+            # lane pass skips it too (BranchCtx.faithful). The auto-router runs
+            # ONLY when the decode fails (the rare fallback), splicing its bends
+            # between the terminal centers. The lookup is keyed by the DEST
+            # terminal uid — graph and heap agree on it exactly, a pure identity
+            # lookup. src_out/dst_in are still computed above regardless — the
+            # coercion-dot placement below (_entry_edge_point) needs dst_in even
+            # in the faithful case.
             faithful = None
             if FAITHFUL_WIRE_TABLE:
-                mid_pts = layout.wire_by_uid.get(raw_dst)
-                if mid_pts is not None:
-                    faithful = list(mid_pts)
+                full = layout.wire_by_uid.get(raw_dst)
+                if full is not None:
+                    faithful = list(full)
             if faithful is not None:
-                mid = faithful
+                # Verbatim decoded geometry (already source..sink); just drop
+                # exactly-collinear vertices, never re-anchor to a terminal.
+                branch = _compress(faithful)
             else:
                 mid = router.route(
                     src_out,
@@ -1546,10 +1551,11 @@ def _build_wire_nets(
                     src_route_owner,
                     dst_route_owner,
                 )
-            # Drop redundant collinear points (the directional stubs are often
-            # collinear with the first/last leg) so we don't add kinks LabVIEW
-            # wouldn't draw.
-            branches.append(_compress([src_center, *mid, dst_center]))
+                # Auto-route fallback: splice the router's bends between the
+                # terminal centers (drop stub-collinear kinks LabVIEW wouldn't
+                # draw).
+                branch = _compress([src_center, *mid, dst_center])
+            branches.append(branch)
             # Same obstacle/owner/confinement this branch was routed against,
             # keyed for the lane pass. net_index = len(nets) (this net is
             # appended after the group loop, so it will occupy that slot).
@@ -1559,6 +1565,9 @@ def _build_wire_nets(
                 confine=confine,
                 src_border=src_border,
                 dst_border=dst_border,
+                # LabVIEW's own decoded geometry -> bypass the auto-route lane
+                # pass entirely (see BranchCtx.faithful / apply_lane_pass).
+                faithful=faithful is not None,
             )
 
             # Coercion dot ONLY on a numeric-representation change (I32->DBL),

--- a/tests/test_issue_corpus.py
+++ b/tests/test_issue_corpus.py
@@ -122,6 +122,43 @@ def test_issue30_conditional_disable_opens_on_saved_visible_frame():
         assert frame_values[raw].index(shown) == 1, (raw, shown)
 
 
+def test_issue37_tunnel_wires_have_no_subpixel_jog():
+    """#37: a wire LabVIEW drew straight through a structure's border tunnel must
+    RENDER straight -- our auto-router's lane pass must not bend it.
+
+    The repro wires ``Numeric`` (I32) straight through a For Loop's input and
+    output tunnels to ``Numeric 2``. The tunnels' 9px-tall termBounds centre at
+    y.5 while the front-panel terminals' 16px-tall bounds centre at y.0 -- a real
+    0.5px offset baked into the VI. LabVIEW draws the wire straight across it;
+    lvkit used to snap the decoded-straight wire orthogonal and inject a mid-Z
+    jog at each tunnel (the reporter's two circled bends). Decoded wires now
+    bypass the auto-route lane pass ENTIRELY, and even the fallback router no
+    longer bends a wire to bridge a sub-pixel offset.
+    """
+    from lvkit.render import build_scene
+
+    graph, vi = _load("37/structure-tunnel-wire-bends.vi")
+    scene = build_scene(graph, vi)
+    assert scene is not None
+
+    def _sub_pixel_jogs(branch: list[tuple[float, float]]):
+        # A jog is an interior vertex whose SHORTER adjacent segment is under a
+        # pixel -- the exact signature of a wire bent to bridge a sub-pixel gap.
+        out = []
+        for i in range(1, len(branch) - 1):
+            a, b, c = branch[i - 1], branch[i], branch[i + 1]
+            la = ((a[0] - b[0]) ** 2 + (a[1] - b[1]) ** 2) ** 0.5
+            lc = ((c[0] - b[0]) ** 2 + (c[1] - b[1]) ** 2) ** 0.5
+            if 0 < min(la, lc) < 1.0:
+                out.append((a, b, c))
+        return out
+
+    branches = [br for net in scene.wire_nets for br in net.branches]
+    assert branches, "the repro really does have wires"
+    jogs = [seg for br in branches for seg in _sub_pixel_jogs(br)]
+    assert not jogs, f"wires bent by a sub-pixel jog (issue #37): {jogs}"
+
+
 @pytest.mark.parametrize("vi,issue_dir", _fixture_vis())
 def test_issue_fixture_renders(vi: Path, issue_dir: Path):
     """Every committed issue-repro VI loads and renders to a non-empty SVG --


### PR DESCRIPTION
Closes #37.

## 1. Tunnel wire bends (#37)
A wire LabVIEW drew straight through a For-loop tunnel rendered with two
unnecessary bends (the reporter's circled kinks). The wire is decoded
deterministically from the heap `compressedWireTable`, but scene.py threw its
endpoints away — it spliced the decoded bends between freshly-recomputed
terminal centers and then ran the auto-router's **lane pass** over the result.
Where the recomputed anchor disagreed with the decode's own anchor by even a
sub-pixel (a tunnel's 9px-tall `termBounds` centres at y.5 vs a front-panel
terminal's 16px-tall at y.0), the lane pass snapped the near-straight wire
orthogonal and injected a mid-Z jog.

**Autoroute (router + lane pass) is a fallback for wires whose decode fails —
never for a wire we already understand.** So a decoded wire is now drawn as
LabVIEW's own complete polyline **verbatim**: no terminal-center override, no
stub, no router, and it bypasses the lane pass entirely (`BranchCtx.faithful`).
The router/splice run only when the decode is absent.

- `parser/layout.py` — `wire_by_uid` stores the full polyline (`[source, *bends, sink]`).
- `render/scene.py` — decoded branch = that polyline verbatim.
- `render/lane_pass.py` — faithful branches bypass the pass; a sub-pixel-jog guard remains as an auto-route backstop.
- `graph/diff.py` — `_wire_path` returns the full decoded polyline directly.
- Test: `test_issue37_tunnel_wires_have_no_subpixel_jog`.

## 2. Byte-exact binary string constants
Surfaced while verifying #37 on the OpenG corpus: a 22-line `largeNamesDict`
string constant rendered as an empty box. pylabview serializes a constant's
binary `DefaultData` through a text codec, so any byte ≥0x80 collapses to
U+FFFD — a 250-byte string's length prefix `00 00 00 FA` loses its low byte, we
read 253, and the over-declared constant decodes empty.

Fix in our monkeypatch layer (**#7**): `HeapNodeString.prepareContentXML` now
serializes **only** the binary `OF__DefaultData` tag as `&#xNN;` byte-entities
— the exact form the constant reader and the localization tests already expect.
Entities are ASCII, so `normalize_extracted_xml` leaves them untouched and
`decode_xml_entities_to_bytes` recovers each byte; the code page is applied by
`decode_labview_text` (CJK string constants still decode correctly). Display
text (labels/names/formats) stays on the mac_roman + normalize path — verified
against `test_text_encoding`.

Also gate the extraction cache on a **narrow** `extraction_fingerprint` (hash of
just the pylabview monkeypatches + extractor + text-encoding helpers), so an
extraction-behaviour change rebuilds the XML without re-running pylabview over
the whole corpus on unrelated edits.

## Verification
ruff clean, pyright 0 errors, full suite **1885 passed, 32 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)