### PR TITLE
fix(render): clamp the VI connector-pane aside like the help tip

### DIFF
--- a/src/lvkit/render/__init__.py
+++ b/src/lvkit/render/__init__.py
@@ -357,6 +357,28 @@ def render_vi(
 
 
 _ASIDE_PAD = 8.0
+# The ▦ overlay reveals the aside a touch larger than its intrinsic drawn size for
+# readability -- it's still clamped to the view by CONNECTOR_PANE_CSS. Applied to
+# BOTH viewers (the aside svg is shared), never to help_tip's per-node panels.
+_ASIDE_REVEAL_SCALE = 1.2
+
+
+def _scale_svg_box(svg: str, factor: float) -> str:
+    """Multiply the FIRST ``<svg>`` tag's width/height by ``factor``; its viewBox is
+    untouched, so the rendered panel scales up uniformly."""
+
+    def _tag(m: re.Match[str]) -> str:
+        tag = m.group(0)
+        for attr in ("width", "height"):
+            tag = re.sub(
+                rf'(\b{attr}=")([\d.]+)(")',
+                lambda a: f"{a.group(1)}{float(a.group(2)) * factor:.1f}{a.group(3)}",
+                tag,
+                count=1,
+            )
+        return tag
+
+    return re.sub(r"<svg\b[^>]*>", _tag, svg, count=1)
 
 
 def _vi_aside_svg(
@@ -386,6 +408,7 @@ def _vi_aside_svg(
         icon_uri=icon_uri,
         theme=theme,
     )
+    panel = _scale_svg_box(panel, _ASIDE_REVEAL_SCALE)
     m = re.search(r'width="([\d.]+)"', panel)
     panel_w = float(m.group(1)) if m else 240.0
     _, y1, x2, _ = scene.bounds

--- a/src/lvkit/render/connector_pane_panel.py
+++ b/src/lvkit/render/connector_pane_panel.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 __all__ = [
     "CONNECTOR_PANE_BUTTON",
+    "CONNECTOR_PANE_CSS",
     "CONNECTOR_PANE_GLYPH",
     "CONNECTOR_PANE_PANEL_BTN_ID",
     "CONNECTOR_PANE_SCRIPT",
@@ -37,6 +38,25 @@ __all__ = [
 
 CONNECTOR_PANE_PANEL_BTN_ID = "lvkitPaneBtn"
 DIFF_CONNECTOR_PANE_PANEL_BTN_ID = "lvkitDiffPaneBtn"
+
+# ONE overlay style, injected into BOTH viewers (render + diff) via the
+# __CONNECTOR_PANE_CSS__ placeholder, so the ▦-toggle aside is revealed IDENTICALLY
+# in each. The aside is a positioned <div> pinned top-right of its CONTENT AREA
+# (its position:relative container -- the render ``.stage-wrap`` / a diff pane
+# wrap), sitting OUTSIDE the zoomable <svg>, so it holds a CONSTANT on-screen size
+# and never scales with the diagram zoom (the in-SVG clone it replaced ballooned to
+# multiples of the view when zoomed). ``max-width``/``max-height`` are a fraction of
+# that content area, so it can NEVER exceed the view -- the same clamp the help-tip
+# hover panel applies; the panel svg has a viewBox, so it scales down within the cap
+# preserving aspect. ``pointer-events:none`` -- purely a view. (Diff-specific
+# changed-terminal highlight + ▦-ring rules stay in the diff template.)
+CONNECTOR_PANE_CSS = (
+    ".lvkit-pane-overlay{position:absolute;top:8px;right:8px;z-index:55;"
+    "max-width:88%;max-height:82%;pointer-events:none;"
+    "filter:drop-shadow(0 2px 8px rgba(0,0,0,.30))}"
+    ".lvkit-pane-overlay svg{display:block;width:auto;height:auto;"
+    "max-width:100%;max-height:100%;background:none;border-radius:0}"
+)
 
 # U+25A6 "SQUARE WITH ORTHOGONAL CROSSHATCH FILL" — a plain grid glyph standing
 # in for the connector-pane grid. A unicode character styled like every other
@@ -96,11 +116,15 @@ def _reveal_toggle_script(
     )
 
 
-# Render viewer: reveal by CLONING each aside OUT of its <defs> into the visible
-# tree; hide by removing the clones. The source stays in <defs> (structurally
-# non-rendered), so nothing leaks when JS is stripped or the SVG is sanitized.
-# Each clone is appended to its OWN owning <svg> as the last child so it paints
-# on top, at the source group's transform (the VI's top-right corner).
+# Render viewer: reveal each aside's panel as a FIXED-SIZE overlay pinned to the
+# stage's top-right, hide by removing the overlays. The source stays in <defs>
+# (structurally non-rendered), so nothing leaks when JS is stripped or the SVG is
+# sanitized. The overlay is a positioned <div> OUTSIDE the zoomable <svg> holding a
+# clone of the panel <svg>, so it keeps a CONSTANT on-screen size (capped to the
+# view by the .lvkit-pane-overlay CSS) instead of ballooning with the diagram zoom
+# -- the same clamp the help-tip hover panel uses. An in-SVG clone lives in
+# diagram user-space and grows to multiples of the view when zoomed in. Same
+# overlay pattern as the diff viewer's per-pane asides.
 CONNECTOR_PANE_SCRIPT = _reveal_toggle_script(
     CONNECTOR_PANE_PANEL_BTN_ID,
     collect_js=(
@@ -115,10 +139,17 @@ CONNECTOR_PANE_SCRIPT = _reveal_toggle_script(
         "      if (window.lvkitCloseProps) window.lvkitCloseProps();\n"
         "      sources.forEach(function (d) {\n"
         "        var svg = d.ownerSVGElement;\n"
-        "        if (!svg) return;\n"
-        "        var c = d.cloneNode(true);\n"
-        "        svg.appendChild(c);\n"
-        "        boxes.push(c);\n"
+        "        var wrap = svg && svg.closest && svg.closest('.stage-wrap');\n"
+        "        var panel = d.querySelector('svg');\n"
+        "        if (!wrap || !panel) return;\n"
+        "        // Lift the panel into a fixed-size overlay pinned top-right, so it\n"
+        "        // is a CONSTANT on-screen size (capped by CSS) -- not an in-SVG\n"
+        "        // clone that balloons with the diagram zoom.\n"
+        "        var box = document.createElement('div');\n"
+        "        box.className = 'lvkit-pane-overlay';\n"
+        "        box.appendChild(panel.cloneNode(true));\n"
+        "        wrap.appendChild(box);\n"
+        "        boxes.push(box);\n"
         "      });\n"
     ),
     hide_body=(

--- a/src/lvkit/render/diff_viewer.py
+++ b/src/lvkit/render/diff_viewer.py
@@ -28,6 +28,7 @@ from importlib.resources import files
 
 from ..graph.diff import ChangeMap
 from .connector_pane_panel import (
+    CONNECTOR_PANE_CSS,
     DIFF_CONNECTOR_PANE_BUTTON,
     DIFF_CONNECTOR_PANE_SCRIPT,
 )
@@ -105,6 +106,7 @@ def build_diff_viewer(
         .replace("__DIFF_PROPERTIES_PANEL__", DIFF_PROPERTIES_PANEL)
         .replace("__DIFF_CONNECTOR_PANE_BTN__", DIFF_CONNECTOR_PANE_BUTTON)
         .replace("__DIFF_CONNECTOR_PANE_SCRIPT__", DIFF_CONNECTOR_PANE_SCRIPT)
+        .replace("__CONNECTOR_PANE_CSS__", CONNECTOR_PANE_CSS)
         .replace("__HELP_TIP__", HELP_TIP)
     )
     return "<!doctype html>\n<meta charset='utf-8'>\n" + html

--- a/src/lvkit/render/render_viewer.py
+++ b/src/lvkit/render/render_viewer.py
@@ -17,7 +17,11 @@ from __future__ import annotations
 
 from importlib.resources import files
 
-from .connector_pane_panel import CONNECTOR_PANE_BUTTON, CONNECTOR_PANE_SCRIPT
+from .connector_pane_panel import (
+    CONNECTOR_PANE_BUTTON,
+    CONNECTOR_PANE_CSS,
+    CONNECTOR_PANE_SCRIPT,
+)
 from .help_tip import HELP_TIP
 from .properties_panel import PROPERTIES_BUTTON, PROPERTIES_PANEL
 from .theme_control import THEME_CONTROL_BUTTON, THEME_CONTROL_SCRIPT
@@ -46,6 +50,7 @@ def build_render_viewer(svg: str, *, title: str) -> str:
         .replace("__PROPERTIES_PANEL__", PROPERTIES_PANEL)
         .replace("__CONNECTOR_PANE_BTN__", CONNECTOR_PANE_BUTTON)
         .replace("__CONNECTOR_PANE_SCRIPT__", CONNECTOR_PANE_SCRIPT)
+        .replace("__CONNECTOR_PANE_CSS__", CONNECTOR_PANE_CSS)
         .replace("__HELP_TIP__", HELP_TIP)
         .replace("__SVG__", svg)
     )

--- a/src/lvkit/render/templates/diff_viewer.html
+++ b/src/lvkit/render/templates/diff_viewer.html
@@ -354,12 +354,10 @@
       background:linear-gradient(180deg,#f0f3f7,#c4cad4);border:1px solid #40464f;
       box-shadow:0 2px 6px #000a,inset 0 1px 0 #fff9;cursor:grab}
   /* Connector-pane compare overlays: one per pane, pinned top-right of its wrap
-     (position:relative), so they stay put while the diagram pans/zooms. The
-     panel svg carries its own (diagram-themed) colours; we only add a drop
-     shadow so it reads as a floating card. pointer-events:none — purely a view. */
-  .lvkit-pane-overlay{position:absolute;top:8px;right:8px;z-index:55;
-    pointer-events:none;filter:drop-shadow(0 2px 8px rgba(0,0,0,.30))}
-  .lvkit-pane-overlay svg{display:block}
+     (position:relative), so they stay put while the diagram pans/zooms and are
+     clamped to that content area. SHARED with the render viewer via
+     CONNECTOR_PANE_CSS (connector_pane_panel.py) so both clamp identically. */
+  __CONNECTOR_PANE_CSS__
   /* A changed terminal lights up as ONE rounded union outline tracing cell ->
      wire -> label. It carries the diagram's OWN classes ("hl node <change>" +
      "hl-num <change>"), so it INHERITS every highlight/selection rule (colour,

--- a/src/lvkit/render/templates/render_viewer.html
+++ b/src/lvkit/render/templates/render_viewer.html
@@ -88,6 +88,10 @@
   .mm-mirror svg{display:block;width:100%;height:auto;max-width:100%;background:none;border-radius:0}
   .mm-view{position:absolute;border:2px solid var(--accent);border-radius:2px;
     background:var(--accent);opacity:.22;pointer-events:none}
+  /* VI connector-pane aside overlay (the ▦ toggle) -- SHARED with the diff viewer
+     (CONNECTOR_PANE_CSS in connector_pane_panel.py); pinned + clamped to this
+     .stage-wrap content area so it never scales with zoom or exceeds the view. */
+  __CONNECTOR_PANE_CSS__
 </style>
 
 <header>

--- a/tests/test_render_viewer.py
+++ b/tests/test_render_viewer.py
@@ -55,6 +55,52 @@ class TestBuildRenderViewerPureUnit:
         for marker in ("__TITLE__", "__SVG__", "__THEME_BTN__", "__THEME_SCRIPT__"):
             assert marker not in html
 
+    def test_connector_pane_reveals_as_clamped_shared_overlay(self):
+        """The ▦ VI connector-pane aside is revealed as a fixed overlay pinned to
+        the content area and CAPPED to the view -- never scaling with the diagram
+        zoom or exceeding the viewbox (the regression where it ballooned to ~3x
+        the view when zoomed in). The overlay CSS is SHARED with the diff viewer,
+        and the render reveal no longer clones the aside INTO the <svg> (an in-SVG
+        clone lives in diagram user-space and is exactly what ballooned)."""
+        from lvkit.render.connector_pane_panel import (
+            CONNECTOR_PANE_CSS,
+            CONNECTOR_PANE_SCRIPT,
+            DIFF_CONNECTOR_PANE_SCRIPT,
+        )
+
+        # The shared overlay CSS clamps to the content area.
+        assert ".lvkit-pane-overlay{position:absolute" in CONNECTOR_PANE_CSS
+        assert "max-width:" in CONNECTOR_PANE_CSS
+        assert "max-height:" in CONNECTOR_PANE_CSS
+
+        # Both viewers reveal via the SAME overlay class (same mechanism)...
+        assert "lvkit-pane-overlay" in CONNECTOR_PANE_SCRIPT
+        assert "lvkit-pane-overlay" in DIFF_CONNECTOR_PANE_SCRIPT
+        # ...and the render reveal is a <div> overlay in the stage-wrap, NOT an
+        # in-SVG clone (appending the aside into the <svg> is what ballooned).
+        assert "stage-wrap" in CONNECTOR_PANE_SCRIPT
+        assert "svg.appendChild" not in CONNECTOR_PANE_SCRIPT
+
+        # The render viewer injects the shared CSS, placeholder fully substituted.
+        html = build_render_viewer("<svg id='lv-stub'></svg>", title="Stub VI")
+        assert CONNECTOR_PANE_CSS in html
+        assert "__CONNECTOR_PANE_CSS__" not in html
+
+
+def test_scale_svg_box_scales_viewport_not_viewbox():
+    """The aside reveal is bumped a touch larger by scaling ONLY the outer <svg>'s
+    width/height (its viewBox + inner content are untouched, so it scales up
+    uniformly and stays clamped by the overlay CSS)."""
+    from lvkit.render import _scale_svg_box
+
+    out = _scale_svg_box(
+        '<svg width="100" height="50" viewBox="0 0 100 50"><rect width="10"/></svg>',
+        1.2,
+    )
+    assert 'width="120.0"' in out and 'height="60.0"' in out  # outer svg scaled
+    assert 'viewBox="0 0 100 50"' in out  # viewBox untouched
+    assert '<rect width="10"/>' in out  # inner content untouched
+
 
 class TestBuildRenderViewerEndToEnd:
     def test_html_embeds_auto_svg_and_controls(self):


### PR DESCRIPTION
## Summary

The **▦ VI connector-pane aside** (the VI's icon + connector pane, revealed in the
render/diff viewers) rendered **enormous** and grew with the diagram zoom. The
render viewer revealed it by cloning it **into** the `<svg>`, so it lived in
diagram user-space — measured **79% of the stage at fit, 294% after a 5× zoom-in**.
The diff viewer's overlay didn't scale with zoom but had **no cap** either.

## Fix — reveal it like `help_tip`

Lift the renderer-drawn panel out of `<defs>` into a positioned `<div>` **outside**
the zoomable `<svg>`, pinned to the top-right of its **content area** (the render
`.stage-wrap` / a diff pane wrap) and **capped to a fraction of that area** — a
constant on-screen size that never scales with zoom and never exceeds the view,
exactly the clamp `help_tip`'s hover panel uses.

- **One shared `CONNECTOR_PANE_CSS`**, injected into **both** viewers via a
  `__CONNECTOR_PANE_CSS__` placeholder (same pattern as `HELP_TIP`), so they reveal
  the aside identically. Diff-specific highlight/ring rules stay in the diff
  template.
- The render reveal switches from an in-SVG clone to the **same overlay `<div>`**
  the diff viewer already uses (both clone the renderer-drawn geometry — never
  recomputed).
- The aside is bumped a touch larger for readability (`_scale_svg_box`, viewBox
  untouched) — still clamped by the overlay cap; `help_tip`'s per-node panels are
  untouched.

## Verification (Playwright, OpenG subVI)

| | before | after |
|---|---|---|
| at fit | 79% of stage | **31%** |
| after 5× zoom-in | **294%** (off-stage) | **31%** (constant) |
| narrow 380px view | — | clamps to **88%**, aspect preserved |

Regression tests assert the overlay reveal (not the in-SVG clone), the
content-area cap, the shared CSS across both viewers, and `_scale_svg_box`. Full
pre-commit gate (ruff + pyright + pytest) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
