### PR TITLE
release: v0.7.3 — web extension CDN fallback for Open VSX (GitLab Web IDE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,27 @@ lvkit follows semantic versioning.
 
 ## [Unreleased]
 
+## [0.7.3] - 2026-08-25
+- **Fix: the web extension now actually starts on Open VSX hosts (GitLab Web IDE,
+  Cursor, Gitpod, code-server).** These hosts do not serve a web extension's
+  bundled `media/` tree — the self-hosted Pyodide runtime and Python wheels —
+  even though those files are present in the published VSIX (upstream
+  [openvsx#2099](https://github.com/eclipse/openvsx/issues/2099)), so the
+  in-browser engine could not read its own assets and failed to start. The
+  extension now detects that and falls back to loading Pyodide from a public CDN
+  (jsDelivr) and the wheels from PyPI. VS Code Marketplace hosts (vscode.dev,
+  GitHub Codespaces) are unaffected and keep loading everything self-hosted and
+  offline; only a host that cannot serve the bundled assets reaches for the
+  network. (The 0.7.2 `.gitignore` cleanup below was necessary but not
+  sufficient — this is the fix that makes it work.)
+
 ## [0.7.2] - 2026-08-25
-- **Fix: the web extension on Open VSX hosts (GitLab Web IDE, Cursor, Gitpod,
-  code-server).** The web VSIX was shipping a stray `media/wheels/.gitignore`
-  (auto-created by `uv build`); Open VSX's resource CDN honored it and 404-ed the
-  bundled Pyodide/wheels, so the in-browser engine failed to start. That ignore no
-  longer ships. (VS Code Marketplace hosts — vscode.dev, GitHub Codespaces — were
-  unaffected.)
+- **Web extension packaging cleanup for Open VSX.** The web VSIX was shipping a
+  stray `media/wheels/.gitignore` (auto-created by `uv build`); it no longer
+  ships. This was a necessary cleanup but did **not** by itself make the
+  in-browser engine load on Open VSX hosts — those hosts do not serve the bundled
+  `media/` tree at all (fixed in 0.7.3, which adds the CDN fallback). VS Code
+  Marketplace hosts (vscode.dev, GitHub Codespaces) were unaffected throughout.
 - **lvkit is now suggested for LabVIEW files.** Registers `.vi`, `.lvclass`,
   `.lvlib`, `.lvproj` as file types, so a hosted or desktop editor that does not
   already have lvkit offers it from the marketplace when you open one.

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "lvkit",
   "displayName": "LVKit",
   "description": "View and diff VIs without LabVIEW.",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "publisher": "pragmatest",
   "icon": "icon.png",
   "license": "Apache-2.0",

--- a/editors/vscode/web/extension.js
+++ b/editors/vscode/web/extension.js
@@ -76,13 +76,32 @@ async function wheelUris(webview, wheelsDir) {
     );
 }
 
-// Resolve the self-hosted Pyodide runtime + wheels for one webview.
+// CDN fallback (below): pinned to match the bundled wheels (uv.lock /
+// build-web-assets.sh) and the `pyodide` devDependency. Keep in sync on a bump.
+const CDN_PYODIDE = "https://cdn.jsdelivr.net/pyodide/v314.0.5/full/";
+const CDN_WHEELS = ["networkx==3.4.2", "pylabview==0.1.2"]; // lvkit appended (its own version)
+
+// Resolve the Pyodide runtime + wheels for one webview. Bundled-FIRST — self-hosted
+// under media/, so MS-Marketplace hosts (vscode.dev, Codespaces) and offline/strict
+// setups stay fast and network-free. CDN FALLBACK for Open VSX hosts (GitLab Web IDE,
+// Cursor, Gitpod): their resource CDN does not serve bundled media/ files
+// (eclipse-openvsx/openvsx#2099), so the bundled read below throws and we load Pyodide
+// from jsDelivr + the wheels from PyPI instead — working there beats not working.
 async function pyodideAssets(webview, context) {
   const wheelsDir = vscode.Uri.joinPath(context.extensionUri, "media", "wheels");
   const pyodideDir = vscode.Uri.joinPath(context.extensionUri, "media", "pyodide");
-  const wheels = await wheelUris(webview, wheelsDir);
-  const pyodideBase = webview.asWebviewUri(pyodideDir).toString() + "/";
-  return { wheels, pyodideBase };
+  try {
+    const wheels = await wheelUris(webview, wheelsDir);
+    const pyodideBase = webview.asWebviewUri(pyodideDir).toString() + "/";
+    return { wheels, pyodideBase, source: "bundled" };
+  } catch (e) {
+    // micropip installs each wheel below by NAME from PyPI (deps:false); lvkit LAST
+    // (it imports networkx + pylabview at import time). loadPyodide + loadPackage come
+    // from jsDelivr. See webviewCsp for the extra hosts this path requires.
+    log(`bundled Pyodide/wheels unavailable (${e && e.message ? e.message : e}) — using CDN fallback`);
+    const lvkitSpec = `lvkit==${context.extension.packageJSON.version}`;
+    return { wheels: [...CDN_WHEELS, lvkitSpec], pyodideBase: CDN_PYODIDE, source: "cdn" };
+  }
 }
 
 // ── The shared Pyodide "engine" (a PANEL WebviewView, not an editor tab) ─────
@@ -502,11 +521,17 @@ function errorHtml(title, message) {
 <pre style="white-space:pre-wrap;color:var(--vscode-descriptionForeground)">${esc(message)}</pre></body>`;
 }
 
+// Hosts the CDN fallback (pyodideAssets) needs when bundled media/ is unavailable:
+// jsDelivr serves the Pyodide runtime (pyodide.js + wasm/data), and micropip resolves
+// wheels via the PyPI JSON index (pypi.org) and downloads them (files.pythonhosted.org).
+// The bundled path uses only webview.cspSource, so these only matter on Open VSX hosts.
+const CDN_HOSTS = "https://cdn.jsdelivr.net https://files.pythonhosted.org https://pypi.org";
+
 function webviewCsp(webview) {
   return [
     "default-src 'none'",
-    `script-src ${webview.cspSource} 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval'`,
-    `connect-src ${webview.cspSource} blob: data:`,
+    `script-src ${webview.cspSource} 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' https://cdn.jsdelivr.net`,
+    `connect-src ${webview.cspSource} blob: data: ${CDN_HOSTS}`,
     "style-src 'unsafe-inline'",
     `img-src ${webview.cspSource} data: blob:`,
     "worker-src blob:",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lvkit"
-version = "0.7.2"
+version = "0.7.3"
 description = "Understand and convert LabVIEW VIs to Python without a LabVIEW license"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/lvkit/__init__.py
+++ b/src/lvkit/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-__version__ = "0.7.2"
+__version__ = "0.7.3"
 
 # The public API is exposed LAZILY (PEP 562 module ``__getattr__``): the graph /
 # parser / structure stacks (networkx, pydantic, pylabview, PIL — ~230 ms) load

--- a/uv.lock
+++ b/uv.lock
@@ -552,7 +552,7 @@ wheels = [
 
 [[package]]
 name = "lvkit"
-version = "0.7.2"
+version = "0.7.3"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
Surgical CDN-fallback fix so the **web extension actually starts on Open VSX hosts** (GitLab Web IDE, Cursor, Gitpod, code-server) — the thing 0.7.2 was supposed to fix but couldn't.

## What
Open VSX's resource CDN does not serve a web extension's bundled `media/` tree (the self-hosted Pyodide runtime + wheels) even though those files ship in the VSIX — [openvsx#2099](https://github.com/eclipse/openvsx/issues/2099). So the in-browser engine couldn't read its own assets and failed to start. `web/extension.js` now:
- tries the **bundled** assets first (MS-Marketplace hosts + offline stay fast/network-free), and
- on failure, **falls back** to loading Pyodide from **jsDelivr** and the wheels (`networkx`, `pylabview`, and `lvkit==<version>`) from **PyPI**, with the CSP widened to allow those hosts.

Verified locally both ways: bundled path renders with zero network; forced-CDN path renders via jsDelivr + PyPI.

## Why the Python version bumps too
The fallback installs `lvkit==${extension version}` from PyPI. Releasing the extension as **0.7.3** therefore requires **lvkit 0.7.3 on PyPI**, so all four version sites bump to 0.7.3 (the Python side is a no-op version bump — no code change).

## Changelog
Adds the `0.7.3` CDN-fix entry and corrects the `0.7.2` entry (its `.gitignore` cleanup was necessary but not sufficient).

Deferred to a later version: the read-only VI text viewer and the netlist/JSON format work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)