### PR TITLE
Fix #33: enum takes a coercion dot like its underlying uint

### DIFF
--- a/src/lvkit/render/style.py
+++ b/src/lvkit/render/style.py
@@ -182,16 +182,35 @@ _TYPE_REPR = {
 
 _NUMERIC_TYPES = _INT_TYPES | _FLOAT_TYPES | _COMPLEX_TYPES
 
+# An enum/ring is stored as an unsigned integer (the UnitUInt8/16/32 codes
+# 0x15/0x16/0x17) and coerces to/from numerics AS that integer — so it takes a
+# coercion dot against a differently-represented numeric exactly like a plain
+# uint would. Map the underlying unit token to the equivalent numeric token so
+# ``numeric_repr`` compares an enum by its width.
+_ENUM_UNIT_TO_NUMERIC = {
+    "UnitUInt8": "NumUInt8",
+    "UnitUInt16": "NumUInt16",
+    "UnitUInt32": "NumUInt32",
+}
+
 
 def numeric_repr(lv_type: LVType | None) -> str | None:
     """The numeric representation of a type (recursing into array elements),
     or None if it isn't numeric. A LabVIEW coercion dot appears ONLY when two
     wired terminals differ in numeric representation (I32 vs DBL) — NOT for
-    structural differences like array↔element at an auto-indexing tunnel."""
+    structural differences like array↔element at an auto-indexing tunnel.
+
+    An enum/ring counts as its underlying unsigned integer (``UnitUInt16`` ->
+    ``NumUInt16``): LabVIEW treats an enum as a special number, so wiring one to
+    a differently-sized numeric (e.g. a U16 enum into an I32 ``Initialize Array``
+    dimension-size input) coerces and draws a dot, just like a plain uint would
+    (issue #33)."""
     if lv_type is None:
         return None
     if lv_type.kind == LVTypeKind.ARRAY:
         return numeric_repr(lv_type.element_type)
+    if lv_type.kind in (LVTypeKind.ENUM, LVTypeKind.RING):
+        return _ENUM_UNIT_TO_NUMERIC.get(lv_type.underlying_type or "")
     if (
         lv_type.kind == LVTypeKind.PRIMITIVE
         and lv_type.underlying_type in _NUMERIC_TYPES

--- a/tests/test_issue_corpus.py
+++ b/tests/test_issue_corpus.py
@@ -159,6 +159,51 @@ def test_issue37_tunnel_wires_have_no_subpixel_jog():
     assert not jogs, f"wires bent by a sub-pixel jog (issue #37): {jogs}"
 
 
+def test_issue33_enum_coerces_like_its_underlying_int():
+    """#33: an enum wired to a differently-sized numeric input takes a coercion
+    dot, exactly like its underlying unsigned int would.
+
+    The repro wires a U16 ``Enum`` and a plain ``U32`` into two ``Initialize
+    Array`` ``dimension size`` inputs (``I32``). The U32 kept its dot but the
+    enum silently dropped it — ``numeric_repr`` treated an enum as non-numeric.
+    The decision keys off the UNDERLYING width (``UnitUInt16`` -> ``NumUInt16``),
+    NOT "enums always coerce": a same-width enum would not dot. Here U16 != I32,
+    so both wires dot (the "not consistent" bug).
+    """
+    from lvkit.models import LVType, LVTypeKind
+    from lvkit.render import build_scene
+    from lvkit.render.style import numeric_repr
+
+    # The fix's core: an enum reports its underlying integer's numeric repr.
+    enum_u16 = LVType(kind=LVTypeKind.ENUM, underlying_type="UnitUInt16")
+    assert numeric_repr(enum_u16) == "NumUInt16"
+    # ...so a same-width target would NOT coerce, a different width WOULD.
+    assert numeric_repr(enum_u16) != numeric_repr(
+        LVType(kind=LVTypeKind.PRIMITIVE, underlying_type="NumInt32")
+    )
+
+    # And the repro renders the dot: the enum-sourced wire into the I32 size
+    # input carries a coercion dot, just like the U32-sourced one (consistency is
+    # the whole bug).
+    graph, vi = _load("33/coercion-dot-consistency.vi")
+    scene = build_scene(graph, vi)
+    assert scene is not None
+    enum_dotted: list[bool] = []
+    uint_dotted: list[bool] = []
+    for net in scene.wire_nets:
+        if net.source is None:
+            continue
+        lt = getattr(graph.get_terminal(net.source.source.terminal_id), "lv_type", None)
+        if lt is None:
+            continue
+        if lt.kind in (LVTypeKind.ENUM, LVTypeKind.RING):
+            enum_dotted.append(bool(net.coercion_dots))
+        elif numeric_repr(lt) == "NumUInt32":  # the plain U32 control
+            uint_dotted.append(bool(net.coercion_dots))
+    assert enum_dotted and all(enum_dotted), "enum wire into I32 size input has no dot"
+    assert uint_dotted and all(uint_dotted), "U32 wire regressed (no coercion dot)"
+
+
 @pytest.mark.parametrize("vi,issue_dir", _fixture_vis())
 def test_issue_fixture_renders(vi: Path, issue_dir: Path):
     """Every committed issue-repro VI loads and renders to a non-empty SVG --


### PR DESCRIPTION
Closes #33.

Coercion dots appeared inconsistently by source type: a plain **U32** wired into
an `Initialize Array` **dimension size** (`I32`) input drew a dot, but a U16
**Enum** into the same input silently dropped it.

**Root cause:** `numeric_repr` (style.py) — the representation token the coercion
check compares — only recognized `ARRAY` and `PRIMITIVE` numerics. An enum's
type (`kind=ENUM`, `underlying_type="UnitUInt16"`) fell through to `None`, so the
`src_num is not None` guard skipped the dot.

**Fix:** an enum/ring is stored as an unsigned integer (the `UnitUInt8/16/32`
codes) and LabVIEW coerces it to/from numerics *as* that integer, so
`numeric_repr` now maps an enum/ring to its underlying numeric token
(`UnitUInt16` → `NumUInt16`). The dot is decided by **width**, not "enums always
coerce" — a same-width target would not dot; here U16 ≠ I32, so both wires dot,
consistently.

Refs: [NI — Enumerated Type Controls](https://www.ni.com/docs/en-US/bundle/labview/page/enumerated-type-controls.html), [Dealing with Coercion Dots](https://forums.ni.com/t5/LabVIEW/Dealing-with-Coercion-Dots/td-p/926925).

Test: `test_issue33_enum_coerces_like_its_underlying_int` (asserts the width mapping + that the repro's enum wire renders a coercion dot like the U32 one). ruff clean, pyright 0 errors, full suite 1886 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)