### PR TITLE
release: v0.7.5 — fix extension README screenshots on vscode.dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ lvkit follows semantic versioning.
 
 ## [Unreleased]
 
+## [0.7.5] - 2026-08-26
+- **Fix: extension README screenshots now load on vscode.dev** — serve them from
+  jsDelivr's GitHub CDN instead of `github.com/.../raw/...`, whose 302 redirect
+  vscode.dev's cross-origin-isolated (COEP) webview blocked.
+
 ## [0.7.4] - 2026-08-26
 - **The web extension now loads Pyodide from the CDN by default, and no longer
   bundles it.** 0.7.3 tried the self-hosted `media/` copy first and only fell back

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -14,11 +14,11 @@ Nodes LVKit doesn't have a glyph for yet render as labeled boxes.
 
 **View** - click a `.vi` in the Explorer.
 
-![A .vi open in VS Code as an interactive block diagram](https://github.com/pragmatest-dev/lvkit/raw/main/editors/vscode/View.png)
+![A .vi open in VS Code as an interactive block diagram](https://cdn.jsdelivr.net/gh/pragmatest-dev/lvkit@main/editors/vscode/View.png)
 
 **Diff** - right-click a changed `.vi` and select "Open Visual Diff"
 
-![The visual before/after diff, opened from the Source Control context menu](https://github.com/pragmatest-dev/lvkit/raw/main/editors/vscode/Diff.png)
+![The visual before/after diff, opened from the Source Control context menu](https://cdn.jsdelivr.net/gh/pragmatest-dev/lvkit@main/editors/vscode/Diff.png)
 
 ## Workspace Trust
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "lvkit",
   "displayName": "LVKit",
   "description": "View and diff VIs without LabVIEW.",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "publisher": "pragmatest",
   "icon": "icon.png",
   "license": "Apache-2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lvkit"
-version = "0.7.4"
+version = "0.7.5"
 description = "Understand and convert LabVIEW VIs to Python without a LabVIEW license"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/lvkit/__init__.py
+++ b/src/lvkit/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-__version__ = "0.7.4"
+__version__ = "0.7.5"
 
 # The public API is exposed LAZILY (PEP 562 module ``__getattr__``): the graph /
 # parser / structure stacks (networkx, pydantic, pylabview, PIL — ~230 ms) load

--- a/uv.lock
+++ b/uv.lock
@@ -552,7 +552,7 @@ wheels = [
 
 [[package]]
 name = "lvkit"
-version = "0.7.4"
+version = "0.7.5"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
## What

The extension README screenshots (View.png / Diff.png) show **broken only on vscode.dev**. Fix: serve them from jsDelivr's GitHub CDN instead of the `github.com/.../raw/...` URLs.

## Why

`github.com/pragmatest-dev/lvkit/raw/main/...View.png` returns a **302 redirect** to `raw.githubusercontent.com`. vscode.dev serves its extension-view webview **cross-origin-isolated** (COEP `require-corp`), and the redirect response carries no `Cross-Origin-Resource-Policy` header — so the browser blocks the image with `ERR_BLOCKED_BY_RESPONSE.NotSameOriginAfterDefaultedToSameOriginByCoep` **before** it ever follows the redirect to the CORP-safe raw host. Every other surface (Marketplace website, Open VSX / GitLab Web IDE, desktop) follows the redirect fine, so only vscode.dev breaks.

`cdn.jsdelivr.net/gh/pragmatest-dev/lvkit@main/...` serves the image directly (no redirect) with `cross-origin-resource-policy: cross-origin` + `access-control-allow-origin: *` — satisfying COEP — and stays **external**, so there are no in-package files and no [openvsx#2099](https://github.com/eclipse/openvsx/issues/2099) risk on Open VSX. (Same CDN the web extension already uses for Pyodide.)

## Scope

README-only. The version bump to **0.7.5** (all four sites + changelog) exists solely so the marketplace listing — whose README lives inside the published VSIX — can be republished.

🤖 Generated with [Claude Code](https://claude.com/claude-code)