### PR TITLE
release: v0.7.4 — web extension loads Pyodide from CDN, drops bundled media/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,11 +80,14 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
-      - name: Build self-hosted web assets (Pyodide + wheels)
+      - name: Build self-hosted web assets (Pyodide + wheels) for the parity render
         working-directory: editors/vscode
+        # The shipped web VSIX is CDN-only (no media/), but the parity check needs a
+        # self-hosted Pyodide to run the wasm render — so build it directly here,
+        # independent of `build:web` (which no longer produces media/).
         run: |
           npm ci
-          npm run build:web
+          bash build/build-web-assets.sh
       - name: Web (wasm) render == native render, byte-for-byte
         run: bash editors/vscode/build/check-web-parity.sh
 

--- a/.github/workflows/publish-bundles.yml
+++ b/.github/workflows/publish-bundles.yml
@@ -252,10 +252,10 @@ jobs:
   # The 5th target: the WEB (browser / Pyodide) VSIX for hosted editors
   # (vscode.dev, GitHub Codespaces web, GitLab Web IDE, Cursor). wasm is
   # platform-agnostic, so this is ONE ubuntu build with NO PyInstaller and NO
-  # signing. Instead of a native bin/ it bundles the self-hosted Pyodide runtime
-  # + wheels (build-web-assets.sh) and packages with the inverse
-  # .vscodeignore.web (ships media/, drops bin/). `--target web` is the marker
-  # that lights up the Marketplace "Install" button on web hosts.
+  # signing. It ships ONLY the browser entry dist/web/extension.js — the engine
+  # loads Pyodide from jsDelivr + wheels from PyPI at runtime, so there's no
+  # bundled media/ (and no bin/); .vscodeignore.web drops both. `--target web` is
+  # the marker that lights up the Marketplace "Install" button on web hosts.
   build-web:
     needs: verify
     runs-on: ubuntu-latest
@@ -265,7 +265,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
-      - name: Build web bundle + self-hosted assets
+      - name: Build web bundle
         shell: bash
         working-directory: editors/vscode
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ lvkit follows semantic versioning.
 
 ## [Unreleased]
 
+## [0.7.4] - 2026-08-25
+- **The web extension now loads Pyodide from the CDN by default, and no longer
+  bundles it.** 0.7.3 tried the self-hosted `media/` copy first and only fell back
+  to the CDN on Open VSX; but on vscode.dev the marketplace/webview-resource layer
+  serves that ~13 MB copy so slowly that the first render took *minutes*, while the
+  same VI over jsDelivr renders in ~3 s. So the extension now loads the Pyodide
+  runtime from jsDelivr and the wheels from PyPI on every web host, and the VSIX no
+  longer ships `media/` at all — smaller download, and fast everywhere. (Hosted
+  editors are always online; there is no offline browser IDE to protect. Desktop is
+  unchanged — it still uses its bundled native binary.)
+
 ## [0.7.3] - 2026-08-25
 - **Fix: the web extension now actually starts on Open VSX hosts (GitLab Web IDE,
   Cursor, Gitpod, code-server).** These hosts do not serve a web extension's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ lvkit follows semantic versioning.
 
 ## [Unreleased]
 
-## [0.7.4] - 2026-08-25
+## [0.7.4] - 2026-08-26
 - **The web extension now loads Pyodide from the CDN by default, and no longer
   bundles it.** 0.7.3 tried the self-hosted `media/` copy first and only fell back
   to the CDN on Open VSX; but on vscode.dev the marketplace/webview-resource layer

--- a/editors/vscode/.vscodeignore.web
+++ b/editors/vscode/.vscodeignore.web
@@ -1,7 +1,8 @@
 # .vscodeignore for the WEB target VSIX (`vsce package --target web
-# --ignoreFile .vscodeignore.web`). The inverse of the desktop .vscodeignore:
-# it SHIPS the self-hosted Pyodide runtime + wheels under media/ and the browser
-# entry dist/web/extension.js, and DROPS the native binary.
+# --ignoreFile .vscodeignore.web`). Ships ONLY the browser entry
+# dist/web/extension.js — DROPS the native binary (bin/) AND the bundled Pyodide
+# runtime + wheels (media/): the engine loads Pyodide from jsDelivr and the wheels
+# from PyPI at runtime (smaller VSIX, and faster than self-hosting media/).
 .vscode/**
 build/**
 setup-jki-demo.sh
@@ -27,6 +28,11 @@ Diff.png
 # Excluding bin/ drops the ~70 MB per-platform PyInstaller bundle the browser
 # cannot execute anyway. (The desktop VSIXes are the ones that carry bin/.)
 bin/**
+
+# No bundled Pyodide/wheels — the engine loads them from the CDN (jsDelivr + PyPI)
+# at runtime (web/extension.js pyodideAssets). Self-hosting media/ was ~13 MB and,
+# served via the marketplace/webview-resource layer, slower than the CDN.
+media/**
 
 # Build sources — the shipped browser entry is the pre-built
 # dist/web/extension.js, so the un-bundled source + its esbuild config stay out.

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "lvkit",
   "displayName": "LVKit",
   "description": "View and diff VIs without LabVIEW.",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "publisher": "pragmatest",
   "icon": "icon.png",
   "license": "Apache-2.0",
@@ -19,7 +19,7 @@
     },
     "virtualWorkspaces": {
       "supported": true,
-      "description": "In a virtual workspace (a hosted/web editor such as vscode.dev, GitHub Codespaces web, GitLab Web IDE, or Cursor) LVKit renders .vi files in the browser via its bundled lvkit WebAssembly build — no local disk or executable needed. Diff and the MCP server remain desktop-only."
+      "description": "In a virtual workspace (a hosted/web editor such as vscode.dev, GitHub Codespaces web, GitLab Web IDE, or Cursor) LVKit renders .vi files in the browser via lvkit compiled to WebAssembly (Pyodide, loaded from a CDN) — no local disk or executable needed. Diff and the MCP server remain desktop-only."
     }
   },
   "categories": ["Visualization", "SCM Providers", "Other"],
@@ -97,7 +97,7 @@
     }
   },
   "scripts": {
-    "build:web": "node esbuild.web.js && bash build/build-web-assets.sh",
+    "build:web": "node esbuild.web.js",
     "test:web": "vscode-test-web --browser=chromium --extensionDevelopmentPath=. ../../tests/corpus/issues/30"
   },
   "devDependencies": {

--- a/editors/vscode/web/extension.js
+++ b/editors/vscode/web/extension.js
@@ -55,53 +55,24 @@ function toBase64(bytes) {
   return btoa(s);
 }
 
-// The lvkit + pylabview + networkx wheels shipped under media/wheels/, as webview
-// URIs. Read from media/wheels/manifest.json (a KNOWN file, written by
-// build-web-assets.sh) — NOT by listing the directory: a browser extension host
-// can't enumerate the extension's own resources (vscode.workspace.fs.readDirectory
-// throws EntryNotADirectory in the web worker), only fetch known files. The
-// manifest is regenerated on a version bump, so this stays hard-coding-free.
-async function wheelUris(webview, wheelsDir) {
-  const raw = await vscode.workspace.fs.readFile(
-    vscode.Uri.joinPath(wheelsDir, "manifest.json")
-  );
-  const names = JSON.parse(new TextDecoder().decode(raw));
-  return names
-    .filter((name) => typeof name === "string" && name.endsWith(".whl"))
-    // lvkit LAST — it imports networkx + pylabview at import time, and
-    // micropip.install(deps=False) does not resolve/order deps for us.
-    .sort((a, b) => (a.startsWith("lvkit-") ? 1 : b.startsWith("lvkit-") ? -1 : 0))
-    .map((name) =>
-      webview.asWebviewUri(vscode.Uri.joinPath(wheelsDir, name)).toString()
-    );
-}
-
-// CDN fallback (below): pinned to match the bundled wheels (uv.lock /
-// build-web-assets.sh) and the `pyodide` devDependency. Keep in sync on a bump.
+// Pyodide runtime + wheels, loaded from public CDNs: jsDelivr for the runtime,
+// PyPI for the pure-Python wheels (micropip installs each by NAME, deps:false;
+// lvkit LAST since it imports networkx + pylabview at import time). Versions pinned
+// to match the render (uv.lock) and lvkit's own release; keep in sync on a bump.
 const CDN_PYODIDE = "https://cdn.jsdelivr.net/pyodide/v314.0.5/full/";
 const CDN_WHEELS = ["networkx==3.4.2", "pylabview==0.1.2"]; // lvkit appended (its own version)
 
-// Resolve the Pyodide runtime + wheels for one webview. Bundled-FIRST — self-hosted
-// under media/, so MS-Marketplace hosts (vscode.dev, Codespaces) and offline/strict
-// setups stay fast and network-free. CDN FALLBACK for Open VSX hosts (GitLab Web IDE,
-// Cursor, Gitpod): their resource CDN does not serve bundled media/ files
-// (eclipse-openvsx/openvsx#2099), so the bundled read below throws and we load Pyodide
-// from jsDelivr + the wheels from PyPI instead — working there beats not working.
-async function pyodideAssets(webview, context) {
-  const wheelsDir = vscode.Uri.joinPath(context.extensionUri, "media", "wheels");
-  const pyodideDir = vscode.Uri.joinPath(context.extensionUri, "media", "pyodide");
-  try {
-    const wheels = await wheelUris(webview, wheelsDir);
-    const pyodideBase = webview.asWebviewUri(pyodideDir).toString() + "/";
-    return { wheels, pyodideBase, source: "bundled" };
-  } catch (e) {
-    // micropip installs each wheel below by NAME from PyPI (deps:false); lvkit LAST
-    // (it imports networkx + pylabview at import time). loadPyodide + loadPackage come
-    // from jsDelivr. See webviewCsp for the extra hosts this path requires.
-    log(`bundled Pyodide/wheels unavailable (${e && e.message ? e.message : e}) — using CDN fallback`);
-    const lvkitSpec = `lvkit==${context.extension.packageJSON.version}`;
-    return { wheels: [...CDN_WHEELS, lvkitSpec], pyodideBase: CDN_PYODIDE, source: "cdn" };
-  }
+// The web extension runs ONLY in hosted editors (vscode.dev, GitLab Web IDE,
+// Cursor, Gitpod, Codespaces) — all online — so we load Pyodide + wheels straight
+// from the CDN rather than bundling ~13 MB of media/ in the VSIX. jsDelivr serves
+// the Pyodide runtime far faster than the marketplace / webview-resource layer
+// serves a self-hosted copy (measured: ~3 s vs. minutes on vscode.dev for the same
+// VI), so this is smaller AND faster. No bundled fallback: an air-gapped browser
+// IDE isn't a real host, and Open VSX can't serve bundled media/ anyway
+// (eclipse-openvsx/openvsx#2099).
+async function pyodideAssets(context) {
+  const lvkitSpec = `lvkit==${context.extension.packageJSON.version}`;
+  return { wheels: [...CDN_WHEELS, lvkitSpec], pyodideBase: CDN_PYODIDE };
 }
 
 // ── The shared Pyodide "engine" (a PANEL WebviewView, not an editor tab) ─────
@@ -167,7 +138,7 @@ function engineViewProvider(context) {
       });
       _engine = engine;
       const wake = () => { const waiters = _engineWaiters; _engineWaiters = []; waiters.forEach((r) => r(engine)); };
-      pyodideAssets(view.webview, context)
+      pyodideAssets(context)
         .then((assets) => { view.webview.html = engineHtml(view.webview, assets.wheels, assets.pyodideBase); wake(); })
         .catch((e) => { view.webview.html = errorHtml("LVKit web build is missing its wheels", String(e)); logError("engine assets", e); engine.rejectReady(new Error(String(e))); wake(); });
     },
@@ -521,10 +492,9 @@ function errorHtml(title, message) {
 <pre style="white-space:pre-wrap;color:var(--vscode-descriptionForeground)">${esc(message)}</pre></body>`;
 }
 
-// Hosts the CDN fallback (pyodideAssets) needs when bundled media/ is unavailable:
-// jsDelivr serves the Pyodide runtime (pyodide.js + wasm/data), and micropip resolves
-// wheels via the PyPI JSON index (pypi.org) and downloads them (files.pythonhosted.org).
-// The bundled path uses only webview.cspSource, so these only matter on Open VSX hosts.
+// Hosts the engine loads from (pyodideAssets): jsDelivr serves the Pyodide runtime
+// (pyodide.js + wasm/data), and micropip resolves wheels via the PyPI JSON index
+// (pypi.org) and downloads them (files.pythonhosted.org).
 const CDN_HOSTS = "https://cdn.jsdelivr.net https://files.pythonhosted.org https://pypi.org";
 
 function webviewCsp(webview) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lvkit"
-version = "0.7.3"
+version = "0.7.4"
 description = "Understand and convert LabVIEW VIs to Python without a LabVIEW license"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/lvkit/__init__.py
+++ b/src/lvkit/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-__version__ = "0.7.3"
+__version__ = "0.7.4"
 
 # The public API is exposed LAZILY (PEP 562 module ``__getattr__``): the graph /
 # parser / structure stacks (networkx, pydantic, pylabview, PIL — ~230 ms) load

--- a/uv.lock
+++ b/uv.lock
@@ -552,7 +552,7 @@ wheels = [
 
 [[package]]
 name = "lvkit"
-version = "0.7.3"
+version = "0.7.4"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
Makes the CDN the **primary** (and only) path for the web extension, and stops bundling `media/` entirely — because the bundled path turned out to be the *slow* one.

## Why
On **vscode.dev**, opening `run.vi` took **minutes** on first render; the **identical VI on GitLab** (which was already using the CDN fallback from 0.7.3) rendered in **~3 s**. DevTools showed the minutes were the ~13 MB self-hosted Pyodide being fed through the marketplace/webview-resource layer in small chunks — jsDelivr serves the same runtime far faster. So "bundled-first" was optimizing for a case that doesn't exist (offline browser IDE) at the cost of the case that does.

## What
- **`web/extension.js`**: `pyodideAssets` is **CDN-only** — always jsDelivr (runtime) + PyPI (wheels: `networkx`, `pylabview`, `lvkit==<version>`). Removed `wheelUris` and the bundled branch. CSP unchanged (already allows those hosts).
- **`build:web`** drops `build-web-assets.sh`; **`.vscodeignore.web`** excludes `media/`; the **`build-web`** workflow comment is updated. The VSIX now ships only `dist/web/extension.js` — no `media/`, no `bin/`.
- CI **web-parity** (render-determinism) still builds wheels via `check-web-parity.sh` — untouched.
- **Python 0.7.4** is a version-only bump so the extension's `lvkit==0.7.4` resolves on PyPI. **Desktop is unchanged** (native binary).

Verified: `node esbuild.web.js` builds; the bundle has the jsDelivr base and **zero** `wheelUris`/bundled-media refs.

## Trade-off
CDN-only fails only on a host that blocks jsDelivr/PyPI at the CSP/network level (rare for a browser IDE). Smaller VSIX, one code path, fast everywhere else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)