### PR TITLE
Cache fingerprint correctness: frozen binary, bundled-only extension, fingerprint-in-path

### DIFF
--- a/.github/workflows/publish-bundles.yml
+++ b/.github/workflows/publish-bundles.yml
@@ -93,6 +93,24 @@ jobs:
           uv pip install -e . pyinstaller
           uv run bash editors/vscode/build/build-binary.sh
 
+      # Smoke-test the FROZEN binary actually RENDERS a VI — the one thing the
+      # build never exercised. A PyInstaller build ships no .py sources, so a code
+      # path that reads its own source (as extraction_fingerprint once did) crashes
+      # ONLY in the frozen binary, never under `uv run` / pytest. Render a
+      # committed fixture that needs extraction (the exact path that broke) and
+      # require real SVG output — the extension reads this file back, so "exits 0
+      # but wrote nothing" is a release-blocker, not a warning.
+      - name: Smoke-test the bundled binary renders a VI
+        shell: bash
+        run: |
+          BIN="editors/vscode/bin/lvkit/lvkit"
+          [ "${{ matrix.target }}" = "win32-x64" ] && BIN="$BIN.exe"
+          "$BIN" render "tests/corpus/issues/34/hidden-iteration-terminal.vi" \
+            --format html --no-cache -o "$RUNNER_TEMP/smoke.html"
+          test -s "$RUNNER_TEMP/smoke.html" || { echo "::error::bundled binary produced no render"; exit 1; }
+          grep -q "<svg" "$RUNNER_TEMP/smoke.html" || { echo "::error::bundled binary render has no SVG"; exit 1; }
+          echo "bundled binary render OK ($(wc -c < "$RUNNER_TEMP/smoke.html") bytes)"
+
       # Windows only: sign every PE in the bundle so Smart App Control (which
       # blocks unsigned native code on enforce-mode Win11) allows the bundled
       # lvkit binary. SAC evaluates each on-disk file by its own hash, so every

--- a/editors/vscode/build/build-binary.sh
+++ b/editors/vscode/build/build-binary.sh
@@ -25,10 +25,13 @@ WORK="editors/vscode/build/.pyi-work"
 # to the package: a frozen binary ships no .py sources, so it cannot compute them
 # at runtime — without this the render/index caches would degrade (blind to code
 # changes) or crash. See embed_fingerprints.py + cache_paths._embedded_fingerprints.
-# ABSOLUTE path: PyInstaller resolves an --add-data SOURCE relative to
-# --specpath, not the cwd, so a repo-relative path would double and be silently
-# skipped (it only prints an ERROR and still exits 0).
-FP_DIR="$REPO/$WORK/fp"
+# PyInstaller resolves an --add-data SOURCE relative to --specpath (NOT the cwd).
+# Write the file under the workdir (= specpath) and pass it as a plain
+# specpath-relative "fp/…" path: a repo-relative path would double (and be
+# silently skipped — PyInstaller only prints an ERROR yet still exits 0), and an
+# absolute git-bash path (/d/a/…) gets mangled to \d\a\ when it reaches the native
+# PyInstaller through the "src;dest" arg on Windows. A bare "fp/…" avoids both.
+FP_DIR="$WORK/fp"
 mkdir -p "$FP_DIR"
 python editors/vscode/build/embed_fingerprints.py "$FP_DIR/_build_fingerprints.json"
 # PyInstaller's --add-data separator is os.pathsep: ';' on Windows, ':' elsewhere.
@@ -40,7 +43,7 @@ case "$(uname -s)" in MINGW*|MSYS*|CYGWIN*) ADSEP=";" ;; *) ADSEP=":" ;; esac
   --collect-all pylabview \
   --collect-submodules networkx \
   --exclude-module tkinter --exclude-module matplotlib \
-  --add-data "$FP_DIR/_build_fingerprints.json${ADSEP}lvkit" \
+  --add-data "fp/_build_fingerprints.json${ADSEP}lvkit" \
   --distpath editors/vscode/bin \
   --workpath "$WORK" \
   --specpath "$WORK" \

--- a/editors/vscode/build/build-binary.sh
+++ b/editors/vscode/build/build-binary.sh
@@ -20,16 +20,40 @@ PYI="${PYINSTALLER:-pyinstaller}"
 # the checkout is on D:, but Git Bash has no TMPDIR so "${TMPDIR:-/tmp}" resolves
 # to C:\...\Temp. A repo-relative path is always on the same drive as the source.
 WORK="editors/vscode/build/.pyi-work"
+
+# Capture lvkit's cache fingerprints from the LIVE sources and bundle them next
+# to the package: a frozen binary ships no .py sources, so it cannot compute them
+# at runtime — without this the render/index caches would degrade (blind to code
+# changes) or crash. See embed_fingerprints.py + cache_paths._embedded_fingerprints.
+# ABSOLUTE path: PyInstaller resolves an --add-data SOURCE relative to
+# --specpath, not the cwd, so a repo-relative path would double and be silently
+# skipped (it only prints an ERROR and still exits 0).
+FP_DIR="$REPO/$WORK/fp"
+mkdir -p "$FP_DIR"
+python editors/vscode/build/embed_fingerprints.py "$FP_DIR/_build_fingerprints.json"
+# PyInstaller's --add-data separator is os.pathsep: ';' on Windows, ':' elsewhere.
+case "$(uname -s)" in MINGW*|MSYS*|CYGWIN*) ADSEP=";" ;; *) ADSEP=":" ;; esac
+
 "$PYI" --onedir --name lvkit --noconfirm \
   --collect-data lvkit \
   --collect-submodules lvkit \
   --collect-all pylabview \
   --collect-submodules networkx \
   --exclude-module tkinter --exclude-module matplotlib \
+  --add-data "$FP_DIR/_build_fingerprints.json${ADSEP}lvkit" \
   --distpath editors/vscode/bin \
   --workpath "$WORK" \
   --specpath "$WORK" \
   editors/vscode/build/lvkit_entry.py
+
+# Fail loudly if the build fingerprints didn't bundle (PyInstaller only prints an
+# ERROR and still exits 0 on a missing --add-data source). Without this file the
+# binary falls back to the code-blind/sentinel path — the very thing this fixes.
+BUNDLED_FP="editors/vscode/bin/lvkit/_internal/lvkit/_build_fingerprints.json"
+test -f "$BUNDLED_FP" || {
+  echo "ERROR: build fingerprints were not bundled ($BUNDLED_FP missing)" >&2
+  exit 1
+}
 
 # macOS PyInstaller emits a Python.framework bundle containing SYMLINKS THAT
 # POINT AT DIRECTORIES (Resources -> Versions/Current/Resources, and

--- a/editors/vscode/build/embed_fingerprints.py
+++ b/editors/vscode/build/embed_fingerprints.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Capture lvkit's cache fingerprints from the LIVE sources for a frozen build.
+
+A PyInstaller binary ships compiled code, not the ``.py`` sources that
+``cache_paths.source_fingerprint`` / ``extraction_fingerprint`` hash — so at
+runtime the binary cannot compute them (source_fingerprint would see only the
+bundled data files, blind to code; extraction_fingerprint's fixed source list
+would not exist at all). This runs at BUILD time, where the sources ARE present,
+and writes both fingerprints to a JSON file that build-binary.sh bundles next to
+the package. At runtime the fingerprint functions return these embedded values,
+so the binary's caches stay correct AND code-aware — the same keys a source or
+wheel install computes — instead of degrading or crashing.
+
+Usage: embed_fingerprints.py <out.json>
+"""
+
+import json
+import sys
+from pathlib import Path
+
+from lvkit import cache_paths
+
+
+def main() -> int:
+    out = Path(sys.argv[1])
+    # Computed from the live source tree (no _build_fingerprints.json exists yet,
+    # so these equal what a source/wheel install computes for this same code).
+    fingerprints = {
+        "source": cache_paths.source_fingerprint(),
+        "extraction": cache_paths.extraction_fingerprint(),
+    }
+    out.write_text(json.dumps(fingerprints, indent=2) + "\n", encoding="utf-8")
+    print(f"embedded fingerprints -> {out}")
+    for k, v in fingerprints.items():
+        print(f"  {k}: {v}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/editors/vscode/extension.js
+++ b/editors/vscode/extension.js
@@ -66,47 +66,46 @@ function bundledLvkit() {
 }
 
 // Resolve a ready-to-exec lvkit command PREFIX for a repo `root`. The prefix may
-// be MULTIPLE tokens (e.g. `uv run lvkit`), so callers must interpolate it raw —
-// never wrap the whole prefix in quotes as if it were a single path. Order:
+// be interpolated raw — never wrap the whole prefix in quotes as if it were a
+// single path. Order (SAME as mcpServerSpec, so the extension's CLI half and MCP
+// half can never land on different lvkit versions):
 //   1. an explicit `lvkit.path` override (the literal default "lvkit" counts as
-//      unset, so auto-resolution can still run) — quoted as one path. IGNORED in
-//      an untrusted workspace (running an arbitrary workspace-configured binary
-//      is exactly what Workspace Trust guards against).
-//   2. the repo-local venv's lvkit on disk (developing inside a lvkit project);
-//   3. `uv run lvkit` when the repo has a pyproject.toml/uv.lock and `uv` is on
-//      PATH (runs lvkit inside the repo's own env — latest code when developing);
-//   4. the BUNDLED, signed standalone binary shipped with the extension (works
-//      with no Python installed — the default for a normal end user);
-//   5. a global `lvkit` on PATH.
+//      unset) — quoted as one path. IGNORED in an untrusted workspace (running an
+//      arbitrary workspace-configured binary is what Workspace Trust guards).
+//   2. the BUNDLED, signed standalone binary shipped with the extension — the
+//      DEFAULT. The extension ALWAYS uses its own bundled lvkit, NEVER a repo
+//      `.venv`/`uv run`: a workspace `.venv` can hold a DIFFERENT lvkit version,
+//      which split the CLI half (this) from the MCP half (mcpServerSpec) onto two
+//      versions writing one shared ~/.lvkit/cache → each treats the other's
+//      entries as foreign and re-extracts the whole corpus. To develop against
+//      live code, point `lvkit.path` at your checkout's binary explicitly.
+//   3. a global `lvkit` on PATH (only when no bundle is present).
 // We NEVER write a global lvkit.path from here.
-function lvkitCmd(root) {
+function lvkitCmd() {
   if (vscode.workspace.isTrusted) {
     const configured = cfg().get('path', 'lvkit');
     if (configured && configured !== 'lvkit') return `"${configured}"`;
   }
-  const venv = process.platform === 'win32'
-    ? path.join(root, '.venv', 'Scripts', 'lvkit.exe')
-    : path.join(root, '.venv', 'bin', 'lvkit');
-  if (fileExists(venv)) return `"${venv}"`;
-  const hasProj = fileExists(path.join(root, 'pyproject.toml')) || fileExists(path.join(root, 'uv.lock'));
-  if (hasProj && onPath('uv')) return 'uv run lvkit';
   const bundled = bundledLvkit();
   if (bundled) return `"${bundled}"`;
   return 'lvkit';
 }
 
 // Resolve the lvkit MCP server as {command, args} for McpStdioServerDefinition,
-// which needs the executable and its args SPLIT (not a shell prefix string). We
-// do NOT use `uv run lvkit` here — an MCP server is a long-lived process VS Code
-// launches directly, so we point at a real executable: the bundled signed binary
-// first, then a repo .venv (dev), then `lvkit` on PATH.
-function mcpServerSpec(root) {
+// which needs the executable and its args SPLIT (not a shell prefix string).
+// SAME resolution as lvkitCmd, so the MCP half and the CLI half always run the
+// EXACT SAME lvkit build — an explicit `lvkit.path` override (trusted only),
+// then the BUNDLED signed binary (the default), then `lvkit` on PATH. No repo
+// `.venv`/`uv run`: the MCP server, the render viewer, and the diff viewer must
+// all agree on one lvkit, or they write conflicting entries into one shared
+// ~/.lvkit/cache and re-do each other's work.
+function mcpServerSpec() {
+  if (vscode.workspace.isTrusted) {
+    const configured = cfg().get('path', 'lvkit');
+    if (configured && configured !== 'lvkit') return { command: configured, args: ['mcp'] };
+  }
   const bundled = bundledLvkit();
   if (bundled) return { command: bundled, args: ['mcp'] };
-  const venv = process.platform === 'win32'
-    ? path.join(root, '.venv', 'Scripts', 'lvkit.exe')
-    : path.join(root, '.venv', 'bin', 'lvkit');
-  if (fileExists(venv)) return { command: venv, args: ['mcp'] };
   return { command: 'lvkit', args: ['mcp'] };
 }
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -36,7 +36,7 @@
         "lvkit.path": {
           "type": "string",
           "default": "lvkit",
-          "markdownDescription": "Path to the `lvkit` executable. Use just `lvkit` if it is on your PATH, or an absolute path (e.g. a project venv's `.venv/bin/lvkit`). If unset, LVKit prefers a lvkit checkout's own `.venv`/`uv run lvkit`, then falls back to its bundled standalone binary. Ignored in an untrusted workspace."
+          "markdownDescription": "Path to a specific `lvkit` executable, overriding the one bundled with the extension. Leave unset (the default) and LVKit always uses its own bundled standalone binary for rendering, diffing, and the MCP server — one build behind every view, so they share a cache instead of fighting over it. Set this only to point at your own build (e.g. a checkout's `.venv/bin/lvkit`) when developing lvkit itself. Ignored in an untrusted workspace."
         },
         "lvkit.searchPaths": {
           "type": "array",

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,5 +1,8 @@
 {
   "include": ["src/lvkit"],
+  "extraPaths": ["src"],
+  "venvPath": ".",
+  "venv": ".venv",
   "pythonVersion": "3.10",
   "typeCheckingMode": "basic"
 }

--- a/src/lvkit/cache_paths.py
+++ b/src/lvkit/cache_paths.py
@@ -90,13 +90,77 @@ def clear_extraction_roots() -> None:
 
 
 def _slug(path: Path) -> str:
-    """Readable per-project cache namespace: the absolute path with its
-    separators turned into ``-`` (``/home/u/repo`` -> ``-home-u-repo``), the way
-    ``~/.claude/projects`` names per-repo dirs. No hash — you can read the cache
-    and see which project a file came from. Windows drive colons and backslashes
-    collapse the same way (``C:\\proj`` -> ``C--proj``).
+    """Compact, path-unique, ALWAYS-bounded cache dir name for an owner root: its
+    last path component (readable) + ``-`` + 8 hex of a sha256 of the FULL path
+    (uniqueness). ``/home/u/repo`` -> ``repo-9f3a1c2b``; ``C:\\proj`` -> ``proj-…``.
+
+    Bounded length is the point: an arbitrarily deep project can never push a
+    cache path past the Windows MAX_PATH limit (the failure the old full-path slug
+    only *warned* about). The tail carries human readability; the hash carries
+    identity — the tail alone is NOT unique (two projects can share a final
+    component like ``test``/``src``). The full path is recoverable from the
+    ``_dirs.json`` sidecar (:func:`_note_owner`).
+
+    Deliberately NOT the build fingerprint: that is identical for every project,
+    so it could never tell two projects apart — it lives in its own path level
+    (:func:`kind_fingerprint`).
     """
-    return str(path).replace(":", "-").replace("\\", "-").replace("/", "-")
+    tail = path.name or "root"
+    tail = "".join(c if (c.isalnum() or c in "._-") else "-" for c in tail)
+    h = hashlib.sha256(str(path).encode("utf-8")).hexdigest()[:8]
+    return f"{tail}-{h}"
+
+
+def kind_fingerprint(kind: str) -> str:
+    """The 8-hex build-compatibility tag stamped into a cache path for ``kind``.
+
+    ``extract`` keys off :func:`extraction_fingerprint` (the narrow extraction-code
+    hash) so an extract slot survives unrelated parser/render edits; every other
+    kind (``render``/``diff``/``index``) keys off :func:`source_fingerprint` (the
+    whole-package hash). This is why the fingerprint sits BELOW ``<kind>`` in the
+    path — the two kinds have genuinely different compatibility axes and each must
+    carry the one that governs it. Truncated to 8 hex: enough to separate
+    incompatible builds, short enough to stay clear of MAX_PATH. Both underlying
+    fingerprints are ``lru_cache``d (and embedded in a frozen build), so this is a
+    memoized lookup + slice, not real work on the hit path."""
+    fp = extraction_fingerprint() if kind == "extract" else source_fingerprint()
+    return fp[:8]
+
+
+_noted_owners: set[str] = set()
+
+
+def _note_owner(owner: Path) -> None:
+    """Best-effort: record ``slug -> full owner path`` in ``<cache>/_dirs.json`` so
+    the compact ``<tail>-<hash>`` slug stays reversible for ``lvkit cache`` / a
+    human. DISPLAY-ONLY — never read to resolve a path on the hit path, so a lost
+    or malformed row can only affect pretty-printing, never correctness. Memoized
+    per owner per process, so it touches disk at most once per project; the write
+    is atomic (temp + replace) and fully best-effort."""
+    key = str(owner)
+    if key in _noted_owners:
+        return
+    _noted_owners.add(key)
+    try:
+        f = global_cache_root() / "_dirs.json"
+        data: dict[str, str] = {}
+        if f.exists():
+            try:
+                loaded = json.loads(f.read_text(encoding="utf-8"))
+                if isinstance(loaded, dict):
+                    data = {str(k): str(v) for k, v in loaded.items()}
+            except (OSError, ValueError):
+                data = {}
+        slug = _slug(owner)
+        if data.get(slug) == key:
+            return
+        data[slug] = key
+        f.parent.mkdir(parents=True, exist_ok=True)
+        tmp = f.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(data, sort_keys=True), encoding="utf-8")
+        os.replace(tmp, f)
+    except OSError:
+        pass
 
 
 def _rel_under(child: Path, parent: Path | None) -> Path | None:
@@ -151,41 +215,51 @@ def classify(vi_path: Path, kind: str) -> tuple[Path, str, str]:
     """Map ``vi_path`` to ``(cache_dir, source_label, namespace)`` for one
     artifact ``kind`` (``"extract"`` | ``"render"`` | ``"diff"``).
 
-    ``cache_dir`` is ``<cache>/<ns>/<slug>/<kind>/<rel-parent>`` — project-first:
-    the VI's identity (namespace + slug) is named ONCE and the ``kind`` hangs off
-    it, so one project's whole cache is a single subtree and sibling VIs of the
-    same kind share a dir. ``namespace`` is ``"projects"``, ``"shared"``, or
-    ``"adhoc"`` — callers path-address the first two and content-address
-    ``adhoc`` (its paths never repeat).
+    ``cache_dir`` is ``<cache>/<ns>/<slug>/<kind>/<fp>/<rel-parent>`` — project-
+    first: the VI's identity (namespace + slug) is named ONCE and the ``kind``
+    hangs off it, so one project's whole cache is a single subtree and sibling VIs
+    of the same kind + build share a dir. ``<fp>`` is the per-kind build tag
+    (:func:`kind_fingerprint`) so two incompatible lvkit builds get separate slots
+    instead of clobbering each other. ``namespace`` is ``"projects"``,
+    ``"shared"``, or ``"adhoc"`` — callers path-address the first two and
+    content-address ``adhoc`` (its paths never repeat).
     """
     resolved = vi_path.resolve()
     cache = global_cache_root()
+    # The per-kind build-compatibility tag (see kind_fingerprint): sits BELOW
+    # <kind> so two incompatible lvkit builds land in SEPARATE slots (they no
+    # longer overwrite each other in place -> no cross-version re-render thrash),
+    # while same-build lookups still hit the same slot.
+    fp = kind_fingerprint(kind)
 
     vilib = _vilib_root
     if vilib is not None:
         rel = _rel_under(resolved, vilib)
         if rel is not None:
-            d = cache / "shared" / "vilib" / _slug(vilib) / kind / rel.parent
+            _note_owner(vilib)
+            d = cache / "shared" / "vilib" / _slug(vilib) / kind / fp / rel.parent
             return d, str(rel), "shared"
 
     userlib = _userlib_root
     if userlib is not None:
         rel = _rel_under(resolved, userlib)
         if rel is not None:
-            d = cache / "shared" / "userlib" / _slug(userlib) / kind / rel.parent
+            _note_owner(userlib)
+            d = cache / "shared" / "userlib" / _slug(userlib) / kind / fp / rel.parent
             return d, str(rel), "shared"
 
     project = _project_root_for(resolved)
     if project is not None:
         proj_abs = project.resolve()
         rel = resolved.relative_to(proj_abs)
-        d = cache / "projects" / _slug(proj_abs) / kind / rel.parent
+        _note_owner(proj_abs)
+        d = cache / "projects" / _slug(proj_abs) / kind / fp / rel.parent
         return d, str(rel), "projects"
 
     # adhoc has NO owner (not a project, not a library) -> no identity slug to
     # name; kind sits right under the namespace and the parent-dir slug is just
     # the path-addressing key (render/diff override this to a flat content pool).
-    return cache / "adhoc" / kind / _slug(resolved.parent), resolved.name, "adhoc"
+    return cache / "adhoc" / kind / fp / _slug(resolved.parent), resolved.name, "adhoc"
 
 
 def cache_target(vi_path: Path, kind: str) -> Path:
@@ -394,7 +468,13 @@ def write_meta(vi_path: Path, meta_path: Path, **extra: object) -> None:
     meta_path.write_text(json.dumps(meta), encoding="utf-8")
 
 
-# ── One-time migration of the pre-kind extraction cache ─────────────────────
+# ── One-time migration of superseded cache layouts ──────────────────────────
+
+# The on-disk cache PATH schema. Bump ONLY when the path layout changes (not on a
+# source/fingerprint change — that is handled by the <fp> path level). A mismatch
+# triggers a one-time drop of the derived namespaces in cleanup_legacy_cache.
+#   "2": project-first with a per-kind <fp> level and <tail>-<hash8> slugs.
+_LAYOUT_VERSION = "2"
 
 
 def cleanup_legacy_cache() -> None:
@@ -419,3 +499,24 @@ def cleanup_legacy_cache() -> None:
         legacy = root / kind
         if legacy.is_dir():
             shutil.rmtree(legacy, ignore_errors=True)
+
+    # Layout migration: the project-first tree gained a per-kind <fp> level and
+    # the slug became <tail>-<hash8> (see classify / _slug). BOTH change every
+    # owned path, so pre-existing entries are unreachable dead weight — a lookup
+    # now computes a different path and simply misses (correctness never depends
+    # on this cleanup; it only reclaims the orphaned disk). On a layout-version
+    # mismatch, drop the derived namespaces ONCE and stamp the new version; the
+    # next run repopulates lazily under the new paths.
+    marker = root / "_layout_version"
+    try:
+        current = marker.read_text(encoding="utf-8").strip() if marker.exists() else ""
+    except OSError:
+        current = ""
+    if current != _LAYOUT_VERSION:
+        for ns in ("projects", "shared", "adhoc"):
+            shutil.rmtree(root / ns, ignore_errors=True)
+        try:
+            root.mkdir(parents=True, exist_ok=True)
+            marker.write_text(_LAYOUT_VERSION, encoding="utf-8")
+        except OSError:
+            pass

--- a/src/lvkit/cache_paths.py
+++ b/src/lvkit/cache_paths.py
@@ -216,6 +216,32 @@ def sha256_file(path: Path) -> str:
 # staleness back in.
 _FINGERPRINT_SKIP_DIRS = frozenset({"codegen", "docs", "formula", "mcp"})
 
+# A FROZEN distribution (PyInstaller) ships compiled code, not the ``.py``
+# sources the fingerprints hash, so neither fingerprint is computable at runtime
+# there (``source_fingerprint`` would see only the bundled data files — blind to
+# code — and ``extraction_fingerprint``'s fixed include list would not exist at
+# all). The build instead computes BOTH from the live sources and writes them to
+# this file, bundled next to the package (editors/vscode/build/build-binary.sh +
+# embed_fingerprints.py); at runtime each fingerprint returns the embedded value
+# when present, so a built binary's caches stay correct AND code-aware — the same
+# keys a source/wheel install computes — instead of degrading or crashing. Absent
+# in a normal source/wheel install, where the live computation is authoritative.
+_BUILD_FINGERPRINTS_FILE = "_build_fingerprints.json"
+
+
+@functools.lru_cache(maxsize=1)
+def _embedded_fingerprints() -> dict[str, str]:
+    """The build-time fingerprints bundled into a frozen distribution, or an
+    empty dict for a live source/wheel install (no such file)."""
+    # This module lives inside the package, so its own directory IS the package
+    # root — no need to import the top-level package to find it.
+    f = Path(__file__).resolve().parent / _BUILD_FINGERPRINTS_FILE
+    try:
+        raw = json.loads(f.read_text(encoding="utf-8"))
+    except OSError:
+        return {}
+    return {str(k): str(v) for k, v in raw.items()}
+
 
 @functools.lru_cache(maxsize=1)
 def source_fingerprint() -> str:
@@ -238,10 +264,16 @@ def source_fingerprint() -> str:
     over-invalidates at worst (one extra cold rebuild). Memoized: the source
     cannot change within a live process (Python does not hot-reload), and a dev
     editing lvkit restarts it before the next run anyway.
-    """
-    import lvkit
 
-    pkg = Path(lvkit.__file__).resolve().parent
+    In a frozen build the sources aren't on disk, so use the build-time value
+    embedded next to the package (``_BUILD_FINGERPRINTS_FILE``) instead of
+    hashing the code-blind data-file remnant.
+    """
+    embedded = _embedded_fingerprints().get("source")
+    if embedded:
+        return embedded
+
+    pkg = Path(__file__).resolve().parent
     h = hashlib.sha256()
     for f in sorted(pkg.rglob("*")):
         if not f.is_file() or f.suffix == ".pyc" or "__pycache__" in f.parts:
@@ -278,15 +310,34 @@ def extraction_fingerprint() -> str:
     pylabview monkeypatch, a read option, the normalize pass — but NOT when
     post-extraction code (parser/graph/render, keyed on ``source_fingerprint``)
     changes. Kept separate from ``source_fingerprint`` on purpose: extraction is
-    the expensive, rarely-changing stage."""
-    import lvkit
+    the expensive, rarely-changing stage.
 
-    pkg = Path(lvkit.__file__).resolve().parent
+    Reads the extraction ``.py`` sources when they are on disk (source checkout,
+    installed wheel, Cloud Run) — the precise, narrow signal. In a FROZEN build
+    (PyInstaller ships compiled code, not ``.py`` sources) those files are absent,
+    so it uses the build-time value embedded next to the package instead. The
+    sentinel return is a last-resort defense for the unexpected case of a frozen
+    build with neither the sources nor an embedded fingerprint — it never crashes
+    trying to read its own source at runtime.
+    """
+    embedded = _embedded_fingerprints().get("extraction")
+    if embedded:
+        return embedded
+
+    pkg = Path(__file__).resolve().parent
     h = hashlib.sha256()
     for rel in _EXTRACTION_CODE_FILES:
+        try:
+            data = (pkg / rel).read_bytes()
+        except OSError:
+            # Defensive only: a frozen build missing BOTH its .py sources and the
+            # embedded fingerprint (a broken build — build-binary.sh always embeds
+            # it, which short-circuits above). Return a stable sentinel rather
+            # than crash; a correctly built binary never reaches here.
+            return "extraction-unavailable"
         h.update(rel.encode())
         h.update(b"\0")
-        h.update((pkg / rel).read_bytes())
+        h.update(data)
         h.update(b"\0")
     return h.hexdigest()
 

--- a/src/lvkit/extractor.py
+++ b/src/lvkit/extractor.py
@@ -37,7 +37,6 @@ from lvkit.cache_paths import (  # noqa: E402
     _slug,
     classify,
     cleanup_legacy_cache,
-    extraction_fingerprint,
     global_cache_root,
     meta_fresh,
 )
@@ -139,7 +138,6 @@ def _write_cache_meta(vi_path: Path, meta_path: Path) -> None:
         tool="pylabview",
         extracted_at=time.time(),
         text_encoding=labview_text_encoding(),
-        extraction_fingerprint=extraction_fingerprint(),
     )
     os.replace(tmp, meta_path)
 
@@ -262,25 +260,28 @@ def extract_vi_xml(
     meta_path = output_dir / f"{vi_stem}.meta.json"
 
     # Cache hit: XML present and the recorded content-hash (or mtime/size
-    # fast-path) still matches the VI.
+    # fast-path) still matches the VI. The extraction-code compatibility check is
+    # now the <extraction_fingerprint> level of the cache PATH (see
+    # cache_paths.kind_fingerprint): an extraction-code change lands in a DIFFERENT
+    # <fp> dir, so a stale slice is never even looked at here — this meta only has
+    # to catch a VI-content or text-encoding change. Bump the slice's mtime on the
+    # hit so the access-TTL sweep keeps the build in active use and only retires
+    # ones the user has upgraded away from.
     if (
         not force
         and bd_xml.exists()
         and meta_fresh(
             vi_path,
             meta_path,
-            extra={
-                "text_encoding": labview_text_encoding(),
-                # Invalidate ONLY when the extraction code changes (a pylabview
-                # monkeypatch / read option / the normalize pass — see
-                # extraction_fingerprint), NOT on unrelated parser/render edits.
-                # Without it an extraction-behaviour change silently serves stale
-                # XML; with source_fingerprint it would needlessly re-run
-                # pylabview over the whole corpus on every edit.
-                "extraction_fingerprint": extraction_fingerprint(),
-            },
+            extra={"text_encoding": labview_text_encoding()},
         )
     ):
+        _now = time.time()
+        for _p in (bd_xml, meta_path):
+            try:
+                os.utime(_p, (_now, _now))
+            except OSError:
+                pass
         return (
             bd_xml,
             fp_xml if fp_xml.exists() else None,

--- a/src/lvkit/index/store.py
+++ b/src/lvkit/index/store.py
@@ -30,7 +30,9 @@ version bump to forget. See ``_ensure_facts_version``.
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
+import time
 from collections.abc import Iterable
 from pathlib import Path
 from typing import Any, cast
@@ -297,18 +299,40 @@ _facts_fingerprint = cache_paths.source_fingerprint
 
 
 def db_path(project_root: Path) -> Path:
-    """The SQLite file for ``project_root``'s index (parent dir created)."""
+    """The SQLite file for ``project_root``'s index (parent dir created).
+
+    Path-partitioned by the source fingerprint (``kind_fingerprint("index")`` —
+    the same ``<fp>`` level every other cache kind uses) so two incompatible lvkit
+    builds keep SEPARATE index dbs and never drop/rebuild each other's tables. The
+    stored-fingerprint self-invalidation in ``_ensure_facts_version`` is now a
+    backstop (a matching path already implies a matching fingerprint), kept
+    because its guard test and any pre-<fp> db still rely on it.
+    """
     slug = cache_paths._slug(project_root.resolve())
-    d = cache_paths.global_cache_root() / "projects" / slug / "index"
+    d = (
+        cache_paths.global_cache_root()
+        / "projects"
+        / slug
+        / "index"
+        / cache_paths.kind_fingerprint("index")
+    )
     d.mkdir(parents=True, exist_ok=True)
     return d / "index.db"
 
 
 def _connect(project_root: Path) -> sqlite3.Connection:
-    conn = sqlite3.connect(db_path(project_root))
+    path = db_path(project_root)
+    conn = sqlite3.connect(path)
     conn.execute("PRAGMA journal_mode=WAL")
     _ensure_facts_version(conn)
     conn.executescript(_SCHEMA)
+    # Bump the slice's mtime so the access-TTL sweep keeps an index in active use
+    # warm and only retires the ones for builds the user has upgraded away from.
+    try:
+        now = time.time()
+        os.utime(path, (now, now))
+    except OSError:
+        pass
     return conn
 
 

--- a/src/lvkit/output_cache.py
+++ b/src/lvkit/output_cache.py
@@ -16,36 +16,69 @@ Addressing mirrors extraction (see :mod:`lvkit.cache_paths`):
   outside any repo) has no owner and no reusable path, so it is **content-
   addressed** in a flat ``<cache>/adhoc/render/<sha>.<ext>`` and swept by TTL.
 
-Freshness = the VI-content signal ``cache_paths.meta_fresh`` already uses PLUS
-the SHARED ``cache_paths.source_fingerprint()`` (the same hash-of-lvkit-source
-that invalidates the SQLite index — so a renderer/graph/parser/data edit busts
-this cache too, with no version bump), the lvkit ``version`` (kept for readable
-meta), text encoding, and an ``options`` tag — so a VI edit, an lvkit CODE
-change, a system-code-page change, or different ``--format``/``--theme`` is a
-miss.
+FRESHNESS (in ``meta.json``, checked by ``cache_paths.meta_fresh``) = the
+VI-content signal (``sha256``/``mtime``/``size``), the ``text_encoding`` (system
+code page), an ``options`` tag, and the lvkit ``version`` (kept for readable
+meta) — so a VI edit, a code-page change, or a different ``--format``/``--theme``
+is a miss.
+
+COMPATIBILITY — which lvkit BUILD produced the artifact — is deliberately NOT a
+freshness key. It is the ``<fp>`` level of the cache PATH (``cache_paths``
+``kind_fingerprint`` → ``source_fingerprint``), so an incompatible build simply
+finds nothing at its own path and rebuilds into a SEPARATE slot beside the other
+build, instead of clobbering it in place. A renderer/graph/parser/data edit thus
+still busts this cache (different path), with no version bump — the same
+invalidation the SQLite index shares — but two builds coexist rather than
+ping-ponging over one slot.
 """
 
 from __future__ import annotations
 
 import os
+import shutil
 import time
 from pathlib import Path
 
 from lvkit import cache_paths
 from lvkit.text_encoding import labview_text_encoding
 
-# The genuinely-growing surfaces get an access-time TTL (a diff or adhoc entry is
-# worthless once its inputs move on — regenerate on demand). Path-addressed
-# render/extract project slots are NOT swept: they overwrite in place and
-# plateau at ~one-per-VI. Override the clock with LVKIT_CACHE_TTL_DAYS.
+# Retirement is decoupled from correctness (a removed file is indistinguishable
+# from a never-built one — the next lookup just does the work), so this is pure
+# policy, freely swappable, and does ONE thing: retire a whole per-build <fp> dir
+# once it is idle past the TTL. There is deliberately NO within-fingerprint file
+# aging — inside a live build, correctness is already handled by VI-content
+# freshness + the <fp> path level, so a per-file TTL would be redundant churn.
+# Files are mtime-bumped on every hit, so the build in ACTIVE use never ages out;
+# only ones you upgraded away from are reclaimed. <fp> dirs live at
+# <ns>/<slug>/<kind>/<fp> and adhoc/<kind>/<fp>. extract gets a longer horizon (it
+# is the costliest to rebuild and the slowest-growing). Override the clocks with
+# LVKIT_CACHE_TTL_DAYS / LVKIT_EXTRACT_TTL_DAYS.
 _DEFAULT_TTL_DAYS = 7.0
+# Extract is STICKIER than render/diff/index: it is the costliest slice to rebuild
+# (re-runs pylabview) and the slowest-growing (a new <fp> only on a rare
+# extraction-code change), so a much longer idle horizon saves the priciest work
+# for near-zero disk. Independently tunable via LVKIT_EXTRACT_TTL_DAYS.
+_EXTRACT_TTL_DAYS = 60.0
 
 
-def _ttl_seconds() -> float:
+def _ttl_seconds(
+    default_days: float = _DEFAULT_TTL_DAYS, env_var: str = "LVKIT_CACHE_TTL_DAYS"
+) -> float:
     try:
-        return float(os.environ.get("LVKIT_CACHE_TTL_DAYS", _DEFAULT_TTL_DAYS)) * 86400
+        return float(os.environ.get(env_var, default_days)) * 86400
     except ValueError:
-        return _DEFAULT_TTL_DAYS * 86400
+        return default_days * 86400
+
+
+# The whole-cache walk is rate-limited to at most once per this interval across ALL
+# processes (a persisted <cache>/_last_sweep stamp), so it is NEVER a per-command
+# cost — a command inside the window stats one file and returns. A 7-day TTL means
+# a daily sweep is plenty timely. Tests set it to 0 to force a walk.
+def _sweep_interval_seconds() -> float:
+    try:
+        return float(os.environ.get("LVKIT_SWEEP_INTERVAL_HOURS", 24.0)) * 3600
+    except ValueError:
+        return 24.0 * 3600
 
 
 def _ext_for(fmt: str) -> str:
@@ -61,9 +94,17 @@ def _render_paths(input_path: Path, fmt: str) -> tuple[Path, Path, bool]:
     Path-addressed for project/shared VIs; flat content-addressed for adhoc.
     """
     ext = _ext_for(fmt)
-    d, _label, ns = cache_paths.classify(input_path, "render")
+    d, _, ns = cache_paths.classify(input_path, "render")
     if ns == "adhoc":
-        d = cache_paths.global_cache_root() / "adhoc" / "render"
+        # Flat content-addressed pool, but still per-build: the <fp> keeps two
+        # lvkit builds from colliding on the same <sha>.<ext> (classify's dir is
+        # discarded here, so its <fp> level has to be re-added by hand).
+        d = (
+            cache_paths.global_cache_root()
+            / "adhoc"
+            / "render"
+            / cache_paths.kind_fingerprint("render")
+        )
         base = f"{cache_paths.sha256_file(input_path)}.{ext}"
     else:
         base = f"{input_path.stem}.{ext}"
@@ -86,10 +127,15 @@ def _diff_paths(
     """
     ext = _diff_ext(fmt)
     before_sha = cache_paths.sha256_file(before_path)
-    d, _label, ns = cache_paths.classify(after_path, "diff")
+    d, _, ns = cache_paths.classify(after_path, "diff")
     if ns == "adhoc":
         after_sha = cache_paths.sha256_file(after_path)
-        d = cache_paths.global_cache_root() / "adhoc" / "diff"
+        d = (
+            cache_paths.global_cache_root()
+            / "adhoc"
+            / "diff"
+            / cache_paths.kind_fingerprint("diff")
+        )
         base = f"{before_sha[:16]}_{after_sha[:16]}.{ext}"
     else:
         base = f"{after_path.stem}.{before_sha[:16]}.{ext}"
@@ -150,14 +196,13 @@ def diff_slot(before_path: Path, after_path: Path, fmt: str) -> Path:
 
 def lookup_render(input_path: Path, fmt: str, options: str, version: str) -> str | None:
     """Return cached render output for ``input_path`` if fresh, else ``None``."""
-    body_path, meta_path, _adhoc = _render_paths(input_path, fmt)
+    body_path, meta_path, _ = _render_paths(input_path, fmt)
     return _read_if_fresh(
         input_path,
         body_path,
         meta_path,
         {
             "lvkit_version": version,
-            "source_fingerprint": cache_paths.source_fingerprint(),
             "options": options,
             "text_encoding": labview_text_encoding(),
         },
@@ -168,7 +213,7 @@ def store_render(
     input_path: Path, fmt: str, options: str, version: str, body: str
 ) -> Path:
     """Cache ``body`` as the render of ``input_path``; return the slot path."""
-    body_path, meta_path, _adhoc = _render_paths(input_path, fmt)
+    body_path, meta_path, _ = _render_paths(input_path, fmt)
     _write(
         body_path,
         meta_path,
@@ -176,7 +221,6 @@ def store_render(
         body,
         {
             "lvkit_version": version,
-            "source_fingerprint": cache_paths.source_fingerprint(),
             "options": options,
             "kind": "render",
             "text_encoding": labview_text_encoding(),
@@ -189,14 +233,13 @@ def lookup_diff(
     before_path: Path, after_path: Path, fmt: str, options: str, version: str
 ) -> str | None:
     """Return cached diff output for the ``(before, after)`` pair if fresh."""
-    body_path, meta_path, before_sha, _adhoc = _diff_paths(before_path, after_path, fmt)
+    body_path, meta_path, before_sha, _ = _diff_paths(before_path, after_path, fmt)
     return _read_if_fresh(
         after_path,
         body_path,
         meta_path,
         {
             "lvkit_version": version,
-            "source_fingerprint": cache_paths.source_fingerprint(),
             "options": options,
             "before_sha": before_sha,
             "text_encoding": labview_text_encoding(),
@@ -213,7 +256,7 @@ def store_diff(
     body: str,
 ) -> Path:
     """Cache ``body`` as the diff of ``(before, after)``; return the slot path."""
-    body_path, meta_path, before_sha, _adhoc = _diff_paths(before_path, after_path, fmt)
+    body_path, meta_path, before_sha, _ = _diff_paths(before_path, after_path, fmt)
     _write(
         body_path,
         meta_path,
@@ -221,7 +264,6 @@ def store_diff(
         body,
         {
             "lvkit_version": version,
-            "source_fingerprint": cache_paths.source_fingerprint(),
             "options": options,
             "before_sha": before_sha,
             "kind": "diff",
@@ -237,34 +279,71 @@ _swept = False
 
 
 def _sweep_once() -> None:
-    """Delete access-stale entries in the growing trees. Runs at most once per
-    process (on the first cache write), a single cheap ``stat``+``unlink`` pass —
-    no daemon, no size accounting. Best-effort: races with a concurrent warm just
-    skip vanished files.
+    """Access-TTL cleanup, best-effort. Runs at most once per process AND at most
+    once per ``LVKIT_SWEEP_INTERVAL_HOURS`` across ALL processes (a persisted
+    ``<cache>/_last_sweep`` stamp), so the whole-cache walk is never a per-command
+    cost — a command inside the window stats one file and returns. When it does
+    run: ONE rule — retire a whole per-build ``<kind>/<fp>/`` dir once every file
+    under it has gone untouched for the TTL (extract on its own longer horizon). No
+    within-fingerprint file aging. Safe against a concurrent warm: a vanished file
+    is skipped, and an in-use build is never idle (files are bumped on every hit).
     """
     global _swept
     if _swept:
         return
     _swept = True
     try:
-        cutoff = time.time() - _ttl_seconds()
+        now = time.time()
         root = cache_paths.global_cache_root()
-        # The growing surfaces, project-first: the whole adhoc namespace (every
-        # kind of ephemeral temp/blob input), plus each owned project's/library's
-        # diff subtree (a before-version file accumulates there as history moves).
-        targets = [root / "adhoc"]
-        targets.extend((root / "projects").glob("*/diff"))
-        targets.extend((root / "shared").glob("*/*/diff"))
-        for base in targets:
-            if not base.is_dir():
+        stamp = root / "_last_sweep"
+        interval = _sweep_interval_seconds()
+        try:
+            if stamp.exists() and (now - stamp.stat().st_mtime) < interval:
+                return  # swept recently (by any process) -> skip the walk entirely
+        except OSError:
+            pass
+        # Claim the sweep up front (refresh the stamp) so a burst of sibling
+        # processes doesn't all walk the cache at once.
+        try:
+            root.mkdir(parents=True, exist_ok=True)
+            stamp.write_text("", encoding="utf-8")
+        except OSError:
+            pass
+        default_cutoff = now - _ttl_seconds()
+        extract_cutoff = now - _ttl_seconds(_EXTRACT_TTL_DAYS, "LVKIT_EXTRACT_TTL_DAYS")
+        # Every per-build <fp> dir: owned at <ns>/<slug>/<kind>/<fp>, adhoc at
+        # adhoc/<kind>/<fp>. The <kind> is always the dir's PARENT, so pick the
+        # horizon (extract is stickier) from d.parent.name.
+        fp_dirs = (
+            list((root / "projects").glob("*/*/*"))
+            + list((root / "shared").glob("*/*/*/*"))
+            + list((root / "adhoc").glob("*/*"))
+        )
+        for d in fp_dirs:
+            if not d.is_dir():
                 continue
-            for dirpath, _dirs, files in os.walk(base):
-                for name in files:
-                    fp = Path(dirpath) / name
-                    try:
-                        if fp.stat().st_mtime < cutoff:
-                            fp.unlink()
-                    except OSError:
-                        pass
+            cutoff = extract_cutoff if d.parent.name == "extract" else default_cutoff
+            _retire_if_idle(d, cutoff)
     except Exception:
         pass  # cache hygiene must never break a render
+
+
+def _retire_if_idle(fp_dir: Path, cutoff: float) -> None:
+    """Remove a whole per-build ``<kind>/<fp>/`` slice if its newest file (its
+    last access) predates ``cutoff``. A dir with no files is left alone."""
+    if not fp_dir.is_dir():
+        return
+    try:
+        newest = 0.0
+        for dirpath, _, files in os.walk(fp_dir):
+            for name in files:
+                try:
+                    m = (Path(dirpath) / name).stat().st_mtime
+                    if m > newest:
+                        newest = m
+                except OSError:
+                    pass
+        if newest and newest < cutoff:
+            shutil.rmtree(fp_dir, ignore_errors=True)
+    except OSError:
+        pass

--- a/src/lvkit/render/glyphs/nodes/label.py
+++ b/src/lvkit/render/glyphs/nodes/label.py
@@ -23,21 +23,35 @@ class LabelGlyph:
 
     def draw(self, backend: Backend, bounds: Rect, theme: Theme) -> None:
         x1, y1, x2, y2 = bounds
-        backend.rect(
-            x1,
-            y1,
-            x2,
-            y2,
-            fill=self._css_fill(theme),
-            stroke=theme.struct_border,
-            stroke_width=1.0,
-        )
+        fill = self._css_fill(theme)
+        # A transparent free label (LabVIEW alpha byte 01) has NO box at all —
+        # text only over whatever is behind it (see draw.py::_draw_owned_label).
+        # Drawing the box would paint its meaningless RGB (usually 000000 → a
+        # solid black rectangle over the diagram/wire).
+        if fill is not None:
+            backend.rect(
+                x1,
+                y1,
+                x2,
+                y2,
+                fill=fill,
+                stroke=theme.struct_border,
+                stroke_width=1.0,
+            )
         if self.text:
             self._draw_wrapped(backend, x1, y1, x2, y2, theme)
 
-    def _css_fill(self, theme: Theme) -> str:
-        """The label's own heap background color, or a neutral fallback."""
+    def _css_fill(self, theme: Theme) -> str | None:
+        """The label's own heap background color, a neutral fallback, or None
+        when the label is TRANSPARENT.
+
+        ``bg_color`` is ``"AARRGGBB"``: the leading ALPHA byte is ``00`` for an
+        opaque colored label and non-zero (``01``) for LabVIEW's transparent
+        flag, where the trailing RGB is meaningless (e.g. ``01000000`` /
+        ``0100000A``). Return None for transparent so the caller draws no box."""
         if self.bg_color and len(self.bg_color) >= 6:
+            if len(self.bg_color) >= 8 and self.bg_color[:2] != "00":
+                return None
             return f"#{self.bg_color[-6:]}"
         return theme.canvas
 

--- a/tests/test_extraction_cache.py
+++ b/tests/test_extraction_cache.py
@@ -63,7 +63,8 @@ class TestClassify:
         vi = _touch_vi(tmp_path / "loose" / "foo.vi")
         target, source, ns = cache_paths.classify(vi, "extract")
         slug = cache_paths._slug(vi.parent.resolve())
-        assert target == _cache() / "adhoc" / "extract" / slug
+        xfp = cache_paths.kind_fingerprint("extract")
+        assert target == _cache() / "adhoc" / "extract" / xfp / slug
         assert source == "foo.vi"
         assert ns == "adhoc"
 
@@ -73,7 +74,8 @@ class TestClassify:
         vi = _touch_vi(proj / "src" / "bar.vi")
         target, source, ns = cache_paths.classify(vi, "extract")
         slug = cache_paths._slug(proj.resolve())
-        assert target == _cache() / "projects" / slug / "extract" / "src"
+        xfp = cache_paths.kind_fingerprint("extract")
+        assert target == _cache() / "projects" / slug / "extract" / xfp / "src"
         assert source == str(Path("src") / "bar.vi")
         assert ns == "projects"
 
@@ -83,7 +85,10 @@ class TestClassify:
         cache_paths.set_extraction_roots(vilib_root=vilib, userlib_root=None)
         target, source, ns = cache_paths.classify(vi, "extract")
         slug = cache_paths._slug(vilib.resolve())
-        assert target == _cache() / "shared" / "vilib" / slug / "extract" / "Utility"
+        xfp = cache_paths.kind_fingerprint("extract")
+        assert (
+            target == _cache() / "shared" / "vilib" / slug / "extract" / xfp / "Utility"
+        )
         assert source == str(Path("Utility") / "u.vi")
         assert ns == "shared"
 
@@ -93,7 +98,11 @@ class TestClassify:
         cache_paths.set_extraction_roots(vilib_root=None, userlib_root=userlib)
         target, _, _ = cache_paths.classify(vi, "extract")
         slug = cache_paths._slug(userlib.resolve())
-        assert target == _cache() / "shared" / "userlib" / slug / "extract" / "MyAddon"
+        xfp = cache_paths.kind_fingerprint("extract")
+        assert (
+            target
+            == _cache() / "shared" / "userlib" / slug / "extract" / xfp / "MyAddon"
+        )
 
     def test_vendored_openg_under_project_is_projects_not_shared(
         self, tmp_path: Path
@@ -129,12 +138,13 @@ class TestClassify:
         t32, _, _ = cache_paths.classify(vi32, "extract")
 
         assert t64 != t32
-        # target == shared/vilib/<slug>/extract/Utility -> the <slug> is
-        # parent.parent, and parent.parent.parent is the shared/vilib tier.
+        # target == shared/vilib/<slug>/extract/<fp>/Utility -> the <slug> is
+        # parent.parent.parent, and parent.parent.parent.parent is the
+        # shared/vilib tier.
         shared_vilib = _cache() / "shared" / "vilib"
         assert shared_vilib in t64.parents and shared_vilib in t32.parents
-        assert t64.parent.parent.parent == t32.parent.parent.parent
-        assert t64.parent.parent.name != t32.parent.parent.name
+        assert t64.parent.parent.parent.parent == t32.parent.parent.parent.parent
+        assert t64.parent.parent.parent.name != t32.parent.parent.parent.name
 
     def test_shared_vilib_reused_across_projects(self, tmp_path: Path) -> None:
         """A vilib VI resolves to the SAME shared entry regardless of which
@@ -157,30 +167,93 @@ class TestClassify:
         assert target.is_dir()
 
 
+# ── the per-kind <fp> path level + the compact slug ─────────────────────────
+
+
+class TestFingerprintPathLevel:
+    def test_kind_fingerprint_mapping(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """extract keys off extraction_fingerprint; render/diff/index off
+        source_fingerprint — both truncated to 8 hex."""
+        monkeypatch.setattr(cache_paths, "source_fingerprint", lambda: "S" * 40)
+        monkeypatch.setattr(cache_paths, "extraction_fingerprint", lambda: "E" * 40)
+        assert cache_paths.kind_fingerprint("extract") == "E" * 8
+        for kind in ("render", "diff", "index"):
+            assert cache_paths.kind_fingerprint(kind) == "S" * 8
+
+    def test_render_change_does_not_move_extract_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The crux of putting <fp> BELOW <kind>: a render/parser edit bumps
+        source_fingerprint (re-namespacing render) but leaves extraction_fingerprint
+        alone — so the extract path is stable and extraction is NOT redone."""
+        proj = tmp_path / "p"
+        _mark_project(proj)
+        vi = _touch_vi(proj / "x.vi")
+        monkeypatch.setattr(cache_paths, "extraction_fingerprint", lambda: "extAAAAA")
+        monkeypatch.setattr(cache_paths, "source_fingerprint", lambda: "srcAAAAA")
+        ext1, _, _ = cache_paths.classify(vi, "extract")
+        ren1, _, _ = cache_paths.classify(vi, "render")
+        # Edit render/parser code only: source fp changes, extraction fp stable.
+        monkeypatch.setattr(cache_paths, "source_fingerprint", lambda: "srcBBBBB")
+        ext2, _, _ = cache_paths.classify(vi, "extract")
+        ren2, _, _ = cache_paths.classify(vi, "render")
+        assert ext1 == ext2  # extraction slot unaffected -> no re-extract
+        assert ren1 != ren2  # render slot re-namespaced -> rebuilds
+
+    def test_slug_is_tail_hash_bounded_and_unique(self) -> None:
+        """The slug is <tail>-<8hex-of-full-path>: readable tail, path-unique hash,
+        always bounded. Two different paths sharing a tail must NOT collide."""
+        a = Path("/home/u/projects/acme/test")
+        b = Path("/home/u/other/test")  # SAME tail, different path
+        sa, sb = cache_paths._slug(a), cache_paths._slug(b)
+        assert sa.startswith("test-") and sb.startswith("test-")
+        assert sa != sb  # tail collision disambiguated by the path hash
+        assert cache_paths._slug(a) == sa  # deterministic
+        assert len(sa) == len("test-") + 8  # bounded regardless of path depth
+
+
 # ── one-time cleanup of the abandoned kind-first cache ──────────────────────
 
 
 class TestLegacyCleanup:
     def test_kind_first_trees_deleted(self) -> None:
         """The abandoned kind-first trees (``<root>/{extract,render,diff,index}/
-        …``) are deleted on cleanup; a live PROJECT-FIRST entry at the root is
-        left untouched (slugs live BELOW ``projects``/``shared``/``adhoc``, so the
-        kind names are never top-level under project-first)."""
+        …``) are deleted on cleanup (slugs live BELOW ``projects``/``shared``/
+        ``adhoc``, so the kind names are never top-level under project-first)."""
         root = cache_paths.global_cache_root()
         for kind in ("extract", "render", "diff", "index"):
             d = root / kind / "projects" / "myslug"
             d.mkdir(parents=True)
             (d / "stale").write_text("old", encoding="utf-8")
-        # A live project-first entry that MUST survive.
-        live = root / "projects" / "myslug" / "extract"
-        live.mkdir(parents=True)
-        (live / "keep").write_text("new", encoding="utf-8")
 
         cache_paths.cleanup_legacy_cache()
 
         for kind in ("extract", "render", "diff", "index"):
             assert not (root / kind).exists()
-        assert (root / "projects" / "myslug" / "extract" / "keep").read_text() == "new"
+
+    def test_layout_migration_drops_pre_fp_entries_once(self) -> None:
+        """On a layout-version mismatch the derived namespaces are dropped ONCE —
+        the per-kind ``<fp>`` level + ``<tail>-<hash>`` slug make every pre-existing
+        owned path unreachable, so old entries are dead weight — then the version
+        is stamped so a matching-version entry survives the next cleanup."""
+        root = cache_paths.global_cache_root()
+        # A pre-<fp> project-first entry (no <fp> level): unreachable now.
+        stale = root / "projects" / "myslug" / "extract" / "keep"
+        stale.parent.mkdir(parents=True)
+        stale.write_text("old", encoding="utf-8")
+
+        cache_paths.cleanup_legacy_cache()  # no marker -> migration wipes
+
+        assert not stale.exists()
+        marker = (root / "_layout_version").read_text(encoding="utf-8").strip()
+        assert marker == cache_paths._LAYOUT_VERSION
+
+        # Version now stamped -> a fresh (new-layout) entry survives the next pass.
+        live = root / "projects" / "p-abcd1234" / "extract" / "ef012345" / "x"
+        live.parent.mkdir(parents=True)
+        live.write_text("new", encoding="utf-8")
+        cache_paths.cleanup_legacy_cache()  # marker matches -> no wipe
+        assert live.read_text(encoding="utf-8") == "new"
 
     def test_cleanup_is_safe_with_nothing_to_delete(self) -> None:
         cache_paths.cleanup_legacy_cache()  # no legacy trees -> no error
@@ -407,7 +480,8 @@ class TestGlobalHomeGuard:
         assert cache_paths._project_root_for(vi.resolve()) == repo.resolve()
         target, source, _ = cache_paths.classify(vi, "extract")
         slug = cache_paths._slug(repo.resolve())
-        assert target == _cache() / "projects" / slug / "extract" / "source"
+        xfp = cache_paths.kind_fingerprint("extract")
+        assert target == _cache() / "projects" / slug / "extract" / xfp / "source"
         assert source == str(Path("source") / "x.vi")
 
 

--- a/tests/test_extraction_cache.py
+++ b/tests/test_extraction_cache.py
@@ -409,3 +409,55 @@ class TestGlobalHomeGuard:
         slug = cache_paths._slug(repo.resolve())
         assert target == _cache() / "projects" / slug / "extract" / "source"
         assert source == str(Path("source") / "x.vi")
+
+
+def test_fingerprints_prefer_embedded_build_values(monkeypatch):
+    """A FROZEN (PyInstaller) build ships compiled code, not ``.py`` sources, so
+    the fingerprints can't be computed live there — ``source_fingerprint`` would
+    see only the bundled data files (blind to code) and ``extraction_fingerprint``
+    would have no sources to read. The build embeds both, and each function must
+    return the embedded value so the binary's caches stay correct and code-aware.
+    """
+    monkeypatch.setattr(
+        cache_paths,
+        "_embedded_fingerprints",
+        lambda: {"source": "SRC_EMBEDDED", "extraction": "EXT_EMBEDDED"},
+    )
+    cache_paths.source_fingerprint.cache_clear()
+    cache_paths.extraction_fingerprint.cache_clear()
+    assert cache_paths.source_fingerprint() == "SRC_EMBEDDED"
+    assert cache_paths.extraction_fingerprint() == "EXT_EMBEDDED"
+    cache_paths.source_fingerprint.cache_clear()
+    cache_paths.extraction_fingerprint.cache_clear()
+
+
+def test_extraction_fingerprint_frozen_fallback_without_embed(monkeypatch):
+    """Last-resort defense: a frozen build with neither ``.py`` sources NOR an
+    embedded fingerprint must NOT crash reading its own source — it falls back to
+    the immutable release version.
+
+    Regression: the desktop binary read ``_pylabview_patches.py`` at render time
+    and raised ``FileNotFoundError`` from every extraction, so the render exited 0
+    having written nothing and the extension failed with ENOENT on the missing
+    ``preview.html``.
+    """
+    # Sources present (this test env), no embed: a real content hash.
+    monkeypatch.setattr(cache_paths, "_embedded_fingerprints", dict)
+    cache_paths.extraction_fingerprint.cache_clear()
+    normal = cache_paths.extraction_fingerprint()
+    assert len(normal) == 64 and all(c in "0123456789abcdef" for c in normal)
+
+    # Now also deny reading the sources → the sentinel fallback, not a crash.
+    real_read = Path.read_bytes
+
+    def deny(self):
+        if self.name in cache_paths._EXTRACTION_CODE_FILES:
+            raise FileNotFoundError(self)
+        return real_read(self)
+
+    monkeypatch.setattr(Path, "read_bytes", deny)
+    cache_paths.extraction_fingerprint.cache_clear()
+    frozen = cache_paths.extraction_fingerprint()
+    assert frozen == "extraction-unavailable"
+    assert frozen != normal
+    cache_paths.extraction_fingerprint.cache_clear()

--- a/tests/test_issue_corpus.py
+++ b/tests/test_issue_corpus.py
@@ -242,6 +242,26 @@ def test_issue32_free_labels_are_modeled_and_rendered():
     assert "Hello World!" in described
 
 
+def test_transparent_free_label_renders_no_box():
+    """A LabVIEW transparent free label (alpha byte ``01`` — e.g. ``01000000`` /
+    ``0100000A``) renders as TEXT ONLY, no background box.
+
+    Regression: the alpha flag was stripped and the meaningless trailing RGB
+    (usually ``000000``) was painted as a solid BLACK rectangle over the diagram
+    and even over wires (seen on real JKI/OpenG VIs full of transparent
+    comments). Opaque colored labels (alpha ``00``) still keep their box.
+    """
+    from lvkit.render.glyphs.nodes.label import LabelGlyph
+    from lvkit.render.style import DEFAULT_THEME
+
+    def fill(bg: str) -> str | None:
+        return LabelGlyph(text="x", bg_color=bg)._css_fill(DEFAULT_THEME)
+
+    assert fill("00FFFEA0") == "#FFFEA0"  # opaque colored → keeps its box
+    assert fill("01000000") is None  # transparent → no box (was solid black)
+    assert fill("0100000A") is None  # transparent over a wire
+
+
 def test_issue32_decorations_are_rendered():
     """#32 (Phase 2): block-diagram decorations (cosm shapes) render as clean-room
     glyphs — z-ordered with nodes, but never graph nodes. The repro has a Flat

--- a/tests/test_output_cache.py
+++ b/tests/test_output_cache.py
@@ -120,9 +120,15 @@ class TestAdhocContentAddressed:
         b = _vi(tmp_path / "tmpB" / "blob.vi", b"identical blob")
         assert output_cache.lookup_render(b, "html", OPT, V) == "RENDERED"
         # It lives in the flat adhoc/render pool, named by content hash.
-        slot, _meta, is_adhoc = output_cache._render_paths(b, "html")
+        slot, _, is_adhoc = output_cache._render_paths(b, "html")
         assert is_adhoc
-        assert slot.parent == cache_paths.global_cache_root() / "adhoc" / "render"
+        assert (
+            slot.parent
+            == cache_paths.global_cache_root()
+            / "adhoc"
+            / "render"
+            / cache_paths.kind_fingerprint("render")
+        )
 
 
 # ── diff: keyed by after-path + before-content ──────────────────────────────
@@ -158,34 +164,142 @@ class TestDiffCache:
         assert output_cache.lookup_diff(before, after, "html", OPT, V) is None
 
 
-# ── TTL sweep ───────────────────────────────────────────────────────────────
+# ── compatibility: coexist, never clobber (the anti-thrash property) ─────────
+
+
+class TestCompatibilityCoexistence:
+    """The headline properties of the ``<fp>``-in-path design: two lvkit builds
+    never clobber each other, and switching BACK to an old build is a hit, not a
+    rebuild (the thrash the fix removes)."""
+
+    def test_two_builds_coexist_no_clobber(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        vi = _project_vi(tmp_path)
+        monkeypatch.setattr(cache_paths, "source_fingerprint", lambda: "buildAAA")
+        a_slot = output_cache.store_render(vi, "html", OPT, V, "A")
+        monkeypatch.setattr(cache_paths, "source_fingerprint", lambda: "buildBBB")
+        b_slot = output_cache.store_render(vi, "html", OPT, V, "B")
+        assert a_slot != b_slot
+        assert a_slot.exists() and b_slot.exists()  # neither overwrote the other
+
+    def test_switch_back_to_old_build_hits_not_rebuilds(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        vi = _project_vi(tmp_path)
+        monkeypatch.setattr(cache_paths, "source_fingerprint", lambda: "buildAAA")
+        output_cache.store_render(vi, "html", OPT, V, "A")
+        monkeypatch.setattr(cache_paths, "source_fingerprint", lambda: "buildBBB")
+        assert output_cache.lookup_render(vi, "html", OPT, V) is None  # B: cold
+        output_cache.store_render(vi, "html", OPT, V, "B")
+        # Back to build A -> still cached, NOT rebuilt (its slot was never touched).
+        monkeypatch.setattr(cache_paths, "source_fingerprint", lambda: "buildAAA")
+        assert output_cache.lookup_render(vi, "html", OPT, V) == "A"
+
+
+# ── TTL sweep: whole-<fp>-dir retirement, extract stickier ───────────────────
+
+
+def _age_dir(d: Path, days: float) -> None:
+    import os
+    import time
+
+    old = time.time() - days * 86400
+    for p in d.rglob("*"):
+        if p.is_file():
+            os.utime(p, (old, old))
 
 
 class TestTTLSweep:
-    def test_stale_diff_swept_fresh_kept_slots_untouched(
+    def test_idle_build_dir_retired_active_kept(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """A whole ``<fp>`` dir idle past the TTL is retired; a fresh sibling
+        ``<fp>`` dir (a different build) is untouched."""
+        monkeypatch.setenv("LVKIT_CACHE_TTL_DAYS", "7")
+        monkeypatch.setenv("LVKIT_SWEEP_INTERVAL_HOURS", "0")  # never skip the walk
+        vi = _project_vi(tmp_path, name="R.vi")
+        slug = cache_paths._slug((tmp_path / "repo").resolve())
+        root = cache_paths.global_cache_root()
+
+        monkeypatch.setattr(cache_paths, "source_fingerprint", lambda: "oldbuild")
+        output_cache.store_render(vi, "html", OPT, V, "OLD")
+        old_dir = root / "projects" / slug / "render" / "oldbuild"
+        assert old_dir.is_dir()
+        _age_dir(old_dir, 30)
+
+        # A store under a NEW build triggers the sweep from a DIFFERENT <fp> dir,
+        # so the old one stays idle and is retired whole.
+        monkeypatch.setattr(cache_paths, "source_fingerprint", lambda: "newbuild")
+        monkeypatch.setattr(output_cache, "_swept", False)
+        output_cache.store_render(vi, "html", OPT, V, "NEW")
+
+        assert not old_dir.exists()  # idle build reclaimed
+        assert (root / "projects" / slug / "render" / "newbuild").is_dir()
+
+    def test_no_within_fingerprint_aging(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An OLD file inside an ACTIVE ``<fp>`` dir survives — retirement is
+        whole-dir only, never per-file within a live fingerprint."""
         import os
         import time
 
         monkeypatch.setenv("LVKIT_CACHE_TTL_DAYS", "7")
-
-        # A path-addressed render slot (must SURVIVE — never swept).
-        vi = _project_vi(tmp_path, name="Render.vi")
-        render_slot = output_cache.store_render(vi, "html", OPT, V, "KEEP")
-
-        # A diff entry, aged well past the TTL.
-        before = _vi(tmp_path / "t" / "old.vi", b"B")
-        after = _project_vi(tmp_path, b"A2", name="After.vi")
-        diff_slot = output_cache.store_diff(before, after, "html", OPT, V, "OLD-DIFF")
-        old = time.time() - 30 * 86400
-        os.utime(diff_slot, (old, old))
-
-        # Force a sweep on the next write (it runs once per process).
+        monkeypatch.setenv("LVKIT_SWEEP_INTERVAL_HOURS", "0")  # never skip the walk
+        after = _project_vi(tmp_path, b"A", name="After.vi")
+        b1 = _vi(tmp_path / "t" / "b1.vi", b"B1")
+        old = output_cache.store_diff(b1, after, "html", OPT, V, "D1")
+        aged = time.time() - 30 * 86400
+        os.utime(old, (aged, aged))
+        # A fresh diff in the SAME <fp> dir keeps the whole dir active.
         monkeypatch.setattr(output_cache, "_swept", False)
-        fresh_before = _vi(tmp_path / "t" / "new.vi", b"NB")
-        output_cache.store_diff(fresh_before, after, "html", OPT, V, "NEW-DIFF")
+        b2 = _vi(tmp_path / "t" / "b2.vi", b"B2")
+        output_cache.store_diff(b2, after, "html", OPT, V, "D2")
+        assert old.exists()  # kept: the fingerprint is still in use
 
-        assert not diff_slot.exists(), "stale diff should be swept"
-        assert render_slot.exists(), "path-addressed render slot must never be swept"
-        assert output_cache.lookup_render(vi, "html", OPT, V) == "KEEP"
+    def test_extract_stickier_than_render(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """At the SAME age (30d) a render ``<fp>`` dir past its 7d TTL is retired,
+        but an extract ``<fp>`` dir within its 60d TTL survives."""
+        monkeypatch.setenv("LVKIT_CACHE_TTL_DAYS", "7")
+        monkeypatch.setenv("LVKIT_SWEEP_INTERVAL_HOURS", "0")  # never skip the walk
+        monkeypatch.setenv("LVKIT_EXTRACT_TTL_DAYS", "60")
+        root = cache_paths.global_cache_root()
+        fslug = "proj-deadbeef"
+        aged_render = root / "projects" / fslug / "render" / "aged1234"
+        aged_extract = root / "projects" / fslug / "extract" / "aged5678"
+        for d in (aged_render, aged_extract):
+            d.mkdir(parents=True)
+            (d / "f").write_text("x", encoding="utf-8")
+        _age_dir(root / "projects" / fslug, 30)
+
+        vi = _project_vi(tmp_path)
+        monkeypatch.setattr(output_cache, "_swept", False)
+        output_cache.store_render(vi, "html", OPT, V, "TRIGGER")
+
+        assert not aged_render.exists()  # past its 7d render TTL
+        assert aged_extract.exists()  # within its 60d extract TTL
+
+    def test_sweep_rate_limited_by_stamp(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A fresh ``<cache>/_last_sweep`` stamp makes the walk skip entirely — so
+        the whole-cache scan is not a per-command cost. (Default 24h interval.)"""
+        monkeypatch.setenv("LVKIT_CACHE_TTL_DAYS", "7")
+        root = cache_paths.global_cache_root()
+        # An aged build dir that WOULD be retired if the walk ran.
+        aged = root / "projects" / "p-deadbeef" / "render" / "old00000"
+        aged.mkdir(parents=True)
+        (aged / "f").write_text("x", encoding="utf-8")
+        _age_dir(root / "projects" / "p-deadbeef", 30)
+        # A fresh sweep stamp (mtime == now) -> the walk must be skipped.
+        root.mkdir(parents=True, exist_ok=True)
+        (root / "_last_sweep").write_text("", encoding="utf-8")
+
+        vi = _project_vi(tmp_path)
+        monkeypatch.setattr(output_cache, "_swept", False)
+        output_cache.store_render(vi, "html", OPT, V, "X")
+
+        assert aged.exists()  # swept recently -> not retired this run


### PR DESCRIPTION
## Summary

Fixes a cluster of cache/fingerprint bugs that made the VS Code extension re-do
work over and over instead of hitting the cache — the "nothing is instant"
symptom on the shipped win32 build — plus a black-box render regression and the
frozen-binary fingerprint crash underneath it.

## What's here (6 commits)

**Frozen-binary fingerprints** (`9311d89`, `d6551a2`, `b9a43a9`)
- The PyInstaller binary couldn't compute its cache fingerprints — they read
  `.py` sources that don't exist in a frozen bundle. Embed both fingerprints at
  build time and read the embedded value in a frozen build; `--add-data` path is
  passed specpath-relative so the Windows build actually bundles it. CI smoke-test
  renders a VI with the bundled binary.

**Render + editor** (`5789867`)
- Transparent free labels (LabVIEW alpha byte `01`) render as text only, not a
  solid black box over the diagram/wire. `pyrightconfig` resolves lvkit
  project-wide (kills the false editor "could not be resolved" warnings).

**Extension uses only the bundled lvkit** (`62b22f8`)
- `lvkitCmd` (render/diff CLI) and `mcpServerSpec` (MCP) resolved with *opposite*
  precedence — the CLI half preferred a repo `.venv`/`uv run`, the MCP half
  preferred the bundle. On a machine with a checkout at a different version the
  two halves ran different builds against one shared `~/.lvkit/cache` and each
  re-did the other's work. Both now resolve identically: explicit `lvkit.path`
  (trusted only) → bundled signed binary (default) → `lvkit` on PATH.

**Build fingerprint in the cache PATH, not the meta freshness key** (`9aafab5`)
- Compatibility is *identity*, not freshness. The fingerprint moves out of every
  `meta.json` and into the path: `<ns>/<slug>/<kind>/<fp>/<rel>/<stem>.<ext>`.
- `<fp>` sits **below `<kind>`**, per-kind: `extract` keys off
  `extraction_fingerprint` (narrow) so it survives unrelated render/parser edits;
  `render`/`diff`/`index` key off `source_fingerprint`. Two incompatible builds
  land in **separate** slots and coexist — switching back to an old build is a
  hit, not a rebuild (the thrash this removes).
- `meta.json` keeps only true freshness (`sha256`/`mtime`/`size`,
  `text_encoding`, `options`). A changed VI still busts every kind.
- Slug becomes `<tail>-<hash8>` — always bounded, closing the Windows MAX_PATH
  exposure the old full-path slug only warned about; `_dirs.json` reverse-maps it.
- Index db partitioned by `<sfp8>` so two builds don't drop each other's tables.
- Retirement is compatibility-GC: retire a whole idle `<fp>` dir on a 7-day
  access TTL (`extract` 60d), rate-limited to ~once/day via `<cache>/_last_sweep`
  so the whole-cache walk is never a per-command cost. No within-fingerprint
  aging. One-time migration drops the pre-`<fp>` layout.

## Testing

- Full suite green (`1900 passed, 32 skipped`); ruff + pyright clean on the
  changed source.
- New scenario tests: coexist-not-clobber, switch-back-to-old-build-hits,
  per-kind fp isolation (a render edit doesn't re-extract), slug
  uniqueness/bounding, whole-`<fp>`-dir retirement, extract stickiness, the
  rate-limit skip, and the layout migration.
- Dry-run bundle build green on all four targets; win32-x64 VSIX + standalone
  binary produced for manual install.

## Not in this PR

The connector-pane-oversizing viewer bug (the reveal isn't clamped the way the
context-help tooltip is) is a separate render-layer issue and is handled in a
follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
