### PR TITLE
release: v0.7.6 — fast web VI open, render-title fix, web wheel-pin decouple

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,21 @@ jobs:
       - run: uv sync --all-extras --dev
       - name: Ruff
         run: uv run ruff check .
+      # The web extension installs `lvkit==<LVKIT_WHEEL>` from PyPI at runtime,
+      # pinned to the lvkit CORE version and DECOUPLED from the extension's own
+      # version (an extension-only fix ships without a PyPI republish). But the
+      # pin must track the published core: it has to equal pyproject's version,
+      # or the web target would install a stale/absent wheel. Fails if a core
+      # (src/lvkit) version bump forgot to update the pin, or vice-versa.
+      - name: Web lvkit wheel pin matches core version
+        run: |
+          pin=$(grep -oE 'LVKIT_WHEEL = "lvkit==[0-9]+\.[0-9]+\.[0-9]+"' editors/vscode/web/extension.js | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          proj=$(grep -oE '^version = "[0-9]+\.[0-9]+\.[0-9]+"' pyproject.toml | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          echo "web LVKIT_WHEEL pin=$pin  pyproject=$proj"
+          if [ "$pin" != "$proj" ]; then
+            echo "::error::LVKIT_WHEEL pin ($pin) != pyproject version ($proj). The web target installs lvkit==<pin> from PyPI, so a core release must bump BOTH — update LVKIT_WHEEL in editors/vscode/web/extension.js (and publish lvkit==$proj to PyPI)."
+            exit 1
+          fi
 
   typecheck:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ lvkit follows semantic versioning.
 
 ## [Unreleased]
 
+## [0.7.6] - 2026-08-26
+- **Web VI open is fast again (seconds, not minutes)** — stage only the opened VI's dependency closure, in parallel, not the whole workspace; render stays byte-identical to desktop.
+- **Fix: the viewer renders the VI you opened**, even when several VIs share a name — resolve by the loader's identity, not a bare filename. Web + desktop.
+- **Web extension version decoupled from the lvkit PyPI version** — an extension-only change now ships without republishing lvkit to PyPI.
+
 ## [0.7.5] - 2026-08-26
 - **Fix: extension README screenshots now load on vscode.dev** — serve them from
   jsDelivr's GitHub CDN instead of `github.com/.../raw/...`, whose 302 redirect

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "lvkit",
   "displayName": "LVKit",
   "description": "View and diff VIs without LabVIEW.",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "publisher": "pragmatest",
   "icon": "icon.png",
   "license": "Apache-2.0",

--- a/editors/vscode/web/extension.js
+++ b/editors/vscode/web/extension.js
@@ -12,9 +12,10 @@
 // The SAME boot page (pyodideWebviewHtml) serves two jobs — a single-VI render
 // (the custom editor) and a two-VI visual diff (the lvkit.diffVI command).
 //
-// Everything is SELF-HOSTED under media/ (build-web-assets.sh): the Pyodide core
-// + pruned package closure in media/pyodide, and the lvkit/pylabview/networkx
-// wheels in media/wheels. Nothing is fetched from a CDN or PyPI at runtime.
+// The Pyodide runtime is loaded from jsDelivr and the lvkit/pylabview/networkx
+// wheels from PyPI at runtime (see CDN_PYODIDE / CDN_WHEELS below); the VSIX
+// bundles no media/ runtime (self-hosting was dropped in v0.7.4 — slower on
+// vscode.dev, and Open VSX couldn't serve it anyway).
 //
 // DIAGNOSTICS: several web-only paths (SubVI staging/resolution, the Git diff
 // integration, the webview CSP/iframe) can't be verified headlessly, so this
@@ -57,10 +58,18 @@ function toBase64(bytes) {
 
 // Pyodide runtime + wheels, loaded from public CDNs: jsDelivr for the runtime,
 // PyPI for the pure-Python wheels (micropip installs each by NAME, deps:false;
-// lvkit LAST since it imports networkx + pylabview at import time). Versions pinned
-// to match the render (uv.lock) and lvkit's own release; keep in sync on a bump.
+// lvkit LAST since it imports networkx + pylabview at import time).
+//
+// LVKIT_WHEEL is pinned to the lvkit CORE version this build runs against, and is
+// DECOUPLED from the extension's own version on purpose: an extension-only fix
+// (anything under editors/vscode/ — a bug in this file, marketplace metadata) can
+// ship a new ext-vX.Y.Z WITHOUT re-publishing lvkit to PyPI, because the web
+// target keeps installing this fixed wheel. Bump LVKIT_WHEEL *only* when src/lvkit
+// changes (and publish that lvkit to PyPI); it MUST name a version that exists on
+// PyPI. networkx/pylabview are likewise pinned to match the render (uv.lock).
 const CDN_PYODIDE = "https://cdn.jsdelivr.net/pyodide/v314.0.5/full/";
-const CDN_WHEELS = ["networkx==3.4.2", "pylabview==0.1.2"]; // lvkit appended (its own version)
+const LVKIT_WHEEL = "lvkit==0.7.6";
+const CDN_WHEELS = ["networkx==3.4.2", "pylabview==0.1.2", LVKIT_WHEEL];
 
 // The web extension runs ONLY in hosted editors (vscode.dev, GitLab Web IDE,
 // Cursor, Gitpod, Codespaces) — all online — so we load Pyodide + wheels straight
@@ -70,9 +79,8 @@ const CDN_WHEELS = ["networkx==3.4.2", "pylabview==0.1.2"]; // lvkit appended (i
 // VI), so this is smaller AND faster. No bundled fallback: an air-gapped browser
 // IDE isn't a real host, and Open VSX can't serve bundled media/ anyway
 // (eclipse-openvsx/openvsx#2099).
-async function pyodideAssets(context) {
-  const lvkitSpec = `lvkit==${context.extension.packageJSON.version}`;
-  return { wheels: [...CDN_WHEELS, lvkitSpec], pyodideBase: CDN_PYODIDE };
+async function pyodideAssets() {
+  return { wheels: CDN_WHEELS, pyodideBase: CDN_PYODIDE };
 }
 
 // ── The shared Pyodide "engine" (a PANEL WebviewView, not an editor tab) ─────
@@ -113,12 +121,12 @@ function makeEngine(webview) {
 }
 
 // Boots Pyodide when the engine view is (re)resolved, and wires the job protocol.
-function engineViewProvider(context) {
+function engineViewProvider() {
   return {
     resolveWebviewView(view) {
       view.webview.options = {
         enableScripts: true,
-        localResourceRoots: [vscode.Uri.joinPath(context.extensionUri, "media")],
+        localResourceRoots: [], // CDN-only: nothing loaded as a local webview resource (no media/)
       };
       const engine = makeEngine(view.webview);
       view.webview.onDidReceiveMessage((m) => {
@@ -138,7 +146,7 @@ function engineViewProvider(context) {
       });
       _engine = engine;
       const wake = () => { const waiters = _engineWaiters; _engineWaiters = []; waiters.forEach((r) => r(engine)); };
-      pyodideAssets(context)
+      pyodideAssets()
         .then((assets) => { view.webview.html = engineHtml(view.webview, assets.wheels, assets.pyodideBase); wake(); })
         .catch((e) => { view.webview.html = errorHtml("LVKit web build is missing its wheels", String(e)); logError("engine assets", e); engine.rejectReady(new Error(String(e))); wake(); });
     },
@@ -335,7 +343,7 @@ async function resolveDiffSides(target) {
   return { before: { uri: head, ref: "HEAD" }, after: { uri: target, ref: null } };
 }
 
-async function diffVI(context, arg) {
+async function diffVI(arg) {
   const target = arg && (arg.resourceUri || arg);
   if (!target || !/\.vi$/i.test(target.path || "")) {
     vscode.window.showErrorMessage("lvkit: no .vi selected.");
@@ -373,7 +381,7 @@ async function diffVI(context, arg) {
       {
         enableScripts: true,
         retainContextWhenHidden: true,
-        localResourceRoots: [vscode.Uri.joinPath(context.extensionUri, "media")],
+        localResourceRoots: [], // CDN-only: nothing loaded as a local webview resource (no media/)
       }
     );
     const engine = await getEngine();
@@ -433,7 +441,7 @@ function activate(context) {
       const webview = panel.webview;
       webview.options = {
         enableScripts: true,
-        localResourceRoots: [vscode.Uri.joinPath(context.extensionUri, "media")],
+        localResourceRoots: [], // CDN-only: nothing loaded as a local webview resource (no media/)
       };
       log(`open VI: ${document.uri.toString()}`);
       const engine = await getEngine();
@@ -498,11 +506,11 @@ function activate(context) {
     })
   );
   context.subscriptions.push(
-    vscode.commands.registerCommand("lvkit.diffVI", (arg) => diffVI(context, arg))
+    vscode.commands.registerCommand("lvkit.diffVI", (arg) => diffVI(arg))
   );
   // The shared Pyodide engine lives in this Panel view (kept alive when hidden).
   context.subscriptions.push(
-    vscode.window.registerWebviewViewProvider("lvkit.engine", engineViewProvider(context), {
+    vscode.window.registerWebviewViewProvider("lvkit.engine", engineViewProvider(), {
       webviewOptions: { retainContextWhenHidden: true },
     })
   );

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lvkit"
-version = "0.7.5"
+version = "0.7.6"
 description = "Understand and convert LabVIEW VIs to Python without a LabVIEW license"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/lvkit/__init__.py
+++ b/src/lvkit/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-__version__ = "0.7.5"
+__version__ = "0.7.6"
 
 # The public API is exposed LAZILY (PEP 562 module ``__getattr__``): the graph /
 # parser / structure stacks (networkx, pydantic, pylabview, PIL — ~230 ms) load

--- a/uv.lock
+++ b/uv.lock
@@ -552,7 +552,7 @@ wheels = [
 
 [[package]]
 name = "lvkit"
-version = "0.7.5"
+version = "0.7.6"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
Cuts **0.7.6**. The staging + render-title fixes are already on `main` (#66); this adds the **web wheel-pin decouple** and the release bump.

## Decouple
The web extension installed `lvkit==${packageJSON.version}` — coupling the extension version to the Python package, so an extension-only fix forced a PyPI republish. Now it installs a fixed **`LVKIT_WHEEL = "lvkit==0.7.6"`**, pinned to the lvkit **core** version and independent of the extension version. Extension-only changes ship without touching PyPI; only a core (`src/lvkit`) change bumps the pin (and PyPI).

- **CI guard** (lint job): `LVKIT_WHEEL` must equal `pyproject`'s version, so a core release can't forget to bump the pin.
- Fixed a stale header comment (the extension is **CDN-only** since 0.7.4, not self-hosted under `media/`) and dropped the now-empty `media/` `localResourceRoots` + the `context` params they stranded.

## Release
Version bumped to 0.7.6 (`pyproject` + `__init__` + `uv.lock` + `editors/vscode/package.json`); CHANGELOG dated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)