### PR TITLE
feat(primitives): VI-Scripting baseline import + ground-truth ID corrections (#59)

### DIFF
--- a/scripts/import_nodes_primitives.py
+++ b/scripts/import_nodes_primitives.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""Merge-import LabVIEW VI-Scripting node export into primitives.json (#59).
+
+Ground truth source: a public LabVIEW VI Scripting export (695 nodes, one per
+primResID/"style_id"), NOT bundled with the repo (gitignored under .tmp/).
+Pass its path with --nodes-json (defaults to the maintainer's known location).
+
+This is a MERGE, not a regenerate, against src/lvkit/data/primitives.json's
+``primitives`` dict. The identity check is CASE-INSENSITIVE (name.casefold()):
+
+  - primResID not present                    -> ADD an unverified entry
+                                                 (no python_code)
+  - primResID present, name mismatch         -> CORRECT name+terminals from
+    (case-insensitive)                          nodes.json, drop the
+                                                 now-misattached python_code,
+                                                 mark verified:false
+  - primResID present, name matches          -> PRESERVE: adopt nodes.json's
+    case-insensitively but differs only         casing but KEEP python_code/
+    in casing                                    verified/terminals as-is
+  - primResID present, name matches exactly  -> PRESERVE untouched (only
+                                                 fills a missing terminal name
+                                                 on exact index+direction
+                                                 match)
+
+A case-sensitive identity check landed a real regression (#59): "Array Of
+Strings To Path" (primitives.json) vs nodes.json's "Array of Strings to Path"
+differ only in capitalization -- the SAME primitive -- but a `!=` comparison
+routed them through CORRECT, silently dropping their working, verified
+python_code (1422/1423). Fixed by casefold()-comparing identity while still
+adopting nodes.json's casing as the canonical spelling going forward.
+
+A small, explicitly-justified HOLD set is carved out of the "name mismatch"
+bucket: primResIDs where the *current* primitives.json entry is backed by
+evidence stronger than a bare name match -- a pinned regression test built
+from real-VI dataflow, or live codegen that hardcodes the primResID's
+identity outside primitives.json entirely. Overwriting those from the nodes
+export's bare style_name, without the maintainer weighing the conflicting
+evidence, is exactly the kind of "fix" CLAUDE.md's BUGS gate reserves for the
+maintainer. See HOLD_IDS below for the itemized evidence.
+
+Deterministic and re-runnable: same nodes.json + same primitives.json in ->
+same primitives.json out.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PRIMITIVES_PATH = REPO_ROOT / "src" / "lvkit" / "data" / "primitives.json"
+BUILTIN_TYPES_PATH = REPO_ROOT / "src" / "lvkit" / "data" / "builtin_types.json"
+DEFAULT_NODES_JSON = Path("/home/ryanf/repos/lvkit/.tmp/nodes.json")
+
+SOURCE_TAG = "vi-scripting-nodes-lv2025"
+
+# --------------------------------------------------------------------------
+# Structures: no fixed data connector pane -- excluded from primitive import.
+# --------------------------------------------------------------------------
+
+# The 12 structures named explicitly in the import brief (issue #59).
+EXCLUDED_STRUCTURES_BRIEF: dict[int, str] = {
+    2000: "Stacked Sequence",
+    2001: "Case Structure",
+    2002: "For Loop",
+    2003: "While Loop",
+    2052: "Event Structure",
+    2054: "Diagram Disable Structure",
+    2064: "Conditional Disable Structure",
+    2352: "While Loop",
+    2360: "In Place Element Structure",
+    2373: "Type Specialization Structure",
+    5570: "Timed Loop",
+    5573: "Timed Sequence",
+}
+
+# Re-scan finding (not in the brief's list): these 3 nodes.json entries show
+# the SAME "no fixed data connector pane" signature as the 12 above --
+# terminals: [] (the VI-Scripting export reports zero terminals at all, a
+# stronger form of "no fixed pane" than several of the 12 explicitly-listed
+# structures which do carry a couple of framework terminals e.g. loop index).
+# 2004 "Formula Node" (self-named). 2370/2371 additionally carry style_name
+# "Unknown" with style_description "Target Structure" / "Race Structure" --
+# i.e. the export itself calls them structures. None of the three are
+# currently in primitives.json, so excluding them changes nothing destructive
+# -- it only withholds three new adds. Flagged for maintainer confirmation;
+# see the script's printed summary.
+EXCLUDED_STRUCTURES_RESCAN: dict[int, str] = {
+    2004: "Formula Node",
+    2370: "Unknown (style_description: Target Structure)",
+    2371: "Unknown (style_description: Race Structure)",
+}
+
+EXCLUDED_STRUCTURES: dict[int, str] = {
+    **EXCLUDED_STRUCTURES_BRIEF,
+    **EXCLUDED_STRUCTURES_RESCAN,
+}
+
+# --------------------------------------------------------------------------
+# HOLD: name-mismatch primResIDs carved OUT of the "CORRECT" bucket.
+#
+# Each entry needs SPECIFIC, checked-this-session evidence contradicting the
+# nodes.json style_name -- not just "it was already named something else" --
+# to be held here instead of corrected. Held entries are left completely
+# untouched; reported to the maintainer for adjudication.
+#
+# RESOLVED (2026-08-27): 1057, 1058, 1108, 1116, 2401 were all held here after
+# the first import pass, each backed by a prior verified:true entry, a pinned
+# regression test, or live codegen hardcoding a different identity. The
+# maintainer reviewed the conflicts and confirmed nodes.json is correct for
+# all five, proven by LabVIEW's own per-terminal EXPRESSION text (not just the
+# style_name): 1057's output terminal is literally named "x+1" (Increment, not
+# Absolute Value); 1058's is "x-1" (Decrement); 1108's two outputs are
+# "min(x,y)" and "max(x,y)" (Max & Min, not Quotient & Remainder or a
+# comparison); 1116's output is "x != 0?" over a scalar double_float input
+# (Not Equal To 0?, not the ruled-out numeric-comparison family -- the old
+# "corpus feeders are boolean/cluster" finding was itself wrong); 2401's pane
+# (x'/y' outputs, x/y/condition inputs) matches Swap Values, and the real
+# Merge Errors is 2147 (error_cluster in x2 / out x1, the expandable pane the
+# old 2401 entry actually described). The prior "verified" identifications and
+# the condition_builder.py / error_handler.py hardcoding were themselves
+# wrong. See the corresponding fixes in codegen/condition_builder.py,
+# codegen/error_handler.py, codegen/nodes/primitive.py, codegen/class_builder.py,
+# codegen/builder.py, and parser/node_types.py. HOLD_IDS is now empty; kept as
+# the mechanism for any FUTURE conflict that needs the same treatment.
+# --------------------------------------------------------------------------
+
+HOLD_IDS: dict[int, str] = {}
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text())
+
+
+def build_alias_map(builtin_types: dict[str, Any]) -> dict[str, str]:
+    alias_map: dict[str, str] = {}
+    for canonical, info in builtin_types["types"].items():
+        for alias in info["aliases"]:
+            alias_map[alias] = canonical
+    return alias_map
+
+
+def canonical_type(
+    data_type: dict[str, Any] | None, alias_map: dict[str, str], sid: str
+) -> tuple[str, str | None]:
+    """Return (canonical_type, note). note is set only for the null case.
+
+    Raises a diagnostic KeyError (naming the offending style_id) instead of a
+    bare one, so a future re-run against an updated/expanded export fails
+    with something actionable rather than an opaque traceback.
+    """
+    if data_type is None:
+        return "Polymorphic", "data_type was null in the VI-Scripting export"
+    if "type" not in data_type:
+        raise KeyError(
+            f"style_id {sid}: data_type {data_type!r} has no 'type' key"
+        )
+    raw = data_type["type"]
+    if raw not in alias_map:
+        raise KeyError(
+            f"style_id {sid}: data_type {raw!r} has no alias in "
+            "builtin_types.json -- add one (or an alias onto an existing "
+            "canonical type) before re-running the import"
+        )
+    return alias_map[raw], None
+
+
+def convert_terminal(
+    term: dict[str, Any], alias_map: dict[str, str], sid: str
+) -> dict[str, Any]:
+    for field in ("index", "is_source", "name"):
+        if field not in term:
+            raise KeyError(
+                f"style_id {sid}: terminal {term!r} is missing required "
+                f"field {field!r}"
+            )
+    data_type = term.get("data_type")
+    ctype, note = canonical_type(data_type, alias_map, sid)
+    out: dict[str, Any] = {
+        "index": term["index"],
+        "direction": "out" if term["is_source"] else "in",
+        "name": term["name"],
+        "type": ctype,
+    }
+    if term.get("is_hidden"):
+        out["hidden"] = True
+    if data_type is not None and data_type.get("type") == "refnum":
+        for key in ("refnum_type", "class_id", "class_name"):
+            if key in data_type:
+                out[key] = data_type[key]
+    if note:
+        out["note"] = note
+    return out
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--nodes-json",
+        type=Path,
+        default=DEFAULT_NODES_JSON,
+        help="Path to the VI-Scripting nodes export (gitignored, not in-tree)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Compute and print the summary without writing primitives.json",
+    )
+    args = parser.parse_args()
+
+    nodes = load_json(args.nodes_json)
+    builtin_types = load_json(BUILTIN_TYPES_PATH)
+    alias_map = build_alias_map(builtin_types)
+
+    data = load_json(PRIMITIVES_PATH)
+    primitives: dict[str, Any] = data["primitives"]
+
+    nodes_by_id: dict[int, dict[str, Any]] = {n["style_id"]: n for n in nodes}
+    assert len(nodes_by_id) == len(nodes), "duplicate style_id in nodes.json"
+
+    excluded_found: list[int] = []
+    other_structure_candidates: list[tuple[int, str]] = []
+    added: list[str] = []
+    corrected: list[str] = []
+    case_renamed: list[str] = []
+    preserved_filled: list[str] = []
+    preserved_untouched: list[str] = []
+    held: list[str] = []
+
+    for style_id, node in sorted(nodes_by_id.items()):
+        sid = str(style_id)
+        style_name = node["style_name"]
+
+        if style_id in EXCLUDED_STRUCTURES:
+            excluded_found.append(style_id)
+            continue
+
+        # Re-scan signal, independent of the fixed exclude list: zero
+        # terminals is the same "no fixed data connector pane" signature the
+        # excluded structures show. Anything NOT already in EXCLUDED_STRUCTURES
+        # that matches it is reported, never silently included or excluded.
+        if len(node["terminals"]) == 0 and style_id not in EXCLUDED_STRUCTURES:
+            other_structure_candidates.append((style_id, style_name))
+
+        if style_id in HOLD_IDS:
+            held.append(f"{sid} ({style_name!r} per nodes.json)")
+            continue
+
+        new_terminals = [
+            convert_terminal(t, alias_map, sid) for t in node["terminals"]
+        ]
+
+        if sid not in primitives:
+            primitives[sid] = {
+                "name": style_name,
+                "terminals": new_terminals,
+                "verified": False,
+                "source": SOURCE_TAG,
+            }
+            added.append(sid)
+            continue
+
+        entry = primitives[sid]
+        entry_name = entry.get("name", "")
+        # Identity check is case-INSENSITIVE: "Array Of Strings To Path" vs
+        # nodes.json's "Array of Strings to Path" is the SAME primitive, a
+        # capitalization-only difference -- not a name mismatch. Treating it
+        # as one (case-sensitive ==) hit the CORRECT branch and dropped
+        # working, verified python_code for no reason (#59 regression:
+        # 1422/1423). Only a genuine case-insensitive mismatch is a real
+        # identity conflict.
+        if entry_name.casefold() != style_name.casefold():
+            primitives[sid] = {
+                "name": style_name,
+                "terminals": new_terminals,
+                "verified": False,
+                "source": SOURCE_TAG,
+                "note": (
+                    "corrected from VI-Scripting nodes export (#59); codegen "
+                    "dropped pending re-derivation"
+                ),
+            }
+            corrected.append(f"{sid} ({entry_name!r} -> {style_name!r})")
+            continue
+
+        # Same primitive (case-insensitively). A case-only difference adopts
+        # nodes.json's casing but KEEPS python_code/verified/terminals/etc --
+        # this is still the PRESERVE path, not a correction.
+        if entry_name != style_name:
+            entry["name"] = style_name
+            case_renamed.append(f"{sid} ({entry_name!r} -> {style_name!r})")
+
+        # PRESERVE: only fill a currently-absent terminal name when
+        # index+direction match exactly; never touch type/python_code/
+        # verified/etc.
+        nodes_terms_by_key = {
+            (t["index"], "out" if t["is_source"] else "in"): t["name"]
+            for t in node["terminals"]
+        }
+        filled_any = False
+        for term in entry.get("terminals", []):
+            key = (term.get("index"), term.get("direction"))
+            if not term.get("name") and key in nodes_terms_by_key:
+                term["name"] = nodes_terms_by_key[key]
+                filled_any = True
+        if filled_any:
+            preserved_filled.append(sid)
+        else:
+            preserved_untouched.append(sid)
+
+    # Order the whole primitives dict by int(primResID) ascending.
+    data["primitives"] = {
+        k: primitives[k] for k in sorted(primitives, key=int)
+    }
+
+    verified_count = sum(
+        1 for v in data["primitives"].values() if v.get("verified") is True
+    )
+    total = len(data["primitives"])
+    data["metadata"] = {
+        "description": "Primitive ID to Python mapping (runtime version)",
+        "source": (
+            "OpenG + JKI VI Tester + LabVIEW VI Scripting nodes export "
+            "(issue #59)"
+        ),
+        "total_primitives": total,
+        # NOT total: "identified" means confirmed identity + codegen, i.e.
+        # verified_count. Counting all 680 here (as an earlier version of
+        # this script did) overstated coverage -- it silently folded in the
+        # ~590 unverified VI-Scripting baseline entries (real name+terminals
+        # from nodes.json, but no python_code and no independent
+        # confirmation) as if they were as trustworthy as a verified entry.
+        "identified": verified_count,
+        "verified_count": verified_count,
+        "unverified_count": total - verified_count,
+        "note": (
+            "verified_count = confirmed identity + codegen (doc/corpus/"
+            "geometry-checked, has python_code); unverified_count = "
+            "VI-Scripting export baseline only (real name+terminals from "
+            "nodes.json, #59, but no codegen and no independent "
+            "confirmation yet). See primitives-codegen-full.json for "
+            "count/vis metadata."
+        ),
+    }
+
+    print(f"Structures excluded: {len(excluded_found)} {sorted(excluded_found)}")
+    if other_structure_candidates:
+        print(
+            "Additional structure-like candidates found by re-scan "
+            f"(0 terminals, not in the brief's exclude list) -- already "
+            f"folded into EXCLUDED_STRUCTURES_RESCAN, confirm with maintainer: "
+            f"{other_structure_candidates}"
+        )
+    print(f"Added: {len(added)}")
+    print(f"Corrected: {len(corrected)}")
+    for c in corrected:
+        print(f"  {c}")
+    print(
+        f"Preserved, case-only rename (python_code/verified kept): "
+        f"{len(case_renamed)}"
+    )
+    for c in case_renamed:
+        print(f"  {c}")
+    print(f"Preserved (terminal name filled): {len(preserved_filled)}")
+    print(f"Preserved (untouched): {len(preserved_untouched)}")
+    print(f"Held (excluded from CORRECT pending maintainer review): {len(held)}")
+    for h in held:
+        print(f"  {h}")
+    print(f"Total primitives in output: {total} (verified={verified_count})")
+
+    if not args.dry_run:
+        PRIMITIVES_PATH.write_text(json.dumps(data, indent=2) + "\n")
+        print(f"Wrote {PRIMITIVES_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lvkit/codegen/builder.py
+++ b/src/lvkit/codegen/builder.py
@@ -74,7 +74,7 @@ def build_module(
     ctx.unresolved_sink = unresolved_sink
 
     # Determine if we need error handling infrastructure (graph-driven).
-    # True only if Merge Errors (prim 2401) exists in the VI's operations.
+    # True only if Merge Errors (prim 2147) exists in the VI's operations.
     use_error_handling = needs_error_handling(vi_context.operations, vi_context)
     ctx.use_held_error_model = use_error_handling
 

--- a/src/lvkit/codegen/class_builder.py
+++ b/src/lvkit/codegen/class_builder.py
@@ -394,9 +394,11 @@ class ClassBuilder:
         # whitelisted by id. (This set was historically populated with stale
         # ids -- 1340/1302/2075/2076 actually map to One Button Dialog / Wait
         # (ms) / Destroy User Event / Unregister For Events -- so real Merge
-        # Errors was never recognized here; corrected to 2401.)
+        # Errors was never recognized here; corrected to 2401, then to 2147
+        # once nodes.json's VI-Scripting export proved 2401 is really Swap
+        # Values and 2147 is the real Merge Errors -- #59.)
         simple_prim_ids = {
-            2401,  # Merge Errors
+            2147,  # Merge Errors
         }
 
         for op in operations:

--- a/src/lvkit/codegen/condition_builder.py
+++ b/src/lvkit/codegen/condition_builder.py
@@ -14,23 +14,30 @@ from .ast_utils import parse_expr
 from .context import CodeGenContext
 
 # Mapping of primitive IDs to AST comparison operators
+#
+# (#59) 1107/1108/1100/1101/1109 were phantom IDs -- they exist in neither
+# nodes.json (a public LabVIEW VI Scripting export of every real primitive
+# style_id) nor primitives.json. The real ids, confirmed by both sources'
+# per-terminal output EXPRESSION text (not just a name guess): 1104's output
+# is "x <= y?" (Less Or Equal?), 1111's is "x < y?" (Less?), 1061's is
+# "x .and. y?" (And), 1062's is "x .or. y?" (Or), 1064's is ".not. x?" (Not).
 COMPARISON_PRIMITIVES: dict[int, type[ast.cmpop]] = {
     1102: ast.Eq,  # Equal?
     1103: ast.GtE,  # Greater Or Equal?
+    1104: ast.LtE,  # Less Or Equal?
     1105: ast.NotEq,  # Not Equal?
-    1107: ast.Lt,  # Less? (inferred)
-    1108: ast.LtE,  # Less Or Equal?
     1110: ast.Gt,  # Greater?
+    1111: ast.Lt,  # Less?
 }
 
 # Mapping of primitive IDs to AST boolean operators
 BOOLEAN_PRIMITIVES: dict[int, type[ast.boolop]] = {
-    1100: ast.And,  # And
-    1101: ast.Or,  # Or
+    1061: ast.And,  # And
+    1062: ast.Or,  # Or
 }
 
 # Not primitive for unary negation
-NOT_PRIMITIVES: set[int] = {1109}  # Not
+NOT_PRIMITIVES: set[int] = {1064}  # Not
 
 
 def build_condition_expr(

--- a/src/lvkit/codegen/error_handler.py
+++ b/src/lvkit/codegen/error_handler.py
@@ -76,8 +76,8 @@ def classify_error_node(op: Operation) -> ErrorHandlingPattern:
     Checks the operation itself — not its downstream connections.
     This is a structural check based on node identity.
     """
-    # Merge Errors primitive (prim 2401)
-    if isinstance(op, PrimitiveOperation) and op.primResID == 2401:
+    # Merge Errors primitive (prim 2147; not 2401, which is Swap Values -- #59)
+    if isinstance(op, PrimitiveOperation) and op.primResID == 2147:
         return ErrorHandlingPattern.MERGE
 
     # Clear Errors VI
@@ -100,7 +100,7 @@ def needs_error_handling(
 ) -> bool:
     """Determine if a VI needs _held_error infrastructure.
 
-    Graph-driven: True only if Merge Errors (prim 2401) exists
+    Graph-driven: True only if Merge Errors (prim 2147) exists
     in the VI's operations. Clear Errors and error case structures
     don't need _held_error — they use different patterns.
     """

--- a/src/lvkit/codegen/nodes/primitive.py
+++ b/src/lvkit/codegen/nodes/primitive.py
@@ -84,10 +84,11 @@ def generate(node: PrimitiveOperation, ctx: CodeGenContext) -> CodeFragment:
     """Generate code for a primitive node."""
     prim_id = node.primResID
 
-    # Merge Errors (prim 2401) is a structural signal, not a code node.
-    # In the exception model, error merging happens via try/except on
-    # future.result() calls — the primitive itself produces no code.
-    if prim_id == 2401:
+    # Merge Errors (prim 2147; not 2401, which is Swap Values -- #59) is a
+    # structural signal, not a code node. In the exception model, error
+    # merging happens via try/except on future.result() calls — the
+    # primitive itself produces no code.
+    if prim_id == 2147:
         return CodeFragment.empty()
 
     # Get primitive hint.

--- a/src/lvkit/data/builtin_types.json
+++ b/src/lvkit/data/builtin_types.json
@@ -1,0 +1,202 @@
+{
+  "metadata": {
+    "description": "Unified built-in LabVIEW terminal-type catalog. One entry per canonical type; `aliases` maps every spelling seen in the corpus (nodes.json's lowercase VI-Scripting vocabulary AND primitives.json's existing flat vocabulary) onto the canonical name, so any terminal `type` string encountered while importing/merging normalizes through this file.",
+    "source": "LabVIEW VI Scripting node terminal data_type names (.tmp/nodes.json, issue #59) unified with lvkit's pre-existing terminal-type vocabulary (src/lvkit/data/primitives.json)",
+    "version": "1.0"
+  },
+  "types": {
+    "NumInt8": {
+      "kind": "integer",
+      "bits": 8,
+      "signed": true,
+      "description": "8-bit signed integer",
+      "aliases": ["i8", "NumInt8"]
+    },
+    "NumInt16": {
+      "kind": "integer",
+      "bits": 16,
+      "signed": true,
+      "description": "16-bit signed integer",
+      "aliases": ["i16", "NumInt16"]
+    },
+    "NumInt32": {
+      "kind": "integer",
+      "bits": 32,
+      "signed": true,
+      "description": "32-bit signed integer",
+      "aliases": ["i32", "NumInt32"]
+    },
+    "NumInt64": {
+      "kind": "integer",
+      "bits": 64,
+      "signed": true,
+      "description": "64-bit signed integer",
+      "aliases": ["i64", "NumInt64"]
+    },
+    "NumUInt8": {
+      "kind": "integer",
+      "bits": 8,
+      "signed": false,
+      "description": "8-bit unsigned integer",
+      "aliases": ["u8", "NumUInt8"]
+    },
+    "NumUInt16": {
+      "kind": "integer",
+      "bits": 16,
+      "signed": false,
+      "description": "16-bit unsigned integer",
+      "aliases": ["u16", "NumUInt16", "UnitUInt16"]
+    },
+    "NumUInt32": {
+      "kind": "integer",
+      "bits": 32,
+      "signed": false,
+      "description": "32-bit unsigned integer",
+      "aliases": ["u32", "NumUInt32"]
+    },
+    "NumUInt64": {
+      "kind": "integer",
+      "bits": 64,
+      "signed": false,
+      "description": "64-bit unsigned integer",
+      "aliases": ["u64", "NumUInt64"]
+    },
+    "NumFloat32": {
+      "kind": "float",
+      "bits": 32,
+      "description": "Single-precision (32-bit) floating point",
+      "aliases": ["single_float"]
+    },
+    "NumFloat64": {
+      "kind": "float",
+      "bits": 64,
+      "description": "Double-precision (64-bit) floating point",
+      "aliases": ["double_float", "NumFloat64"]
+    },
+    "NumFloatExt": {
+      "kind": "float",
+      "bits": null,
+      "description": "Extended-precision floating point (platform-native \"long double\"; bit width is platform-dependent, commonly 80-bit on x86)",
+      "aliases": ["extended_float"]
+    },
+    "NumComplex64": {
+      "kind": "complex",
+      "bits": 64,
+      "description": "Single-precision complex (two 32-bit floats)",
+      "aliases": ["single_complex"]
+    },
+    "NumComplex128": {
+      "kind": "complex",
+      "bits": 128,
+      "description": "Double-precision complex (two 64-bit floats)",
+      "aliases": ["double_complex", "NumComplex"],
+      "note": "'NumComplex' (primitives.json's pre-existing generic spelling) is aliased here, not to an abstract/precision-less complex type, because primResID 1044 'Complex To Re/Im' terminal idx0 uses 'NumComplex' in primitives.json and nodes.json's ground truth for that exact same terminal (same primResID, same index/direction) is 'double_complex' -- cross-referenced from .tmp/nodes.json, not guessed."
+    },
+    "NumComplexExt": {
+      "kind": "complex",
+      "bits": null,
+      "description": "Extended-precision complex (two extended-precision floats; bit width is platform-dependent)",
+      "aliases": ["extended_complex"]
+    },
+    "Boolean": {
+      "kind": "boolean",
+      "description": "LabVIEW boolean",
+      "aliases": ["boolean", "Boolean"]
+    },
+    "String": {
+      "kind": "string",
+      "description": "LabVIEW string",
+      "aliases": ["string", "String"]
+    },
+    "Path": {
+      "kind": "path",
+      "description": "LabVIEW path",
+      "aliases": ["path", "Path"]
+    },
+    "Refnum": {
+      "kind": "refnum",
+      "description": "Reference number (opaque handle); specific refnum family carried on the terminal as refnum_type/class_id/class_name when nodes.json supplies it, not in this catalog",
+      "aliases": ["refnum", "Refnum"]
+    },
+    "Cluster": {
+      "kind": "cluster",
+      "description": "Generic LabVIEW cluster",
+      "aliases": ["cluster", "Cluster"]
+    },
+    "ErrorCluster": {
+      "kind": "cluster",
+      "description": "LabVIEW error cluster (status, code, source)",
+      "aliases": ["error_cluster"]
+    },
+    "Array": {
+      "kind": "array",
+      "description": "LabVIEW array (element type and dimensionality carried per-terminal, not in this catalog)",
+      "aliases": ["array", "Array"]
+    },
+    "Enum": {
+      "kind": "enum",
+      "bits": null,
+      "description": "Enumerated ring type of unspecified bit width -- primitives.json's pre-existing generic 'enum' spelling, kept distinct from nodes.json's bit-width-specific enum_u16/enum_u32 rather than assumed to be either",
+      "aliases": ["enum"]
+    },
+    "Enum16": {
+      "kind": "enum",
+      "bits": 16,
+      "description": "16-bit enumerated ring type",
+      "aliases": ["enum_u16"]
+    },
+    "Enum32": {
+      "kind": "enum",
+      "bits": 32,
+      "description": "32-bit enumerated ring type",
+      "aliases": ["enum_u32"]
+    },
+    "LVVariant": {
+      "kind": "variant",
+      "description": "LabVIEW variant",
+      "aliases": ["lv_variant", "LVVariant"]
+    },
+    "Timestamp": {
+      "kind": "timestamp",
+      "description": "LabVIEW absolute timestamp",
+      "aliases": ["timestamp", "MeasureData"],
+      "note": "'MeasureData' (primitives.json's pre-existing spelling) is aliased here, not to Waveform, because every existing primitives.json use of 'MeasureData' (primResIDs 1303 idx0 'current_time', 8100 idx2 'timestamp', 8082 idx1 'last_mod') matches -- same primResID, same index/direction -- a nodes.json 'timestamp' terminal, cross-referenced from .tmp/nodes.json, not guessed. Elsewhere in the codebase (src/lvkit/models.py LVType.measure_flavor) 'MeasureData' names a different, unrelated concept (the waveform/digital-data underlying_type family); this catalog only covers the primitives.json/nodes.json terminal-type vocabulary and does not change that."
+    },
+    "Waveform": {
+      "kind": "waveform",
+      "description": "LabVIEW waveform (element type carried per-terminal, not in this catalog)",
+      "aliases": ["waveform"]
+    },
+    "SetCollection": {
+      "kind": "collection",
+      "description": "LabVIEW Set collection",
+      "aliases": ["set_collection"]
+    },
+    "MapCollection": {
+      "kind": "collection",
+      "description": "LabVIEW Map collection",
+      "aliases": ["map_collection"]
+    },
+    "FixedPoint": {
+      "kind": "fixedpoint",
+      "description": "LabVIEW fixed-point numeric (word_length/integer_word_length/signed/overflow-status carried per-terminal, not in this catalog)",
+      "aliases": ["fixed_point"]
+    },
+    "ExpressData": {
+      "kind": "express",
+      "description": "Express VI dynamic data wire type",
+      "aliases": ["express_data"]
+    },
+    "Void": {
+      "kind": "void",
+      "description": "No data (e.g. a bare system handle)",
+      "aliases": ["void"]
+    },
+    "Polymorphic": {
+      "kind": "abstract",
+      "abstract": true,
+      "description": "Adapts to wired type",
+      "aliases": ["polymorphic", "numeric"]
+    }
+  }
+}

--- a/src/lvkit/data/primitives.json
+++ b/src/lvkit/data/primitives.json
@@ -1,107 +1,286 @@
 {
   "metadata": {
     "description": "Primitive ID to Python mapping (runtime version)",
-    "source": "OpenG + JKI VI Tester",
-    "total_primitives": 141,
-    "identified": 141,
-    "note": "See primitives-codegen-full.json for count/vis metadata"
+    "source": "OpenG + JKI VI Tester + LabVIEW VI Scripting nodes export (issue #59)",
+    "total_primitives": 680,
+    "identified": 90,
+    "verified_count": 90,
+    "unverified_count": 590,
+    "note": "verified_count = confirmed identity + codegen (doc/corpus/geometry-checked, has python_code); unverified_count = VI-Scripting export baseline only (real name+terminals from nodes.json, #59, but no codegen and no independent confirmation yet). See primitives-codegen-full.json for count/vis metadata."
   },
   "primitives": {
-    "1907": {
-      "name": "Array Max & Min",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/array-max-min.html",
+    "1044": {
+      "name": "Complex To Re/Im",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/complex-to-re-im.html",
       "terminals": [
         {
           "index": 0,
           "direction": "in",
-          "name": "array",
-          "type": "polymorphic"
+          "name": "x",
+          "type": "NumComplex"
         },
         {
           "index": 1,
           "direction": "out",
-          "name": "max value",
-          "type": "polymorphic"
+          "name": "re",
+          "type": "NumFloat64"
         },
         {
           "index": 2,
           "direction": "out",
-          "name": "max index",
-          "type": "NumInt32"
-        },
-        {
-          "index": 3,
-          "direction": "out",
-          "name": "min value",
-          "type": "polymorphic"
-        },
-        {
-          "index": 4,
-          "direction": "out",
-          "name": "min index",
-          "type": "NumInt32"
+          "name": "im",
+          "type": "NumFloat64"
         }
       ],
       "python_code": {
-        "max_value": "(max(in_0) if in_0 else 0)",
-        "max_index": "(in_0.index(max(in_0)) if in_0 else -1)",
-        "min_value": "(min(in_0) if in_0 else 0)",
-        "min_index": "(in_0.index(min(in_0)) if in_0 else -1)"
+        "re": "in_0.real",
+        "im": "in_0.imag"
       },
-      "inline": true,
-      "verified": true,
-      "note": "Array Max & Min -- returns max value & its first index, min value & its first index (NI array-max-min doc); terminals from OpenG samples 'limitDecendantsTo1Level', 'Fit VI window to Largest Dec'."
+      "note": "re/im output index order (out1=re,out2=im) assumed by convention; confirm geometry.",
+      "verified": false
     },
-    "1083": {
-      "name": "First Call?",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/first-call.html",
+    "1045": {
+      "name": "Complex To Polar",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "r * e^(i*theta)",
+          "type": "NumComplex128"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "r",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "theta",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1046": {
+      "name": "Re/Im To Complex",
       "terminals": [
         {
           "index": 0,
           "direction": "out",
-          "name": "first_call",
-          "type": "Boolean"
-        }
-      ],
-      "python_code": {
-        "_body": "raise RuntimeError('First Call? (1083) should be dispatched to codegen/nodes/first_call.py by primResID -- this stub should be unreachable')"
-      },
-      "inline": true,
-      "verified": true,
-      "note": "First Call? -- 0 inputs, 1 Boolean out; returns TRUE only on the first execution after the VI runs, FALSE thereafter (stateful, not a constant); matches NI Synchronization doc."
-    },
-    "1104": {
-      "name": "Less Or Equal?",
-      "elementwise": true,
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "x_less_or_equal_y",
-          "type": "boolean"
+          "name": "x + iy",
+          "type": "NumComplex128"
         },
         {
           "index": 1,
           "direction": "in",
           "name": "y",
-          "type": "polymorphic",
-          "default_value": "0"
+          "type": "NumFloat64"
         },
         {
           "index": 2,
           "direction": "in",
           "name": "x",
-          "type": "polymorphic",
-          "default_value": "0"
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1047": {
+      "name": "Polar To Complex",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "r * e^(i*theta)",
+          "type": "NumComplex128"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "theta",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "r",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1048": {
+      "name": "Complex Conjugate",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "x - iy",
+          "type": "NumComplex128"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x + iy",
+          "type": "NumComplex128"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1049": {
+      "name": "Sign",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/sign.html",
+      "elementwise": true,
+      "guess_reason": "Unary, type-preserving numeric op (DBL->DBL, Array[DBL]->Array[DBL]); raw typeDescs confirm both ends NumFloat64. Forced by this VI's direction detection: consecutive angle deltas -> Sign(each) -> Add Array Elements(sum) -> Sign(sum) -> To Byte Integer -> xcreasing in {-1,0,+1}. Only Sign (returns 1/0/-1, type-preserving) collapses the sum to a +/-1 direction; sum (not product) makes it a wrap-robust majority vote. Array inputs would need element-wise handling.",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "sign",
+          "type": "polymorphic"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "polymorphic"
         }
       ],
       "python_code": {
-        "x_less_or_equal_y": "in_2 <= in_1"
+        "sign": "(in_1 > 0) - (in_1 < 0)"
+      },
+      "inline": true,
+      "verified": true
+    },
+    "1050": {
+      "name": "Add",
+      "elementwise": true,
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "sum",
+          "type": "polymorphic"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "y",
+          "type": "polymorphic"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "x",
+          "type": "polymorphic"
+        }
+      ],
+      "python_code": {
+        "sum": "in_1 + in_2"
       },
       "inline": true,
       "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/less-or-equal.html",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/add.html",
       "note": "Input slots run Bottom->Top, so the upper input `x` takes the higher index."
+    },
+    "1051": {
+      "name": "Subtract",
+      "elementwise": true,
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "difference",
+          "type": "numeric"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "y",
+          "type": "numeric"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "x",
+          "type": "numeric"
+        }
+      ],
+      "python_code": {
+        "difference": "in_2 - in_1"
+      },
+      "inline": true,
+      "verified": true,
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/subtract.html",
+      "note": "Input slots run Bottom->Top, so the upper input `x` takes the higher index."
+    },
+    "1052": {
+      "name": "Multiply",
+      "elementwise": true,
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "product",
+          "type": "polymorphic"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "y",
+          "type": "polymorphic"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "x",
+          "type": "polymorphic"
+        }
+      ],
+      "python_code": {
+        "product": "in_1 * in_2"
+      },
+      "inline": true,
+      "verified": true,
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/multiply.html",
+      "note": "Input slots run Bottom->Top, so the upper input `x` takes the higher index."
+    },
+    "1053": {
+      "name": "Divide",
+      "elementwise": true,
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "quotient",
+          "type": "polymorphic"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "y",
+          "type": "polymorphic"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "x",
+          "type": "polymorphic"
+        }
+      ],
+      "python_code": {
+        "quotient": "in_2 / in_1"
+      },
+      "inline": true,
+      "verified": true,
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/divide.html",
+      "note": "Divide -- polymorphic; per NI docs int/int -> Float64 (Python `/` matches). Input slots run Bottom->Top, so the upper input `x` takes the higher index."
     },
     "1054": {
       "name": "Absolute Value",
@@ -125,6 +304,143 @@
       "inline": true,
       "verified": true,
       "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/absolute-value.html"
+    },
+    "1055": {
+      "name": "Round To Nearest",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "nearest integer value",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "number",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1056": {
+      "name": "Quotient & Remainder",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "floor(x/y)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "x-y*floor(x/y)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "y",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025",
+      "note": "corrected from VI-Scripting nodes export (#59); codegen dropped pending re-derivation"
+    },
+    "1057": {
+      "name": "Increment",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "x+1",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": true,
+      "source": "vi-scripting-nodes-lv2025",
+      "note": "corrected from VI-Scripting nodes export (#59); python_code restored (in_1 + 1) once the terminal geometry was confirmed -- x is the sole input, no operand-order ambiguity.",
+      "python_code": {
+        "incremented": "in_1 + 1"
+      },
+      "elementwise": true
+    },
+    "1058": {
+      "name": "Decrement",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "x-1",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": true,
+      "source": "vi-scripting-nodes-lv2025",
+      "note": "corrected from VI-Scripting nodes export (#59); python_code restored (in_1 - 1) once the terminal geometry was confirmed -- x is the sole input, no operand-order ambiguity.",
+      "python_code": {
+        "decremented": "in_1 - 1"
+      },
+      "elementwise": true
+    },
+    "1059": {
+      "name": "Reciprocal",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "1/x",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1060": {
+      "name": "Square Root",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "sqrt(x)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
     },
     "1061": {
       "name": "And",
@@ -228,36 +544,1242 @@
       "verified": true,
       "note": "Polymorphic over Boolean and integers (bitwise); python_code=boolean, python_code_int=bitwise. Input slots run Bottom->Top, so the upper input `x` takes the higher index."
     },
-    "1051": {
-      "name": "Subtract",
+    "1064": {
+      "name": "Not",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "not_x",
+          "type": "Boolean"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "Boolean"
+        }
+      ],
+      "python_code": {
+        "not_x": "not in_1"
+      },
+      "inline": true,
+      "verified": true,
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/not.html"
+    },
+    "1069": {
+      "name": "Negate",
       "elementwise": true,
       "terminals": [
         {
           "index": 0,
           "direction": "out",
-          "name": "difference",
-          "type": "numeric"
+          "name": "neg_x",
+          "type": "polymorphic"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "polymorphic"
+        }
+      ],
+      "python_code": {
+        "neg_x": "-in_1"
+      },
+      "inline": true,
+      "verified": true,
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/negate.html"
+    },
+    "1070": {
+      "name": "Random Number (0-1)",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "number",
+          "type": "NumFloat64"
+        }
+      ],
+      "python_code": {
+        "number": "random.random()"
+      },
+      "_import": "import random",
+      "verified": true,
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/random-number-0-1.html"
+    },
+    "1071": {
+      "name": "Not And",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": ".not. (x .and. y)?",
+          "type": "Boolean"
         },
         {
           "index": 1,
           "direction": "in",
           "name": "y",
-          "type": "numeric"
+          "type": "Boolean"
         },
         {
           "index": 2,
+          "direction": "in",
+          "name": "x",
+          "type": "Boolean"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1072": {
+      "name": "Not Or",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/not-or.html",
+      "terminals": [
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "y",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "x",
+          "type": "Boolean"
+        },
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "nor",
+          "type": "Boolean"
+        }
+      ],
+      "python_code": {
+        "nor": "not (in_1 or in_2)"
+      },
+      "inline": true,
+      "verified": true,
+      "note": "Not Or (NOR) -- deduced from a Valid Path idiom: NOT(empty OR not-a-path); only NOR fits that truth table (And/Or/Xor/Not already claimed at 1061-1064). Commutative. Input slots run Bottom->Top, so the upper input `x` takes the higher index."
+    },
+    "1073": {
+      "name": "Not Exclusive Or",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": ".not. (x .xor. y)?",
+          "type": "Boolean"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "y",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "x",
+          "type": "Boolean"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1074": {
+      "name": "Scale By Power Of 2",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/scale-by-power-of-2.html",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "x*2^n",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "n",
+          "type": "NumInt16"
+        }
+      ],
+      "python_code": {
+        "scaled": "in_1 * (2.0 ** in_2)"
+      },
+      "verified": true,
+      "note": "operand order corrected from nodes.json terminal geometry (#59); confirmed against pylabview terminal_info in corpus -- old indices had x/y swapped, inverting the result."
+    },
+    "1075": {
+      "name": "Round Toward -Infinity",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/round-toward-infinity.html",
+      "terminals": [
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "polymorphic"
+        },
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "floor_x",
+          "type": "polymorphic"
+        }
+      ],
+      "python_code": {
+        "floor_x": "__import__('math').floor(in_1)"
+      },
+      "inline": true,
+      "verified": true,
+      "note": "Round Toward -Infinity (floor) -- forced in 'MasterAquisitionFile_2P' (a scaled index must floor); distinct from 1076 (+Inf), co-occurring in 'GenerateStimulusOutputs_FP'. NB NI slug misleads: unsuffixed round-toward-infinity.html is -Inf."
+    },
+    "1076": {
+      "name": "Round Toward +Infinity",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "ceiling",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "python_code": {
+        "ceiling": "math.ceil(in_1)"
+      },
+      "inline": true,
+      "verified": true,
+      "guess_reason": "Unary DBL->DBL. Consumer dataflow pins the mode: String Length (1502) -> /3 (Divide 1053) -> 1076 -> For Loop N count, i.e. ceil(len/3) = number of 3-digit blocks (a 4-digit number needs 2 blocks; only rounding UP is correct). NI docs (labview-api-ref/functions/round-toward-infinity-2): Round Toward +Infinity 'rounds to the next highest integer... equivalent of the ceiling function'."
+    },
+    "1077": {
+      "name": "Path To String",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "string",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "path",
+          "type": "Path"
+        }
+      ],
+      "python_code": {
+        "string": "str(in_1)"
+      },
+      "inline": true,
+      "verified": true,
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/path-to-string.html"
+    },
+    "1078": {
+      "name": "String To Path",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "path",
+          "type": "Path"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "string",
+          "type": "String"
+        }
+      ],
+      "python_code": {
+        "path": "Path(in_1)"
+      },
+      "inline": true,
+      "verified": true,
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/string-to-path.html"
+    },
+    "1079": {
+      "name": "Cast Unit Bases",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "unit (none)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1080": {
+      "name": "Implies",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "x .implies. y?",
+          "type": "Boolean"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "y",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "x",
+          "type": "Boolean"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1081": {
+      "name": "Logical Shift",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/logical-shift.html",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "x << y",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "y",
+          "type": "NumInt16"
+        }
+      ],
+      "python_code": {
+        "shifted": "(in_1 << in_2) if in_2 >= 0 else (in_1 >> -in_2)"
+      },
+      "inline": true,
+      "verified": true,
+      "note": "operand order corrected from nodes.json terminal geometry (#59); confirmed against pylabview terminal_info in corpus -- old indices had x/y swapped, inverting the result."
+    },
+    "1082": {
+      "name": "Rotate",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "x rotated left by y",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "y",
+          "type": "NumInt16"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025",
+      "note": "corrected from VI-Scripting nodes export (#59); codegen dropped pending re-derivation"
+    },
+    "1083": {
+      "name": "First Call?",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/first-call.html",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "first_call",
+          "type": "Boolean"
+        }
+      ],
+      "python_code": {
+        "_body": "raise RuntimeError('First Call? (1083) should be dispatched to codegen/nodes/first_call.py by primResID -- this stub should be unreachable')"
+      },
+      "inline": true,
+      "verified": true,
+      "note": "First Call? -- 0 inputs, 1 Boolean out; returns TRUE only on the first execution after the VI runs, FALSE thereafter (stateful, not a constant); matches NI Synchronization doc."
+    },
+    "1084": {
+      "name": "DataSocket Open",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "connection id",
+          "type": "Refnum",
+          "refnum_type": "data_socket"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "ms timeout (10000)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "mode",
+          "type": "Enum16"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "URL",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1085": {
+      "name": "DataSocket Close",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "timed out",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "ms timeout (0)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "connection id",
+          "type": "Refnum",
+          "refnum_type": "data_socket"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1086": {
+      "name": "DataSocket Read",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "timed out",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "data",
+          "type": "LVVariant"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "connection out",
+          "type": "String"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "timestamp",
+          "type": "Timestamp"
+        },
+        {
+          "index": 5,
+          "direction": "out",
+          "name": "quality",
+          "type": "NumUInt64"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "wait for updated value (T)",
+          "type": "Boolean"
+        },
+        {
+          "index": 7,
+          "direction": "out",
+          "name": "status",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 9,
+          "direction": "in",
+          "name": "ms timeout (10000)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 10,
+          "direction": "in",
+          "name": "type (Variant)",
+          "type": "LVVariant"
+        },
+        {
+          "index": 11,
+          "direction": "in",
+          "name": "connection in",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1087": {
+      "name": "DataSocket Write",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "timed out",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "connection out",
+          "type": "String"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "ms timeout (0)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "data",
+          "type": "Cluster"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "connection in",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1088": {
+      "name": "Resource Index",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "Index",
+          "type": "NumInt32"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "Resource",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1102": {
+      "name": "Equal?",
+      "elementwise": true,
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "equal",
+          "type": "polymorphic"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "y",
+          "type": "polymorphic",
+          "default_value": "0"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "x",
+          "type": "polymorphic",
+          "default_value": "0"
+        }
+      ],
+      "python_code": {
+        "equal": "in_1 == in_2"
+      },
+      "inline": true,
+      "verified": true,
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/equal.html",
+      "note": "Input slots run Bottom->Top, so the upper input `x` takes the higher index."
+    },
+    "1103": {
+      "name": "Greater Or Equal?",
+      "elementwise": true,
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "greater_or_equal",
+          "type": "polymorphic"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "y",
+          "type": "polymorphic",
+          "default_value": "0"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "x",
+          "type": "polymorphic",
+          "default_value": "0"
+        }
+      ],
+      "python_code": {
+        "greater_or_equal": "in_2 >= in_1"
+      },
+      "inline": true,
+      "verified": true,
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/greater-or-equal.html",
+      "note": "Input slots run Bottom->Top, so the upper input `x` takes the higher index."
+    },
+    "1104": {
+      "name": "Less Or Equal?",
+      "elementwise": true,
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "x_less_or_equal_y",
+          "type": "boolean"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "y",
+          "type": "polymorphic",
+          "default_value": "0"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "x",
+          "type": "polymorphic",
+          "default_value": "0"
+        }
+      ],
+      "python_code": {
+        "x_less_or_equal_y": "in_2 <= in_1"
+      },
+      "inline": true,
+      "verified": true,
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/less-or-equal.html",
+      "note": "Input slots run Bottom->Top, so the upper input `x` takes the higher index."
+    },
+    "1105": {
+      "name": "Not Equal?",
+      "elementwise": true,
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "result",
+          "type": "Boolean"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "y",
+          "type": "polymorphic",
+          "default_value": "0"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "x",
+          "type": "polymorphic",
+          "default_value": "0"
+        }
+      ],
+      "python_code": {
+        "result": "in_1 != in_2"
+      },
+      "inline": true,
+      "verified": true,
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/not-equal.html",
+      "note": "Input slots run Bottom->Top, so the upper input `x` takes the higher index."
+    },
+    "1108": {
+      "name": "Max & Min",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "min(x,y)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "max(x,y)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "y",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025",
+      "note": "corrected from VI-Scripting nodes export (#59); codegen dropped pending re-derivation"
+    },
+    "1110": {
+      "name": "Greater?",
+      "elementwise": true,
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "result",
+          "type": "Boolean"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "y",
+          "type": "polymorphic",
+          "default_value": "0"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "x",
+          "type": "polymorphic",
+          "default_value": "0"
+        }
+      ],
+      "python_code": {
+        "result": "in_2 > in_1"
+      },
+      "inline": true,
+      "verified": true,
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/greater.html",
+      "note": "Input slots run Bottom->Top, so the upper input `x` takes the higher index."
+    },
+    "1111": {
+      "name": "Less?",
+      "elementwise": true,
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "x_less_than_y",
+          "type": "Boolean"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "y",
+          "type": "polymorphic"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "x",
+          "type": "polymorphic"
+        }
+      ],
+      "python_code": {
+        "x_less_than_y": "in_2 < in_1"
+      },
+      "inline": true,
+      "verified": true,
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/less.html",
+      "note": "Input slots run Bottom->Top, so the upper input `x` takes the higher index."
+    },
+    "1112": {
+      "name": "Empty String/Path?",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/empty-string-path.html",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "is_empty",
+          "type": "Boolean"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "string_or_path",
+          "type": "polymorphic"
+        }
+      ],
+      "python_code": {
+        "is_empty": "len(in_1) == 0"
+      },
+      "inline": true,
+      "verified": true,
+      "guess_reason": "Was mislabeled 'Not A Number/Path/Refnum?' (which takes NUMBERS). Observed polymorphic over String (Number to Proper Engl Text) AND Path (Get Class Inheritance from Class Path.vi), both -> Boolean. NI docs (labview-api-ref/functions/empty-string-path): Empty String/Path? 'returns TRUE if string/path is an empty string or an empty path'. The String/Path->Bool polymorphism uniquely pins it."
+    },
+    "1113": {
+      "name": "Equal To 0?",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "x_equals_zero",
+          "type": "Boolean"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "polymorphic"
+        }
+      ],
+      "python_code": {
+        "x_equals_zero": "in_1 == 0"
+      },
+      "inline": true,
+      "verified": true,
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/equal-to-0.html",
+      "note": "Equal To 0? (=0), the dominant to-0 form (NI equal-to-0 doc). On non-negative feeders ==0 and <=0 are behaviorally identical, so 1113(=0) vs 1115(<=0) is not corpus-separable; pinned by doc slug. See 1115."
+    },
+    "1114": {
+      "name": "Greater Or Equal To 0?",
+      "elementwise": true,
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "result",
+          "type": "Boolean"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "polymorphic"
+        }
+      ],
+      "python_code": {
+        "result": "in_1 >= 0"
+      },
+      "inline": true,
+      "verified": true,
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/greater-or-equal-to-0.html",
+      "note": "Greater Or Equal To 0? (>=0) -- unary comparison-to-0, complement of 1118 (<0); pinned >=0 by search-result-offset feeders (Search 1D Array, Match Pattern offset-past-match) across the corpus. Was mislabeled 'Greater Or Equal?'."
+    },
+    "1115": {
+      "name": "Less Or Equal To 0?",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "result",
+          "type": "Boolean"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "polymorphic"
+        }
+      ],
+      "python_code": {
+        "result": "in_1 <= 0"
+      },
+      "inline": true,
+      "verified": false,
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/less-or-equal-to-0.html",
+      "note": "Less Or Equal To 0? (<=0) (NI less-or-equal-to-0 doc) -- best-supported <=0 in 'test Queue Size is Zero' (checks a queue count >=0). UNVERIFIED: <=0 vs ==0 not corpus-separable. Was a duplicate 'Equal To 0?'."
+    },
+    "1116": {
+      "name": "Not Equal To 0?",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "x != 0?",
+          "type": "Boolean"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025",
+      "note": "corrected from VI-Scripting nodes export (#59); codegen dropped pending re-derivation"
+    },
+    "1117": {
+      "name": "Greater Than 0?",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "result",
+          "type": "Boolean"
+        },
+        {
+          "index": 1,
           "direction": "in",
           "name": "x",
           "type": "numeric"
         }
       ],
       "python_code": {
-        "difference": "in_2 - in_1"
+        "result": "in_1 > 0"
+      },
+      "inline": true,
+      "verified": false,
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/greater-than-0.html",
+      "note": "Greater Than 0? (>0) (NI greater-than-0 doc) -- fed by Array Size -> Select ('non-empty') and Match Pattern offset. UNVERIFIED: >0 vs !=0 not corpus-separable. Was mislabeled 'Not Equal To 0?'."
+    },
+    "1118": {
+      "name": "Less Than 0?",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/less-than-0.html",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "result",
+          "type": "Boolean"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "numeric"
+        }
+      ],
+      "python_code": {
+        "result": "in_1 < 0"
+      },
+      "inline": true,
+      "verified": true
+    },
+    "1119": {
+      "name": "Decimal Digit?",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "digit?",
+          "type": "Boolean"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "char",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1120": {
+      "name": "Sort 1D Array",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "sorted_array",
+          "type": "Array"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "array",
+          "type": "Array"
+        }
+      ],
+      "python_code": {
+        "sorted_array": "sorted(in_1)"
       },
       "inline": true,
       "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/subtract.html",
-      "note": "Input slots run Bottom->Top, so the upper input `x` takes the higher index."
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/sort-1d-array.html",
+      "note": "Sort 1D Array (sorts ascending) -- in OpenG Sort wrappers, the separate 1900 (Reverse 1D Array) flips to descending (case frame 1)."
+    },
+    "1123": {
+      "name": "Hex Digit?",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "hex?",
+          "type": "Boolean"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "char",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1124": {
+      "name": "Printable?",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "printable ASCII?",
+          "type": "Boolean"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "char",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1125": {
+      "name": "White Space?",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "space, h/v tab, cr, lf, ff?",
+          "type": "Boolean"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "char",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1126": {
+      "name": "Lexical Class",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "class number",
+          "type": "NumInt16"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "char",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1127": {
+      "name": "In Range and Coerce",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/in-range-and-coerce.html",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "In Range?",
+          "type": "Boolean"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "coerced(x)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "lower limit",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "upper limit",
+          "type": "NumFloat64"
+        }
+      ],
+      "python_code": {
+        "in_range": "in_2 <= in_3 <= in_4",
+        "coerced": "max(in_2, min(in_3, in_4))"
+      },
+      "verified": true,
+      "note": "operand order corrected from nodes.json terminal geometry (#59); confirmed against pylabview terminal_info in corpus -- old indices had x/y swapped, inverting the result."
+    },
+    "1128": {
+      "name": "Not A Number/Path/Refnum?",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "not_a_refnum",
+          "type": "Boolean"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "value",
+          "type": "polymorphic"
+        }
+      ],
+      "python_code": {
+        "not_a_refnum": "not bool(in_1)"
+      },
+      "inline": true,
+      "verified": true,
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/not-a-number-path-refnum.html",
+      "note": "Polymorphic variant of 1112 for Refnum type."
+    },
+    "1129": {
+      "name": "Octal Digit?",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "octal?",
+          "type": "Boolean"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "char",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1140": {
+      "name": "To Byte Integer",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/to-byte-integer.html",
+      "guess_reason": "Conversion to signed 8-bit integer: output is always NumInt8 (or Array[NumInt8]) regardless of input numeric type, verified across corpus (NumInt8/NumInt64/NumInt32/Array[NumFloat64] inputs). NI docs: rounds float to nearest (ties to even) and saturates to [-128, 127]. Scalar template; array inputs would need element-wise handling.",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "byte_integer",
+          "type": "NumInt8"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "number",
+          "type": "numeric"
+        }
+      ],
+      "python_code": "max(-128, min(127, int(round(in_1))))",
+      "inline": true,
+      "verified": true
     },
     "1141": {
       "name": "To Word Integer",
@@ -304,223 +1826,28 @@
       "inline": true,
       "verified": true
     },
-    "1540": {
-      "name": "Array To Spreadsheet String",
+    "1143": {
+      "name": "To Unsigned Byte Integer",
       "terminals": [
         {
           "index": 0,
           "direction": "out",
-          "name": "spreadsheet_string",
-          "type": "String"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "delimiter",
-          "type": "String",
-          "default_value": "'\\t'"
-        },
-        {
-          "index": 2,
-          "direction": "in",
-          "name": "array",
-          "type": "Array"
-        },
-        {
-          "index": 3,
-          "direction": "in",
-          "name": "format_string",
-          "type": "String"
-        }
-      ],
-      "python_code": {
-        "spreadsheet_string": "(in_1 or '\\t').join(in_3 % x for x in in_2)"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/array-to-spreadsheet-string.html",
-      "note": "parmIndex from OBSERVED caller dataflow (OpenG '1D Array to String' control wiring: in_1<-delimiter, in_2<-array, in_3<-format '%s'): in_1=delimiter (default Tab), in_2=array, in_3=format string, out=spreadsheet string. python_code covers the common 1-D case; full N-D (Tab columns / EOL rows / page headers) would need an lvkit runtime helper, as with 1539."
-    },
-    "1050": {
-      "name": "Add",
-      "elementwise": true,
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "sum",
-          "type": "polymorphic"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "y",
-          "type": "polymorphic"
-        },
-        {
-          "index": 2,
-          "direction": "in",
-          "name": "x",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "sum": "in_1 + in_2"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/add.html",
-      "note": "Input slots run Bottom->Top, so the upper input `x` takes the higher index."
-    },
-    "1052": {
-      "name": "Multiply",
-      "elementwise": true,
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "product",
-          "type": "polymorphic"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "y",
-          "type": "polymorphic"
-        },
-        {
-          "index": 2,
-          "direction": "in",
-          "name": "x",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "product": "in_1 * in_2"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/multiply.html",
-      "note": "Input slots run Bottom->Top, so the upper input `x` takes the higher index."
-    },
-    "1057": {
-      "name": "Absolute Value",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/absolute-value.html",
-      "guess_reason": "Was mislabeled 'Array Size'. It is unary scalar X -> scalar X (same type), not an array op, and sits in the numeric cluster (1050-1064), not the array-size range. Confirmed by usage: Subtract -> 1057 -> Increment -> ROI coordinate computes |x1-x0|+1 (a pixel span). This is the integer-typed Absolute Value; 1054 is the same op for extended float (verified by the |a-b|>tolerance compare in failUnlessEqual/passIfEqual), and the two never co-occur. Array inputs would need element-wise handling.",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "absolute_value",
-          "type": "polymorphic"
+          "name": "result",
+          "type": "NumUInt8"
         },
         {
           "index": 1,
           "direction": "in",
           "name": "x",
-          "type": "polymorphic"
+          "type": "numeric"
         }
       ],
       "python_code": {
-        "absolute_value": "abs(in_1)"
-      },
-      "inline": true,
-      "verified": true
-    },
-    "1056": {
-      "name": "Split 1D Array",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "first subarray",
-          "type": "polymorphic"
-        },
-        {
-          "index": 1,
-          "direction": "out",
-          "name": "second subarray",
-          "type": "polymorphic"
-        },
-        {
-          "index": 2,
-          "direction": "in",
-          "name": "index",
-          "type": "polymorphic",
-          "default_value": "0"
-        },
-        {
-          "index": 3,
-          "direction": "in",
-          "name": "array",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "first_subarray": "in_3[:int(in_2)]",
-        "second_subarray": "in_3[int(in_2):]"
+        "result": "int(in_1) & 0xFF"
       },
       "inline": true,
       "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/split-1d-array.html",
-      "note": "Connector pane: idx=2 is index (numeric), idx=3 is array. Confirmed from pco.camera_FloatingMean_Example.vi instances."
-    },
-    "1103": {
-      "name": "Greater Or Equal?",
-      "elementwise": true,
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "greater_or_equal",
-          "type": "polymorphic"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "y",
-          "type": "polymorphic",
-          "default_value": "0"
-        },
-        {
-          "index": 2,
-          "direction": "in",
-          "name": "x",
-          "type": "polymorphic",
-          "default_value": "0"
-        }
-      ],
-      "python_code": {
-        "greater_or_equal": "in_2 >= in_1"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/greater-or-equal.html",
-      "note": "Input slots run Bottom->Top, so the upper input `x` takes the higher index."
-    },
-    "1112": {
-      "name": "Empty String/Path?",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/empty-string-path.html",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "is_empty",
-          "type": "Boolean"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "string_or_path",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "is_empty": "len(in_1) == 0"
-      },
-      "inline": true,
-      "verified": true,
-      "guess_reason": "Was mislabeled 'Not A Number/Path/Refnum?' (which takes NUMBERS). Observed polymorphic over String (Number to Proper Engl Text) AND Path (Get Class Inheritance from Class Path.vi), both -> Boolean. NI docs (labview-api-ref/functions/empty-string-path): Empty String/Path? 'returns TRUE if string/path is an empty string or an empty path'. The String/Path->Bool polymorphism uniquely pins it."
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/to-unsigned-byte-integer.html"
     },
     "1144": {
       "name": "To Unsigned Word Integer",
@@ -546,14 +1873,211 @@
       "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/to-unsigned-word-integer.html"
     },
     "1145": {
-      "name": "Coerce To Type",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/coerce-to-type.html",
+      "name": "To Unsigned Long Integer",
       "terminals": [
         {
           "index": 0,
           "direction": "out",
-          "name": "coerced output",
+          "name": "unsigned 32bit integer",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "number",
+          "type": "NumUInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025",
+      "note": "corrected from VI-Scripting nodes export (#59); codegen dropped pending re-derivation"
+    },
+    "1146": {
+      "name": "To Single Precision Float",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/to-single-precision-float.html",
+      "terminals": [
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "number",
           "type": "polymorphic"
+        },
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "result",
+          "type": "polymorphic"
+        }
+      ],
+      "python_code": {
+        "result": "float(in_1)"
+      },
+      "verified": true
+    },
+    "1147": {
+      "name": "To Double Precision Float",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/to-double-precision-float.html",
+      "terminals": [
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "number",
+          "type": "polymorphic"
+        },
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "result",
+          "type": "polymorphic"
+        }
+      ],
+      "python_code": {
+        "result": "float(in_1)"
+      },
+      "verified": true
+    },
+    "1149": {
+      "name": "To Extended Precision Float",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/to-extended-precision-float.html",
+      "terminals": [
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "number",
+          "type": "polymorphic"
+        },
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "result",
+          "type": "polymorphic"
+        }
+      ],
+      "python_code": {
+        "result": "float(in_1)"
+      },
+      "verified": true
+    },
+    "1150": {
+      "name": "Mantissa & Exponent",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "number",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "mantissa",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "exponent",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1151": {
+      "name": "To Single Precision Complex",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/to-single-precision-complex.html",
+      "terminals": [
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "number",
+          "type": "polymorphic"
+        },
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "result",
+          "type": "polymorphic"
+        }
+      ],
+      "python_code": {
+        "result": "complex(in_1)"
+      },
+      "verified": true
+    },
+    "1152": {
+      "name": "To Double Precision Complex",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/to-double-precision-complex.html",
+      "terminals": [
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "number",
+          "type": "polymorphic"
+        },
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "result",
+          "type": "polymorphic"
+        }
+      ],
+      "python_code": {
+        "result": "complex(in_1)"
+      },
+      "verified": true
+    },
+    "1154": {
+      "name": "To Extended Precision Complex",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/to-extended-precision-complex.html",
+      "terminals": [
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "number",
+          "type": "polymorphic"
+        },
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "result",
+          "type": "polymorphic"
+        }
+      ],
+      "python_code": {
+        "result": "complex(in_1)"
+      },
+      "verified": true
+    },
+    "1155": {
+      "name": "To Quad Integer",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "64bit integer",
+          "type": "NumInt64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "number",
+          "type": "NumInt64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1156": {
+      "name": "To Unsigned Quad Integer",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/to-unsigned-quad-integer.html",
+      "verified": true,
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "result",
+          "type": "NumUInt64"
         },
         {
           "index": 1,
@@ -563,11 +2087,3046 @@
         }
       ],
       "python_code": {
-        "coerced_output": "in_1"
+        "result": "int(in_1) & 0xFFFFFFFFFFFFFFFF"
+      },
+      "inline": true,
+      "note": "To Unsigned Quad Integer (NI doc) -- completes the To-<T> conversion family (1140-1144), idx0=out/idx1=in. Terminals from 'pco.camera_FloatingMean_Example_IMAQ.vi', 'testNumericU64.vi' (JKI-EasyXML)."
+    },
+    "1160": {
+      "name": "Flatten To String",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "anything",
+          "type": "Cluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "type string",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "data string",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1161": {
+      "name": "Unflatten From String",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "value",
+          "type": "Cluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "err",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "type",
+          "type": "Cluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "binary string",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1162": {
+      "name": "Swap Bytes",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/swap-bytes.html",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "swapped",
+          "type": "polymorphic"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "data",
+          "type": "polymorphic"
+        }
+      ],
+      "python_code": {
+        "swapped": "[((v & 0x00FF00FF) << 8) | ((v >> 8) & 0x00FF00FF) for v in in_1]"
+      },
+      "note": "Swap Bytes -- endianness op; chained 1162->1163 gives a full 32-bit byte-reversal (MD5 little-endian words). Bytes=1162/Words=1163 follows NI palette order. Polymorphic: Array[U32] + cluster.",
+      "verified": false
+    },
+    "1163": {
+      "name": "Swap Words",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/swap-words.html",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "swapped",
+          "type": "polymorphic"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "data",
+          "type": "polymorphic"
+        }
+      ],
+      "python_code": {
+        "swapped": "[((v & 0xFFFF) << 16) | ((v >> 16) & 0xFFFF) for v in in_1]"
+      },
+      "note": "Swap Words -- endianness op; chained 1162->1163 gives a full 32-bit byte-reversal (MD5 little-endian words). Bytes=1162/Words=1163 follows NI palette order. Polymorphic: Array[U32] + cluster.",
+      "verified": false
+    },
+    "1164": {
+      "name": "Flatten To String",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "type string",
+          "type": "Array",
+          "hidden": true
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "data string",
+          "type": "String"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "byte order (0:big-endian, network order)",
+          "type": "Enum16"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "prepend array or string size? (T)",
+          "type": "Boolean"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "anything",
+          "type": "Cluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025",
+      "note": "corrected from VI-Scripting nodes export (#59); codegen dropped pending re-derivation"
+    },
+    "1165": {
+      "name": "Unflatten From String",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "value",
+          "type": "Cluster"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "rest of the binary string",
+          "type": "String"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "type",
+          "type": "Cluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "byte order (0:big-endian, network order)",
+          "type": "Enum16"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "data includes array or string size? (T)",
+          "type": "Boolean"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "binary string",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025",
+      "note": "corrected from VI-Scripting nodes export (#59); codegen dropped pending re-derivation"
+    },
+    "1166": {
+      "name": "Type Cast",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloatExt"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "type",
+          "type": "String"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "*(type *) &x",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025",
+      "note": "corrected from VI-Scripting nodes export (#59); codegen dropped pending re-derivation"
+    },
+    "1167": {
+      "name": "Boolean To (0,1)",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "zero_or_one",
+          "type": "NumInt16"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "boolean",
+          "type": "polymorphic"
+        }
+      ],
+      "python_code": {
+        "zero_or_one": "int(bool(in_1))"
+      },
+      "inline": true,
+      "verified": true,
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/boolean-to-0-1.html",
+      "note": "Polymorphic: Boolean -> I16 (1 or 0). Array of Boolean -> Array of I16. primIndex=69."
+    },
+    "1168": {
+      "name": "Array To Cluster",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "cluster",
+          "type": "Cluster"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "array",
+          "type": "Array"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1169": {
+      "name": "Cluster To Array",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "array",
+          "type": "Array"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "cluster",
+          "type": "Cluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1170": {
+      "name": "Split Number",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/split-number.html",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "input",
+          "type": "polymorphic"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "high",
+          "type": "polymorphic"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "low",
+          "type": "polymorphic"
+        }
+      ],
+      "python_code": {
+        "high": "in_0 >> 16",
+        "low": "in_0 & 0xFFFF"
       },
       "inline": true,
       "verified": false,
-      "note": "1in/1out type conversion. Python is dynamically typed so this is a passthrough."
+      "note": "1in/2out array\u2192array+array. Could be Split Number or type-specific split. Unconfirmed."
+    },
+    "1171": {
+      "name": "Join Numbers",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/join-numbers.html",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "(hi.lo)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "lo",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "hi",
+          "type": "NumUInt16"
+        }
+      ],
+      "python_code": {
+        "joined": "(in_2 << (in_1.bit_length() or 8)) | in_1"
+      },
+      "verified": true,
+      "note": "operand order corrected from nodes.json terminal geometry (#59); confirmed against pylabview terminal_info in corpus -- old indices had x/y swapped, inverting the result."
+    },
+    "1180": {
+      "name": "Number To Decimal String",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/number-to-decimal-string.html",
+      "terminals": [
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "width",
+          "type": "NumInt16"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "number",
+          "type": "polymorphic"
+        },
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "decimal_integer_string",
+          "type": "polymorphic"
+        }
+      ],
+      "python_code": {
+        "decimal_integer_string": "str(int(round(in_2))).rjust(in_1)"
+      },
+      "inline": true,
+      "verified": false,
+      "note": "Number To Decimal String -- pane identical to sibling 1181 (Number To Hexadecimal String), adjacent palette slot (Decimal precedes Hex); 2 inputs excludes Engineering/Fractional/Exponential. python_code not execution-verified for width/pad."
+    },
+    "1181": {
+      "name": "Number To Hexadecimal String",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/number-to-hexadecimal-string.html",
+      "terminals": [
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "width",
+          "type": "NumInt16"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "number",
+          "type": "Array"
+        },
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "hex_string",
+          "type": "Array"
+        }
+      ],
+      "python_code": {
+        "hex_string": "['%0*X' % (in_1, b) for b in in_2]"
+      },
+      "note": "polymorphic: scalar number->hex string, or array->array of hex strings; width pads digits.",
+      "verified": false
+    },
+    "1182": {
+      "name": "Number To Octal String",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "octal integer string",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "width (-)",
+          "type": "NumInt16"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "number",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1183": {
+      "name": "Number To Engineering String",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "Engineering string",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "use system decimal point (T)",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "precision (6)",
+          "type": "NumInt16"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "width (-)",
+          "type": "NumInt16"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "number",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1184": {
+      "name": "Decimal String To Number",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/decimal-string-to-number.html",
+      "verified": true,
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "number",
+          "type": "polymorphic"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "offset_past_number",
+          "type": "NumInt32"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "default",
+          "type": "polymorphic"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "offset",
+          "type": "NumInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "string",
+          "type": "String"
+        }
+      ],
+      "placeholder": true,
+      "python_code": "pass",
+      "note": "Decimal String To Number (NI doc) -- string, offset, default -> offset past number, number. Terminals from 'Results Status Update Process__core.vi', 'Get LV Mem Usage.vi'. Placeholder codegen: integer-only scan, needs float/exponent handling."
+    },
+    "1185": {
+      "name": "Hexadecimal String To Number",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "number",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "offset past number",
+          "type": "NumInt32"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "default (0uL)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "offset",
+          "type": "NumInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "string",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1186": {
+      "name": "Octal String To Number",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "number",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "offset past number",
+          "type": "NumInt32"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "default (0uL)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "offset",
+          "type": "NumInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "string",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1187": {
+      "name": "Fract/Exp String To Number",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "number",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "offset past number",
+          "type": "NumInt32"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "use system decimal point (T)",
+          "type": "Boolean"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "default (0 dbl)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "offset",
+          "type": "NumInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "string",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1188": {
+      "name": "To Upper Case",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/to-upper-case.html",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "all_upper_case_string",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "string",
+          "type": "String"
+        }
+      ],
+      "python_code": {
+        "all_upper_case_string": "in_1.upper() if isinstance(in_1, str) else [s.upper() for s in in_1]"
+      },
+      "inline": true,
+      "verified": true,
+      "guess_reason": "2-terminal unary type-preserving string op (same pane class as 1537 To Lower Case); candidates were to-upper/reverse/rotate-string. Consumer-forced: in GIF.Read.Unpack its output is Equal?-compared to literals 'GIF87A'/'GIF89A' (GIF signatures), so it must PRESERVE letters -> rules out reverse/rotate; UPPER because the compared targets are uppercase (case-insensitive header check). Also fits To Proper Case. Cleanroom: no glyph; resolved from consumer dataflow."
+    },
+    "1189": {
+      "name": "To Lower Case",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "all lower case string",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "string",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025",
+      "note": "corrected from VI-Scripting nodes export (#59); codegen dropped pending re-derivation"
+    },
+    "1200": {
+      "name": "Sine",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/sine.html",
+      "terminals": [
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "result",
+          "type": "NumFloat64"
+        }
+      ],
+      "python_code": {
+        "result": "__import__('math').sin(in_1)"
+      },
+      "verified": true
+    },
+    "1201": {
+      "name": "Cosine",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "cos(x)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1202": {
+      "name": "Tangent",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "tan(x)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1203": {
+      "name": "Secant",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "1/cos(x)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1204": {
+      "name": "Cosecant",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "1/sin(x)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1205": {
+      "name": "Cotangent",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "1/tan(x)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1206": {
+      "name": "Inverse Sine",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "arcsin(x)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1207": {
+      "name": "Inverse Cosine",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "arccos(x)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1208": {
+      "name": "Inverse Tangent",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "arctan(x)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1209": {
+      "name": "Natural Logarithm",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "ln(x)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1210": {
+      "name": "Logarithm Base 10",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "log(x)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1211": {
+      "name": "Exponential",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "exp(x)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1212": {
+      "name": "Power Of 10",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "10^x",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1213": {
+      "name": "Power Of X",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/power-of-x.html",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "x^y",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "y",
+          "type": "NumFloat64"
+        }
+      ],
+      "python_code": {
+        "x_to_the_y": "in_1 ** in_2"
+      },
+      "inline": true,
+      "verified": true,
+      "note": "operand order corrected from nodes.json terminal geometry (#59); confirmed against pylabview terminal_info in corpus -- old indices had x/y swapped, inverting the result."
+    },
+    "1214": {
+      "name": "Hyperbolic Sine",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "sinh(x)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1215": {
+      "name": "Hyperbolic Cosine",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "cosh(x)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1216": {
+      "name": "Hyperbolic Tangent",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "tanh(x)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1217": {
+      "name": "Inverse Hyperbolic Sine",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "argsinh(x)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1218": {
+      "name": "Inverse Hyperbolic Cosine",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "argcosh(x)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1219": {
+      "name": "Inverse Hyperbolic Tangent",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "argtanh(x)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1220": {
+      "name": "Sine & Cosine",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "sin(x)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "cos(x)",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1221": {
+      "name": "Natural Logarithm (Arg +1)",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "ln(x+1)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1222": {
+      "name": "Exponential (Arg) -1",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "exp(x) -1",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1223": {
+      "name": "Power Of 2",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/power-of-2.html",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "two_pow_x",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "polymorphic"
+        }
+      ],
+      "python_code": {
+        "two_pow_x": "2.0 ** in_1"
+      },
+      "verified": false
+    },
+    "1224": {
+      "name": "Logarithm Base X",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "logx(y)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "y",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1225": {
+      "name": "Logarithm Base 2",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/logarithm-base-2.html",
+      "terminals": [
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumInt32"
+        },
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "result",
+          "type": "NumFloat64"
+        }
+      ],
+      "python_code": {
+        "result": "__import__('math').log2(in_1)"
+      },
+      "note": "context-inferred: GIF min-code-size = ceil(log2(colors)); feeds a round op.",
+      "verified": false
+    },
+    "1227": {
+      "name": "Sinc",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "sin(x)/x",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1228": {
+      "name": "Inverse Tangent (2 Input)",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "atan2(y,x)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "y",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1300": {
+      "name": "Tick Count (ms)",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "millisecond_timer_value",
+          "type": "NumUInt32"
+        }
+      ],
+      "python_code": {
+        "millisecond_timer_value": "int(time.time() * 1000)"
+      },
+      "_import": "import time",
+      "verified": true,
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/tick-count-ms.html"
+    },
+    "1302": {
+      "name": "Wait (ms)",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "millisecond_timer_value",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "milliseconds_to_wait",
+          "type": "NumUInt32"
+        }
+      ],
+      "python_code": {
+        "_import": "import time",
+        "_body": "time.sleep(in_1 / 1000)",
+        "millisecond_timer_value": "0"
+      },
+      "imports": [
+        "import time"
+      ],
+      "inline": false,
+      "verified": true,
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/wait-ms.html"
+    },
+    "1303": {
+      "name": "Get Date/Time In Seconds",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "current_time",
+          "type": "MeasureData"
+        }
+      ],
+      "python_code": {
+        "_import": "import time",
+        "current_time": "time.time()"
+      },
+      "imports": [
+        "import time"
+      ],
+      "inline": true,
+      "verified": true,
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/get-date-time-in-seconds.html"
+    },
+    "1308": {
+      "name": "Date/Time To Seconds",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "time stamp",
+          "type": "Timestamp"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "is UTC (F)",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "date time rec",
+          "type": "Cluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1309": {
+      "name": "Seconds To Date/Time",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "date time rec",
+          "type": "Cluster"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "to UTC (F)",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "time stamp (now)",
+          "type": "Timestamp"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1327": {
+      "name": "Wait Until Next ms Multiple",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/wait-until-next-ms-multiple.html",
+      "terminals": [
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "ms_multiple",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "millisecond_timer_value",
+          "type": "NumUInt32"
+        }
+      ],
+      "python_code": {
+        "millisecond_timer_value": "__import__('time').monotonic_ns() // 1_000_000"
+      },
+      "note": "sleeps until the ms timer is a multiple of ms_multiple; returns the timer value.",
+      "verified": false
+    },
+    "1328": {
+      "name": "Wait For Front Panel Activity",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "millisecond timer value",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "timeout ms (-1 never timeout)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "front panel (this VI's panel)",
+          "type": "Refnum",
+          "refnum_type": "vi_server",
+          "class_id": 2,
+          "class_name": "VI"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "do not wait! (False)",
+          "type": "Boolean"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1329": {
+      "name": "Generate Front Panel Activity",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "front panel (this VI's panel)",
+          "type": "Refnum",
+          "refnum_type": "vi_server",
+          "class_id": 2,
+          "class_name": "VI"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1340": {
+      "name": "One Button Dialog",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/one-button-dialog.html",
+      "terminals": [
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "button_name",
+          "type": "String"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "message",
+          "type": "String"
+        },
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "true",
+          "type": "Boolean"
+        }
+      ],
+      "python_code": {
+        "true": "True"
+      },
+      "inline": true,
+      "verified": false,
+      "note": "One Button Dialog -- 3-terminal pane; message (idx2) wired 19/19, button name (idx1) never wired (defaults 'OK'). Two Button Dialog excluded (three strings). Side-effecting dialog; python_code does not emit it."
+    },
+    "1341": {
+      "name": "Two Button Dialog",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/two-button-dialog.html",
+      "verified": true,
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "t_button_pressed",
+          "type": "Boolean"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "t_button_name",
+          "type": "String"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "f_button_name",
+          "type": "String"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "message",
+          "type": "String"
+        }
+      ],
+      "placeholder": true,
+      "python_code": "pass",
+      "note": "Two Button Dialog (NI Two Button Dialog doc) -> T button?. Terminals from 'Graphical Test Runner - Main UI - .vi', 'Dictionary Example.vi', 'Folder Reuse Warning.vi'. Placeholder: T-vs-F is a real branch, python_code hard-codes True."
+    },
+    "1350": {
+      "name": "Stop",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "stop? (T)",
+          "type": "Boolean"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025",
+      "note": "corrected from VI-Scripting nodes export (#59); codegen dropped pending re-derivation"
+    },
+    "1352": {
+      "name": "Quit LabVIEW",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "quit? (T)",
+          "type": "Boolean"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1353": {
+      "name": "Control Help Window",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "Top Left Corner",
+          "type": "Cluster"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "Show",
+          "type": "Boolean"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1354": {
+      "name": "Get Help Window Status",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "Top Left Corner",
+          "type": "Cluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "Show",
+          "type": "Boolean"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1355": {
+      "name": "Control Online Help",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "Path to the help file",
+          "type": "Path"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "String to search for",
+          "type": "String"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "Operation",
+          "type": "Enum16"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1402": {
+      "name": "New Directory",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "dup directory path",
+          "type": "Path"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "permissions",
+          "type": "NumInt16"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "group",
+          "type": "String"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "directory path",
+          "type": "Path"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1403": {
+      "name": "Open File",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "file path",
+          "type": "Path"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "open mode (0)",
+          "type": "Enum16"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "deny mode (2)",
+          "type": "Enum16"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "datalog type",
+          "type": "NumInt32"
+        },
+        {
+          "index": 5,
+          "direction": "out",
+          "name": "refnum",
+          "type": "Refnum",
+          "refnum_type": "byte_stream"
+        },
+        {
+          "index": 6,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1404": {
+      "name": "New File",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "refnum",
+          "type": "Refnum",
+          "refnum_type": "byte_stream"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "datalog type",
+          "type": "NumInt32"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "overwrite (F)",
+          "type": "Boolean"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "permissions",
+          "type": "NumInt16"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "deny mode (2)",
+          "type": "Enum16"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "group",
+          "type": "String"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "file path",
+          "type": "Path"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1405": {
+      "name": "Close File",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "path",
+          "type": "Path"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "refnum",
+          "type": "Refnum",
+          "refnum_type": "byte_stream"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1406": {
+      "name": "Flush File",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "dup refnum",
+          "type": "Refnum",
+          "refnum_type": "byte_stream"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "refnum",
+          "type": "Refnum",
+          "refnum_type": "byte_stream"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1407": {
+      "name": "Read File",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "offset",
+          "type": "NumInt32"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "data",
+          "type": "String"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "dup refnum",
+          "type": "Refnum",
+          "refnum_type": "byte_stream"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "byte stream type",
+          "type": "NumInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "convert eol (F)",
+          "type": "Boolean"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "count",
+          "type": "NumInt32"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "line mode (F)",
+          "type": "Boolean"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 9,
+          "direction": "in",
+          "name": "pos offset (0)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 10,
+          "direction": "in",
+          "name": "pos mode (0:2)",
+          "type": "Enum16"
+        },
+        {
+          "index": 11,
+          "direction": "in",
+          "name": "refnum",
+          "type": "Refnum",
+          "refnum_type": "byte_stream"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1408": {
+      "name": "Write File",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "offset",
+          "type": "NumInt32"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "dup refnum",
+          "type": "Refnum",
+          "refnum_type": "byte_stream"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "convert eol (F)",
+          "type": "Boolean"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "data",
+          "type": "Cluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "header (F)",
+          "type": "Boolean"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "pos offset (0)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "pos mode (0:2)",
+          "type": "Enum16"
+        },
+        {
+          "index": 9,
+          "direction": "in",
+          "name": "refnum",
+          "type": "Refnum",
+          "refnum_type": "byte_stream"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1409": {
+      "name": "Seek",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "offset",
+          "type": "NumInt32"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "dup refnum",
+          "type": "Refnum",
+          "refnum_type": "byte_stream"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "pos offset (0)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "pos mode (0:2)",
+          "type": "Enum16"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "refnum",
+          "type": "Refnum",
+          "refnum_type": "byte_stream"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1410": {
+      "name": "EOF",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "offset",
+          "type": "NumInt32"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "dup refnum",
+          "type": "Refnum",
+          "refnum_type": "byte_stream"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "pos offset (0)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "pos mode (0:1)",
+          "type": "Enum16"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "refnum",
+          "type": "Refnum",
+          "refnum_type": "byte_stream"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1411": {
+      "name": "Lock Range",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "dup refnum",
+          "type": "Refnum",
+          "refnum_type": "byte_stream"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "count",
+          "type": "NumInt32"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "set lock (F)",
+          "type": "Boolean"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "pos offset (0)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "pos mode (0:2)",
+          "type": "Enum16"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "refnum",
+          "type": "Refnum",
+          "refnum_type": "byte_stream"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1412": {
+      "name": "Access Rights",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "permissions",
+          "type": "NumInt16"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "group",
+          "type": "String"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "owner",
+          "type": "String"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "dup path",
+          "type": "Path"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "path",
+          "type": "Path"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "new permissions",
+          "type": "NumInt16"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "new group",
+          "type": "String"
+        },
+        {
+          "index": 9,
+          "direction": "in",
+          "name": "new owner",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1413": {
+      "name": "File/Directory Info",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "last mod",
+          "type": "Timestamp"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "size",
+          "type": "NumInt32"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "dup path",
+          "type": "Path"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "directory",
+          "type": "Boolean"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "path",
+          "type": "Path"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1414": {
+      "name": "Volume Info",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "free",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "used",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "size",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "volume path",
+          "type": "Path"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "path",
+          "type": "Path"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1415": {
+      "name": "Move",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "new path",
+          "type": "Path"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "target path",
+          "type": "Path"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "source path",
+          "type": "Path"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1416": {
+      "name": "Copy",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "new path",
+          "type": "Path"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "target path",
+          "type": "Path"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "source path",
+          "type": "Path"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1417": {
+      "name": "Delete",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "dup path",
+          "type": "Path"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "path",
+          "type": "Path"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1418": {
+      "name": "List Folder",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "folder names",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "file names",
+          "type": "Array"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "dup folder path",
+          "type": "Path"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "datalog type",
+          "type": "NumInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "pattern",
+          "type": "String"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "folder path",
+          "type": "Path"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1419": {
+      "name": "Build Path",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "appended path",
+          "type": "Path"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "name or relative path",
+          "type": "polymorphic"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "base path",
+          "type": "Path",
+          "default_value": "''"
+        }
+      ],
+      "python_code": {
+        "_import": "from pathlib import Path as _Path",
+        "appended_path": "_Path(in_2) / in_1"
+      },
+      "inline": true,
+      "verified": true,
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/build-path.html"
+    },
+    "1420": {
+      "name": "Strip Path",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "path",
+          "type": "Path"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "stripped path",
+          "type": "Path"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "name",
+          "type": "String"
+        }
+      ],
+      "python_code": {
+        "_import": "from pathlib import Path as _Path",
+        "stripped_path": "_Path(in_0).parent",
+        "name": "_Path(in_0).name"
+      },
+      "inline": true,
+      "verified": true,
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/strip-path.html"
+    },
+    "1421": {
+      "name": "Path Type",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/path-type.html",
+      "terminals": [
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "path",
+          "type": "Path"
+        },
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "type",
+          "type": "NumInt16"
+        }
+      ],
+      "python_code": {
+        "type": "(0 if __import__('os').path.isabs(in_1) else 1)"
+      },
+      "note": "type code: 0=absolute,1=relative,2=UNC,3=not a path (confirm exact mapping vs doc).",
+      "verified": false
+    },
+    "1422": {
+      "name": "Array of Strings to Path",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "names",
+          "type": "Array"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "is_relative",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "path",
+          "type": "Path"
+        }
+      ],
+      "python_code": {
+        "path": "Path(*in_0) if not in_1 else Path(*in_0)"
+      },
+      "inline": true,
+      "verified": true,
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/array-of-strings-to-path.html"
+    },
+    "1423": {
+      "name": "Path to Array of Strings",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "path",
+          "type": "Path"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "empty_path",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "names",
+          "type": "Array"
+        }
+      ],
+      "python_code": {
+        "empty_path": "str(in_0) == ''",
+        "names": "list(in_0.parts) if in_0 else []"
+      },
+      "verified": true,
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/path-to-array-of-strings.html"
+    },
+    "1424": {
+      "name": "Refnum to Path",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "path",
+          "type": "Path"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "refnum",
+          "type": "Refnum",
+          "refnum_type": "byte_stream"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1425": {
+      "name": "VI Library",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/vi-library.html",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "path",
+          "type": "Path"
+        }
+      ],
+      "python_code": {
+        "path": "__import__('os').environ.get('LABVIEW_VI_LIB', 'vi.lib')"
+      },
+      "inline": true,
+      "verified": false,
+      "note": "VI Library constant (vi.lib path) -- node XML is byte-identical to the User/Instrument Library variants; identified in 'Is VI-LIB' (output feeds Path To Array Of Strings + Equal? on the path). python_code is a placeholder."
+    },
+    "1426": {
+      "name": "Current VI's Path",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "path",
+          "type": "Path"
+        }
+      ],
+      "python_code": {
+        "_import": "from pathlib import Path as _Path",
+        "path": "_Path(__file__)"
+      },
+      "inline": true,
+      "verified": false,
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/current-vi-s-path.html"
+    },
+    "1427": {
+      "name": "Default Directory",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "path",
+          "type": "Path"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1429": {
+      "name": "File Dialog",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "cancelled",
+          "type": "Boolean"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "exists",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "path",
+          "type": "Path"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "pattern label",
+          "type": "String"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "button label",
+          "type": "String"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "datalog type",
+          "type": "NumInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "prompt",
+          "type": "String"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "pattern",
+          "type": "String"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "default name",
+          "type": "String"
+        },
+        {
+          "index": 9,
+          "direction": "in",
+          "name": "select mode (2)",
+          "type": "Enum32"
+        },
+        {
+          "index": 10,
+          "direction": "in",
+          "name": "start path",
+          "type": "Path"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1430": {
+      "name": "Open Device",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "err",
+          "type": "NumInt32"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "device refnum",
+          "type": "Refnum",
+          "refnum_type": "device"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "unit(0)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "device name",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1431": {
+      "name": "Write Device",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "new offset",
+          "type": "NumInt32"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "count",
+          "type": "NumInt32"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "err",
+          "type": "NumInt16"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "spc reset (F)",
+          "type": "Boolean"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "misc (-)",
+          "type": "Array"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "async (T)",
+          "type": "Boolean"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "pos offset (-)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "pos mode (-)",
+          "type": "NumInt16"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "string",
+          "type": "String"
+        },
+        {
+          "index": 9,
+          "direction": "in",
+          "name": "device refnum",
+          "type": "Refnum",
+          "refnum_type": "device"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1432": {
+      "name": "Read Device",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "new offset",
+          "type": "NumInt32"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "string",
+          "type": "String"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "err",
+          "type": "NumInt16"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "spc reset (F)",
+          "type": "Boolean"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "misc (-)",
+          "type": "Array"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "async (T)",
+          "type": "Boolean"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "pos offset (-)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "pos mode (-)",
+          "type": "NumInt16"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "count",
+          "type": "NumInt32"
+        },
+        {
+          "index": 9,
+          "direction": "in",
+          "name": "device refnum",
+          "type": "Refnum",
+          "refnum_type": "device"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1433": {
+      "name": "Device Control/Status",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "new param",
+          "type": "Cluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "err",
+          "type": "NumInt32"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "spc reset (F)",
+          "type": "Boolean"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "async (T)",
+          "type": "Boolean"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "param (-)",
+          "type": "Cluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "code (-)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "ctrl/stat (T:ctrl)",
+          "type": "Boolean"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "device refnum",
+          "type": "Refnum",
+          "refnum_type": "device"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1434": {
+      "name": "Type and Creator",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "creator",
+          "type": "String"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "type",
+          "type": "String"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "dup path",
+          "type": "Path"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "new creator",
+          "type": "String"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "new type",
+          "type": "String"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "path",
+          "type": "Path"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1435": {
+      "name": "Temporary Directory",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "path",
+          "type": "Path"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
     },
     "1502": {
       "name": "String Length",
@@ -591,6 +5150,112 @@
       "inline": true,
       "verified": true,
       "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/string-length.html"
+    },
+    "1503": {
+      "name": "String Subset",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "substring",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "length (rest)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "offset (0)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "string",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025",
+      "note": "corrected from VI-Scripting nodes export (#59); codegen dropped pending re-derivation"
+    },
+    "1505": {
+      "name": "Number To Exponential String",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "E-format string",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "use system decimal point (T)",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "precision (6)",
+          "type": "NumInt16"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "width (-)",
+          "type": "NumInt16"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "number",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1506": {
+      "name": "Number To Fractional String",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "F-format string",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "use system decimal point (T)",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "precision (6)",
+          "type": "NumInt16"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "width (-)",
+          "type": "NumInt16"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "number",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
     },
     "1510": {
       "name": "Pick Line",
@@ -628,6 +5293,74 @@
       "verified": true,
       "guess_reason": "Pick Line primitive (String >> Additional String Functions): chooses the zero-based line_index-th line from multi_line_string and appends it to string; out-of-range index returns the base string unchanged (NI docs). Confirmed a primitive not the vi.lib Pick Line & Append.vi: heap node is class=prim primResID=1510 with no VI-link fields. Observed 5x in Number to Proper Engl Text__ogtk.vi as (I32 index <- Scan From String, String source, String base unwired) -> String -> Concatenate. idx2=multi-line source vs idx3=append-base disambiguated by dataflow: if idx3 were the source it is empty, making the node a no-op passthrough."
     },
+    "1511": {
+      "name": "Append True/False String",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "output string",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "selector",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "false string",
+          "type": "String"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "true string",
+          "type": "String"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "string (\"\")",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1512": {
+      "name": "Format Value",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "output string",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "value (0)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "format string",
+          "type": "String"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "string (\"\")",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
     "1516": {
       "name": "Select",
       "terminals": [
@@ -664,251 +5397,141 @@
       "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/select.html",
       "note": "Select -- result = t_value if selector else f_value (class='prim' primResID 1516; real Array Subset uses class='subset', resolved by node_type)."
     },
-    "1608": {
-      "name": "Flatten To String",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/flatten-to-string.html",
+    "1531": {
+      "name": "Index String Array",
       "terminals": [
         {
           "index": 0,
           "direction": "out",
-          "name": "data string",
-          "type": "polymorphic"
+          "name": "output string",
+          "type": "String"
         },
         {
           "index": 1,
           "direction": "in",
-          "name": "anything",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "data_string": "str(in_1)"
-      },
-      "inline": true,
-      "verified": false,
-      "note": "Flatten To String serializes data. In Python, str() is a rough equivalent."
-    },
-    "1999": {
-      "name": "Not A Path",
-      "terminals": [
+          "name": "index",
+          "type": "NumInt32"
+        },
         {
-          "index": 0,
-          "direction": "out",
-          "name": "Not A Path",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "not_a_path": "None"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/constants/not-a-path-constant.html",
-      "note": "Constant that returns the <Not A Path> value. In Python, None represents an invalid/empty path."
-    },
-    "2076": {
-      "name": "Unregister For Events",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/unregister-for-events.html",
-      "verified": false,
-      "placeholder": true,
-      "terminals": [
-        {
-          "index": 0,
+          "index": 2,
           "direction": "in",
-          "name": "event_reg_refnum",
-          "type": "Refnum"
+          "name": "string array",
+          "type": "Array"
         },
         {
           "index": 3,
           "direction": "in",
-          "name": "error_in",
-          "type": "Cluster"
-        },
-        {
-          "index": 7,
-          "direction": "out",
-          "name": "error_out",
-          "type": "Cluster"
+          "name": "string (\"\")",
+          "type": "String"
         }
       ],
-      "python_code": "pass",
-      "note": "Unregister For Events -- event registration refnum + error in -> error out only; matches NI Unregister For Events doc. Terminals from 'DAQmx AO.vi' (lv-flex-channel-examples). Placeholder codegen (no lvkit event-registration runtime yet)."
-    },
-    "2074": {
-      "name": "Register Event Source (internal)",
       "verified": false,
-      "placeholder": true,
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "in",
-          "name": "event_reg_in",
-          "type": "Refnum"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "event_source_data",
-          "type": "Cluster"
-        },
-        {
-          "index": 3,
-          "direction": "in",
-          "name": "error_in",
-          "type": "Cluster"
-        },
-        {
-          "index": 4,
-          "direction": "in",
-          "name": "config",
-          "type": "NumUInt32"
-        },
-        {
-          "index": 8,
-          "direction": "out",
-          "name": "event_reg_out",
-          "type": "Refnum"
-        },
-        {
-          "index": 11,
-          "direction": "out",
-          "name": "error_out",
-          "type": "Cluster"
-        }
-      ],
-      "python_code": "pass",
-      "note": "Register Event Source (internal) -- no matching NI doc; deduced compiler-internal fold of a freshly-registered EventReg into the running accumulated EventReg. Terminals from 'DAQmx AO.vi'. Placeholder codegen; verified false."
+      "source": "vi-scripting-nodes-lv2025"
     },
-    "2401": {
-      "name": "Merge Errors",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/merge-errors.html",
-      "terminals": [
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "error_in",
-          "type": "cluster",
-          "expandable": true
-        },
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "error out",
-          "type": "cluster"
-        }
-      ],
-      "python_code": {
-        "error out": "next((e for e in [{expandable_inputs}] if e), None)"
-      },
-      "inline": true,
-      "verified": false,
-      "note": "Merge Errors (NI Merge Errors doc) -- EXPANDABLE: in#1 is the expandable base absorbing all further error inputs; corpus wires up to idx14. Semantics simplified to first-error-wins (NI also falls back to first warning; not modeled)."
-    },
-    "1809": {
-      "name": "Array Size",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/array-size.html",
-      "guess_reason": "class=prim primResID 1809 is Array Size (Array[X] -> NumInt32), verified across many samples with varied element types (Path/Refnum/String/Cluster/NumInt32) all yielding a single I32 output. The expandable Index Array is XML class aIndx (resolved by node_type), not this primResID.",
+    "1532": {
+      "name": "Match First String",
       "terminals": [
         {
           "index": 0,
           "direction": "out",
-          "name": "size",
+          "name": "index",
           "type": "NumInt32"
         },
         {
           "index": 1,
-          "direction": "in",
-          "name": "array",
-          "type": "array"
-        }
-      ],
-      "python_code": "len(in_1)",
-      "inline": true,
-      "verified": true
-    },
-    "1049": {
-      "name": "Sign",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/sign.html",
-      "elementwise": true,
-      "guess_reason": "Unary, type-preserving numeric op (DBL->DBL, Array[DBL]->Array[DBL]); raw typeDescs confirm both ends NumFloat64. Forced by this VI's direction detection: consecutive angle deltas -> Sign(each) -> Add Array Elements(sum) -> Sign(sum) -> To Byte Integer -> xcreasing in {-1,0,+1}. Only Sign (returns 1/0/-1, type-preserving) collapses the sum to a +/-1 direction; sum (not product) makes it a wrap-robust majority vote. Array inputs would need element-wise handling.",
-      "terminals": [
-        {
-          "index": 0,
           "direction": "out",
-          "name": "sign",
-          "type": "polymorphic"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "x",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "sign": "(in_1 > 0) - (in_1 < 0)"
-      },
-      "inline": true,
-      "verified": true
-    },
-    "1140": {
-      "name": "To Byte Integer",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/to-byte-integer.html",
-      "guess_reason": "Conversion to signed 8-bit integer: output is always NumInt8 (or Array[NumInt8]) regardless of input numeric type, verified across corpus (NumInt8/NumInt64/NumInt32/Array[NumFloat64] inputs). NI docs: rounds float to nearest (ties to even) and saturates to [-128, 127]. Scalar template; array inputs would need element-wise handling.",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "byte_integer",
-          "type": "NumInt8"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "number",
-          "type": "numeric"
-        }
-      ],
-      "python_code": "max(-128, min(127, int(round(in_1))))",
-      "inline": true,
-      "verified": true
-    },
-    "1166": {
-      "name": "String Subset",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "in",
-          "name": "string",
-          "type": "polymorphic"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "offset",
-          "type": "polymorphic",
-          "default_value": "0"
+          "name": "output string",
+          "type": "String"
         },
         {
           "index": 2,
-          "direction": "out",
-          "name": "substring",
-          "type": "polymorphic"
+          "direction": "in",
+          "name": "string array",
+          "type": "Array"
         },
         {
           "index": 3,
           "direction": "in",
-          "name": "length",
-          "type": "polymorphic",
-          "default_value": "None"
+          "name": "string",
+          "type": "String"
         }
       ],
-      "python_code": {
-        "substring": "in_0[in_1:] if in_3 is None else in_0[in_1:in_1 + in_3]"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/string-subset.html"
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1533": {
+      "name": "Match True/False String",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "selection",
+          "type": "Boolean"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "output string",
+          "type": "String"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "false string",
+          "type": "String"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "true string",
+          "type": "String"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "string",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1534": {
+      "name": "Scan Value",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "value",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "output string",
+          "type": "String"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "default (0 dbl)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "format string",
+          "type": "String"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "string",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
     },
     "1535": {
       "name": "Match Pattern",
@@ -968,125 +5591,14 @@
       "verified": true,
       "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/match-pattern.html"
     },
-    "1076": {
-      "name": "Round Toward +Infinity",
+    "1536": {
+      "name": "Rotate String",
       "terminals": [
         {
           "index": 0,
           "direction": "out",
-          "name": "ceiling",
-          "type": "NumFloat64"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "x",
-          "type": "NumFloat64"
-        }
-      ],
-      "python_code": {
-        "ceiling": "math.ceil(in_1)"
-      },
-      "inline": true,
-      "verified": true,
-      "guess_reason": "Unary DBL->DBL. Consumer dataflow pins the mode: String Length (1502) -> /3 (Divide 1053) -> 1076 -> For Loop N count, i.e. ceil(len/3) = number of 3-digit blocks (a 4-digit number needs 2 blocks; only rounding UP is correct). NI docs (labview-api-ref/functions/round-toward-infinity-2): Round Toward +Infinity 'rounds to the next highest integer... equivalent of the ceiling function'."
-    },
-    "1077": {
-      "name": "Path To String",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "string",
+          "name": "first char last",
           "type": "String"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "path",
-          "type": "Path"
-        }
-      ],
-      "python_code": {
-        "string": "str(in_1)"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/path-to-string.html"
-    },
-    "1058": {
-      "name": "Increment",
-      "elementwise": true,
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "result",
-          "type": "numeric"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "x",
-          "type": "numeric"
-        }
-      ],
-      "python_code": {
-        "result": "in_1 + 1"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/increment.html"
-    },
-    "1069": {
-      "name": "Negate",
-      "elementwise": true,
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "neg_x",
-          "type": "polymorphic"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "x",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "neg_x": "-in_1"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/negate.html"
-    },
-    "1070": {
-      "name": "Random Number (0-1)",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "number",
-          "type": "NumFloat64"
-        }
-      ],
-      "python_code": {
-        "number": "random.random()"
-      },
-      "_import": "import random",
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/random-number-0-1.html"
-    },
-    "1078": {
-      "name": "String To Path",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "path",
-          "type": "Path"
         },
         {
           "index": 1,
@@ -1095,742 +5607,16 @@
           "type": "String"
         }
       ],
-      "python_code": {
-        "path": "Path(in_1)"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/string-to-path.html"
-    },
-    "1110": {
-      "name": "Greater?",
-      "elementwise": true,
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "result",
-          "type": "Boolean"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "y",
-          "type": "polymorphic",
-          "default_value": "0"
-        },
-        {
-          "index": 2,
-          "direction": "in",
-          "name": "x",
-          "type": "polymorphic",
-          "default_value": "0"
-        }
-      ],
-      "python_code": {
-        "result": "in_2 > in_1"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/greater.html",
-      "note": "Input slots run Bottom->Top, so the upper input `x` takes the higher index."
-    },
-    "1108": {
-      "name": "Quotient & Remainder",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "remainder",
-          "type": "polymorphic"
-        },
-        {
-          "index": 1,
-          "direction": "out",
-          "name": "quotient",
-          "type": "polymorphic"
-        },
-        {
-          "index": 2,
-          "direction": "in",
-          "name": "y",
-          "type": "polymorphic"
-        },
-        {
-          "index": 3,
-          "direction": "in",
-          "name": "x",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "remainder": "in_3 % in_2",
-        "quotient": "in_3 // in_2"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/quotient-remainder.html",
-      "note": "Input slots run Bottom->Top, so the upper input `x` takes the higher index."
-    },
-    "1105": {
-      "name": "Not Equal?",
-      "elementwise": true,
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "result",
-          "type": "Boolean"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "y",
-          "type": "polymorphic",
-          "default_value": "0"
-        },
-        {
-          "index": 2,
-          "direction": "in",
-          "name": "x",
-          "type": "polymorphic",
-          "default_value": "0"
-        }
-      ],
-      "python_code": {
-        "result": "in_1 != in_2"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/not-equal.html",
-      "note": "Input slots run Bottom->Top, so the upper input `x` takes the higher index."
-    },
-    "1114": {
-      "name": "Greater Or Equal To 0?",
-      "elementwise": true,
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "result",
-          "type": "Boolean"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "x",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "result": "in_1 >= 0"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/greater-or-equal-to-0.html",
-      "note": "Greater Or Equal To 0? (>=0) -- unary comparison-to-0, complement of 1118 (<0); pinned >=0 by search-result-offset feeders (Search 1D Array, Match Pattern offset-past-match) across the corpus. Was mislabeled 'Greater Or Equal?'."
-    },
-    "1167": {
-      "name": "Boolean To (0,1)",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "zero_or_one",
-          "type": "NumInt16"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "boolean",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "zero_or_one": "int(bool(in_1))"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/boolean-to-0-1.html",
-      "note": "Polymorphic: Boolean -> I16 (1 or 0). Array of Boolean -> Array of I16. primIndex=69."
-    },
-    "1081": {
-      "name": "Logical Shift",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "shifted",
-          "type": "polymorphic"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "y",
-          "type": "polymorphic"
-        },
-        {
-          "index": 2,
-          "direction": "in",
-          "name": "x",
-          "type": "NumInt32"
-        }
-      ],
-      "python_code": {
-        "shifted": "(in_2 << in_1) if in_1 >= 0 else (in_2 >> -in_1)"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/logical-shift.html",
-      "note": "Logical Shift -- polymorphic on x (any int); y = shift count, positive=left, negative=right (LabVIEW). Input slots run Bottom->Top, so the upper input `x` takes the higher index."
-    },
-    "1053": {
-      "name": "Divide",
-      "elementwise": true,
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "quotient",
-          "type": "polymorphic"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "y",
-          "type": "polymorphic"
-        },
-        {
-          "index": 2,
-          "direction": "in",
-          "name": "x",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "quotient": "in_2 / in_1"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/divide.html",
-      "note": "Divide -- polymorphic; per NI docs int/int -> Float64 (Python `/` matches). Input slots run Bottom->Top, so the upper input `x` takes the higher index."
-    },
-    "1111": {
-      "name": "Less?",
-      "elementwise": true,
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "x_less_than_y",
-          "type": "Boolean"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "y",
-          "type": "polymorphic"
-        },
-        {
-          "index": 2,
-          "direction": "in",
-          "name": "x",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "x_less_than_y": "in_2 < in_1"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/less.html",
-      "note": "Input slots run Bottom->Top, so the upper input `x` takes the higher index."
-    },
-    "8056": {
-      "name": "Delete",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/delete.html",
-      "terminals": [
-        {
-          "index": 7,
-          "direction": "in",
-          "name": "prompt",
-          "type": "String"
-        },
-        {
-          "index": 8,
-          "direction": "in",
-          "name": "error_in",
-          "type": "cluster"
-        },
-        {
-          "index": 9,
-          "direction": "in",
-          "name": "entire_hierarchy",
-          "type": "Boolean"
-        },
-        {
-          "index": 10,
-          "direction": "in",
-          "name": "confirm",
-          "type": "Boolean"
-        },
-        {
-          "index": 11,
-          "direction": "in",
-          "name": "path",
-          "type": "Path"
-        },
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "error_out",
-          "type": "cluster"
-        },
-        {
-          "index": 1,
-          "direction": "out",
-          "name": "cancelled",
-          "type": "Boolean"
-        },
-        {
-          "index": 3,
-          "direction": "out",
-          "name": "path_out",
-          "type": "Path"
-        }
-      ],
-      "python_code": {
-        "path_out": "in_11",
-        "cancelled": "False",
-        "error_out": "in_8"
-      },
-      "note": "Delete (NI Delete doc; renamed from a mislabelled 'File Dialog'). in#9/in#10 Boolean order (entire-hierarchy vs confirm) not disambiguated. python_code is a no-op placeholder, not execution-verified.",
-      "verified": false
-    },
-    "1113": {
-      "name": "Equal To 0?",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "x_equals_zero",
-          "type": "Boolean"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "x",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "x_equals_zero": "in_1 == 0"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/equal-to-0.html",
-      "note": "Equal To 0? (=0), the dominant to-0 form (NI equal-to-0 doc). On non-negative feeders ==0 and <=0 are behaviorally identical, so 1113(=0) vs 1115(<=0) is not corpus-separable; pinned by doc slug. See 1115."
-    },
-    "1115": {
-      "name": "Less Or Equal To 0?",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "result",
-          "type": "Boolean"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "x",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "result": "in_1 <= 0"
-      },
-      "inline": true,
       "verified": false,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/less-or-equal-to-0.html",
-      "note": "Less Or Equal To 0? (<=0) (NI less-or-equal-to-0 doc) -- best-supported <=0 in 'test Queue Size is Zero' (checks a queue count >=0). UNVERIFIED: <=0 vs ==0 not corpus-separable. Was a duplicate 'Equal To 0?'."
-    },
-    "1117": {
-      "name": "Greater Than 0?",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "result",
-          "type": "Boolean"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "x",
-          "type": "numeric"
-        }
-      ],
-      "python_code": {
-        "result": "in_1 > 0"
-      },
-      "inline": true,
-      "verified": false,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/greater-than-0.html",
-      "note": "Greater Than 0? (>0) (NI greater-than-0 doc) -- fed by Array Size -> Select ('non-empty') and Match Pattern offset. UNVERIFIED: >0 vs !=0 not corpus-separable. Was mislabeled 'Not Equal To 0?'."
-    },
-    "1143": {
-      "name": "To Unsigned Byte Integer",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "result",
-          "type": "NumUInt8"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "x",
-          "type": "numeric"
-        }
-      ],
-      "python_code": {
-        "result": "int(in_1) & 0xFF"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/to-unsigned-byte-integer.html"
-    },
-    "1189": {
-      "name": "Flatten To String",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "data_string",
-          "type": "String"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "anything",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "data_string": "str(in_1)"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/flatten-to-string.html"
-    },
-    "1422": {
-      "name": "Array Of Strings To Path",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "in",
-          "name": "names",
-          "type": "Array"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "is_relative",
-          "type": "Boolean"
-        },
-        {
-          "index": 2,
-          "direction": "out",
-          "name": "path",
-          "type": "Path"
-        }
-      ],
-      "python_code": {
-        "path": "Path(*in_0) if not in_1 else Path(*in_0)"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/array-of-strings-to-path.html"
-    },
-    "1609": {
-      "name": "Unflatten From String",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "value",
-          "type": "String"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "binary_string",
-          "type": "Array"
-        }
-      ],
-      "python_code": {
-        "value": "bytes(in_1).decode('latin-1')"
-      },
-      "inline": true,
-      "verified": false,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/unflatten-from-string.html"
-    },
-    "1300": {
-      "name": "Tick Count (ms)",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "millisecond_timer_value",
-          "type": "NumUInt32"
-        }
-      ],
-      "python_code": {
-        "millisecond_timer_value": "int(time.time() * 1000)"
-      },
-      "_import": "import time",
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/tick-count-ms.html"
-    },
-    "1423": {
-      "name": "Path To Array Of Strings",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "in",
-          "name": "path",
-          "type": "Path"
-        },
-        {
-          "index": 1,
-          "direction": "out",
-          "name": "empty_path",
-          "type": "Boolean"
-        },
-        {
-          "index": 2,
-          "direction": "out",
-          "name": "names",
-          "type": "Array"
-        }
-      ],
-      "python_code": {
-        "empty_path": "str(in_0) == ''",
-        "names": "list(in_0.parts) if in_0 else []"
-      },
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/path-to-array-of-strings.html"
-    },
-    "1164": {
-      "name": "Get Type Information",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/vi-lib/utility/data-type/get-type-information-vi.html",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "error_out",
-          "type": "Cluster"
-        },
-        {
-          "index": 2,
-          "direction": "out",
-          "name": "names",
-          "type": "Array"
-        },
-        {
-          "index": 3,
-          "direction": "out",
-          "name": "name",
-          "type": "String"
-        },
-        {
-          "index": 8,
-          "direction": "in",
-          "name": "error_in",
-          "type": "Cluster"
-        },
-        {
-          "index": 9,
-          "direction": "in",
-          "name": "type_enum",
-          "type": "UnitUInt16"
-        },
-        {
-          "index": 10,
-          "direction": "in",
-          "name": "include_control",
-          "type": "Boolean"
-        },
-        {
-          "index": 11,
-          "direction": "in",
-          "name": "reference",
-          "type": "Refnum"
-        }
-      ],
-      "python_code": {
-        "names": "[]",
-        "name": "''"
-      },
-      "verified": false
-    },
-    "3914": {
-      "name": "Match Regular Expression",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "in",
-          "name": "string",
-          "type": "String"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "multiline",
-          "type": "Boolean"
-        },
-        {
-          "index": 2,
-          "direction": "in",
-          "name": "ignore_case",
-          "type": "Boolean"
-        },
-        {
-          "index": 3,
-          "direction": "in",
-          "name": "dotall",
-          "type": "Boolean"
-        },
-        {
-          "index": 4,
-          "direction": "out",
-          "name": "after_match",
-          "type": "String"
-        },
-        {
-          "index": 5,
-          "direction": "in",
-          "name": "regular_expression",
-          "type": "String"
-        },
-        {
-          "index": 7,
-          "direction": "in",
-          "name": "replacement_string",
-          "type": "String"
-        },
-        {
-          "index": 8,
-          "direction": "out",
-          "name": "offset",
-          "type": "NumInt32"
-        },
-        {
-          "index": 9,
-          "direction": "in",
-          "name": "offset_in",
-          "type": "NumInt32"
-        },
-        {
-          "index": 10,
-          "direction": "out",
-          "name": "replacement_count",
-          "type": "NumInt32"
-        },
-        {
-          "index": 11,
-          "direction": "in",
-          "name": "error_in",
-          "type": "Cluster"
-        },
-        {
-          "index": 15,
-          "direction": "out",
-          "name": "error_out",
-          "type": "Cluster"
-        }
-      ],
-      "python_code": {
-        "_import": "import re",
-        "_body": "_result = re.search(in_5, in_0[in_9:])",
-        "after_match": "in_0[in_9:][_result.end():] if _result else ''",
-        "offset": "(in_9 + _result.start()) if _result else -1"
-      },
-      "verified": false,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/vi-lib/regexp/match-regular-expression-xnode.html"
-    },
-    "8070": {
-      "name": "Read from Text File",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/read-from-text-file.html",
-      "terminals": [
-        {
-          "index": 7,
-          "direction": "in",
-          "name": "prompt",
-          "type": "String"
-        },
-        {
-          "index": 8,
-          "direction": "in",
-          "name": "error_in",
-          "type": "cluster"
-        },
-        {
-          "index": 10,
-          "direction": "in",
-          "name": "count",
-          "type": "NumInt32"
-        },
-        {
-          "index": 11,
-          "direction": "in",
-          "name": "file",
-          "type": "polymorphic"
-        },
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "error_out",
-          "type": "cluster"
-        },
-        {
-          "index": 1,
-          "direction": "out",
-          "name": "cancelled",
-          "type": "Boolean"
-        },
-        {
-          "index": 2,
-          "direction": "out",
-          "name": "text",
-          "type": "polymorphic"
-        },
-        {
-          "index": 3,
-          "direction": "out",
-          "name": "refnum_out",
-          "type": "Refnum"
-        }
-      ],
-      "python_code": {
-        "text": "(in_11.read() if hasattr(in_11, \"read\") else open(in_11).read())",
-        "refnum_out": "in_11",
-        "cancelled": "False",
-        "error_out": "in_8"
-      },
-      "note": "Read from Text File (renamed from a mislabelled 'List Folder') -- file (in#11) accepts a refnum or path; text (out#2) is a string, or array of strings when count is wired. Side-effecting IO, not execution-verified.",
-      "verified": false
+      "source": "vi-scripting-nodes-lv2025"
     },
     "1537": {
-      "name": "To Lower Case",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/to-lower-case.html",
+      "name": "Reverse String",
       "terminals": [
         {
           "index": 0,
           "direction": "out",
-          "name": "all_lower_case_string",
+          "name": "reversed",
           "type": "String"
         },
         {
@@ -1840,12 +5626,9 @@
           "type": "String"
         }
       ],
-      "python_code": {
-        "all_lower_case_string": "in_1.lower() if isinstance(in_1, str) else [s.lower() for s in in_1]"
-      },
-      "inline": true,
-      "verified": true,
-      "guess_reason": "Was mislabeled 'Search and Replace String' (an 8-terminal string op); the actual node is a hard 2-terminal (termList elements=2, no unwired terminal), UNARY, type-preserving, polymorphic over String AND Array[String] (auto-maps). Among the four 2-terminal unary string primitives (to-lower-case, to-upper-case, reverse-string, rotate-string), reverse/rotate would scramble word characters and don't fit the number->text role; NI docs (labview-api-ref/functions/to-lower-case): To Lower Case 'converts all alphabetic characters to lowercase... does not affect non-alphabetic characters... polymorphic'. Chosen lower (not upper) because the VI's word output is lowercase (all constants lowercase, conventional English number text). Cleanroom: no glyph available to confirm upper-vs-lower; resolved from VI logic."
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025",
+      "note": "corrected from VI-Scripting nodes export (#59); codegen dropped pending re-derivation"
     },
     "1538": {
       "name": "Search/Split String",
@@ -1895,255 +5678,1869 @@
       "verified": true,
       "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/search-split-string.html"
     },
-    "1102": {
-      "name": "Equal?",
-      "elementwise": true,
+    "1539": {
+      "name": "Spreadsheet String To Array",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/spreadsheet-string-to-array.html",
       "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "equal",
-          "type": "polymorphic"
-        },
         {
           "index": 1,
           "direction": "in",
-          "name": "y",
-          "type": "polymorphic",
-          "default_value": "0"
+          "name": "delimiter",
+          "type": "String"
         },
         {
           "index": 2,
           "direction": "in",
-          "name": "x",
-          "type": "polymorphic",
-          "default_value": "0"
-        }
-      ],
-      "python_code": {
-        "equal": "in_1 == in_2"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/equal.html",
-      "note": "Input slots run Bottom->Top, so the upper input `x` takes the higher index."
-    },
-    "1116": {
-      "name": "Unresolved primitive 1116",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "output",
-          "type": "polymorphic"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "input",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "output": "in_1"
-      },
-      "inline": true,
-      "verified": false,
-      "placeholder": true,
-      "note": "Unresolved primitive 1116 -- unary 1in/1out, likely a boolean/error op (corpus feeders are boolean/cluster, not numeric). Kept as a passthrough placeholder; used by TestCase.lvclass. Unidentified."
-    },
-    "1170": {
-      "name": "Split Number",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/split-number.html",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "in",
-          "name": "input",
-          "type": "polymorphic"
-        },
-        {
-          "index": 1,
-          "direction": "out",
-          "name": "high",
-          "type": "polymorphic"
-        },
-        {
-          "index": 2,
-          "direction": "out",
-          "name": "low",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "high": "in_0 >> 16",
-        "low": "in_0 & 0xFFFF"
-      },
-      "inline": true,
-      "verified": false,
-      "note": "1in/2out array→array+array. Could be Split Number or type-specific split. Unconfirmed."
-    },
-    "1503": {
-      "name": "Replace Substring",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "result string",
-          "type": "polymorphic"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "offset",
-          "type": "polymorphic",
-          "default_value": "0"
-        },
-        {
-          "index": 2,
-          "direction": "in",
-          "name": "length",
-          "type": "polymorphic"
+          "name": "array_type",
+          "type": "Array"
         },
         {
           "index": 3,
           "direction": "in",
-          "name": "string",
-          "type": "polymorphic"
+          "name": "spreadsheet_string",
+          "type": "String"
         },
         {
           "index": 4,
           "direction": "in",
-          "name": "substring",
-          "type": "polymorphic",
-          "default_value": "''"
-        }
-      ],
-      "python_code": {
-        "result_string": "in_3[:in_1] + in_4 + in_3[in_1 + in_2:]"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/replace-substring.html"
-    },
-    "1904": {
-      "name": "Multiply Array Elements",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/multiply-array-elements.html",
-      "guess_reason": "Was mislabeled 'Array Size'. Output tracks the element type (Array[UInt32]->UInt32, Array[Int32]->Int32), so it is a numeric reduction, not an I32 count. Sibling of Add Array Elements (1903) in the array-reduction cluster (1910 Or, 1911 And Array Elements). Sum-vs-product settled by context: in 'MultiD Array to 1D Array', 1904(dimension_sizes) feeds a For Loop count -- the total element count of an n-D array is the PRODUCT of its dimension sizes. Empty array -> 1 (math.prod identity), matching LabVIEW.",
-      "terminals": [
+          "name": "format_string",
+          "type": "String"
+        },
         {
           "index": 0,
           "direction": "out",
-          "name": "product",
-          "type": "polymorphic"
-        },
-        {
-          "index": 1,
-          "direction": "in",
           "name": "array",
           "type": "Array"
         }
       ],
       "python_code": {
-        "_import": "import math",
-        "product": "math.prod(in_1)"
+        "array": "[r.split(in_1 or '\\t') for r in in_3.splitlines()]"
       },
       "inline": true,
-      "verified": true
+      "verified": false,
+      "note": "Spreadsheet String To Array -- splits a delimited string into a typed array. python_code covers only the 2-D string case; real dimensionality/element type come from array_type + format_string and need an lvkit runtime helper."
     },
-    "1910": {
-      "name": "Or Array Elements",
+    "1540": {
+      "name": "Array To Spreadsheet String",
       "terminals": [
         {
           "index": 0,
           "direction": "out",
-          "name": "logical_or",
+          "name": "spreadsheet_string",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "delimiter",
+          "type": "String",
+          "default_value": "'\\t'"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "array",
+          "type": "Array"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "format_string",
+          "type": "String"
+        }
+      ],
+      "python_code": {
+        "spreadsheet_string": "(in_1 or '\\t').join(in_3 % x for x in in_2)"
+      },
+      "inline": true,
+      "verified": true,
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/array-to-spreadsheet-string.html",
+      "note": "parmIndex from OBSERVED caller dataflow (OpenG '1D Array to String' control wiring: in_1<-delimiter, in_2<-array, in_3<-format '%s'): in_1=delimiter (default Tab), in_2=array, in_3=format string, out=spreadsheet string. python_code covers the common 1-D case; full N-D (Tab columns / EOL rows / page headers) would need an lvkit runtime helper, as with 1539."
+    },
+    "1600": {
+      "name": "Get Date/Time String",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "time string",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "date string",
+          "type": "String"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "want seconds? (F)",
+          "type": "Boolean"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "seconds (now)",
+          "type": "Timestamp"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "date format (0)",
+          "type": "Enum16"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1603": {
+      "name": "Size Handle",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "handle",
+          "type": "Void"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "error",
+          "type": "NumInt32"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "handle (-)",
+          "type": "Void"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "size",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1604": {
+      "name": "Handle Peek",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "value",
+          "type": "NumInt32"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "error",
+          "type": "NumInt32"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "num type (long)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "offset",
+          "type": "NumInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "handle",
+          "type": "Void"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1605": {
+      "name": "Handle Poke",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "old value",
+          "type": "NumInt32"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "handle",
+          "type": "Void"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "error",
+          "type": "NumInt32"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "new value",
+          "type": "NumInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "offset",
+          "type": "NumInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "handle",
+          "type": "Void"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1606": {
+      "name": "Rotate Left With Carry",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "value",
+          "type": "NumInt32"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "msb carry out",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "value",
+          "type": "NumInt32"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "carry",
+          "type": "Boolean"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1607": {
+      "name": "Rotate Right With Carry",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "value",
+          "type": "NumInt32"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "lsb carry out",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "value",
+          "type": "NumInt32"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "carry",
+          "type": "Boolean"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1608": {
+      "name": "String To Byte Array",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "unsigned byte array",
+          "type": "Array"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "string",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025",
+      "note": "corrected from VI-Scripting nodes export (#59); codegen dropped pending re-derivation"
+    },
+    "1609": {
+      "name": "Byte Array To String",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "string",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "unsigned byte array",
+          "type": "Array"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025",
+      "note": "corrected from VI-Scripting nodes export (#59); codegen dropped pending re-derivation"
+    },
+    "1610": {
+      "name": "Request Deallocation",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "flag",
+          "type": "Boolean"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1700": {
+      "name": "Generate Occurrence",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "occurrence",
+          "type": "Refnum",
+          "refnum_type": "occurence"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1701": {
+      "name": "Wait on Occurrence",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/wait-on-occurrence.html",
+      "terminals": [
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "ignore_previous",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "occurrence",
+          "type": "Refnum"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "ms_timeout",
+          "type": "NumInt32"
+        },
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "timed_out",
+          "type": "Boolean"
+        }
+      ],
+      "python_code": {
+        "timed_out": "in_2.wait(None if in_3 < 0 else in_3 / 1000.0) is False"
+      },
+      "note": "waits on an Occurrence refnum (mapped to threading.Event); returns timed_out.",
+      "verified": false
+    },
+    "1702": {
+      "name": "Set Occurrence",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "occurrence",
+          "type": "Refnum",
+          "refnum_type": "occurence"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1710": {
+      "name": "IP To String",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "name",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "dot notation? (F)",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "net address",
+          "type": "NumUInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1711": {
+      "name": "String To IP",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "net address",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "name",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1712": {
+      "name": "TCP Wait On Listener",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "remote port",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "remote address",
+          "type": "String"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "listener ID out",
+          "type": "Refnum",
+          "refnum_type": "tcp_net_connection"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "connection ID",
+          "type": "Refnum",
+          "refnum_type": "tcp_net_connection"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "timeout ms (wait forever: -1)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "resolve remote address (T)",
+          "type": "Boolean"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "listener ID in",
+          "type": "Refnum",
+          "refnum_type": "tcp_net_connection"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1713": {
+      "name": "TCP Close Connection",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "connection ID out",
+          "type": "Refnum",
+          "refnum_type": "tcp_net_connection"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "abort (F)",
+          "type": "Boolean"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "connection ID",
+          "type": "Refnum",
+          "refnum_type": "tcp_net_connection"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1714": {
+      "name": "TCP Write",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "bytes written",
+          "type": "NumInt32"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "connection ID out",
+          "type": "Refnum",
+          "refnum_type": "tcp_net_connection"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "timeout ms (25000)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "data in",
+          "type": "String"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "connection ID",
+          "type": "Refnum",
+          "refnum_type": "tcp_net_connection"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1715": {
+      "name": "TCP Open Connection",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "connection ID",
+          "type": "Refnum",
+          "refnum_type": "tcp_net_connection"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "local port",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "timeout ms (60000)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "remote port or service name",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "address",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1716": {
+      "name": "TCP Read",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "data out",
+          "type": "String"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "connection ID out",
+          "type": "Refnum",
+          "refnum_type": "tcp_net_connection"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "mode (standard)",
+          "type": "Enum16"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "timeout ms (25000)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "bytes to read",
+          "type": "NumInt32"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "connection ID",
+          "type": "Refnum",
+          "refnum_type": "tcp_net_connection"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1717": {
+      "name": "TCP Create Listener",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "port",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "listener ID",
+          "type": "Refnum",
+          "refnum_type": "tcp_net_connection"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "net address",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "timeout ms (25000)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "port",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "service name",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1718": {
+      "name": "TCP Flattened Read",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "data out",
+          "type": "Cluster"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "connection ID out",
+          "type": "Refnum",
+          "refnum_type": "tcp_net_connection"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "type",
+          "type": "Cluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "timeout ms (25000)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "connection ID",
+          "type": "Refnum",
+          "refnum_type": "tcp_net_connection"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1719": {
+      "name": "TCP Flattened Write",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "connection ID out",
+          "type": "Refnum",
+          "refnum_type": "tcp_net_connection"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "timeout ms (25000)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "data in",
+          "type": "Cluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "connection ID",
+          "type": "Refnum",
+          "refnum_type": "tcp_net_connection"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1720": {
+      "name": "TCP Flex Read",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "coerced?",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "data out",
+          "type": "Cluster"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "connection ID out",
+          "type": "Refnum",
+          "refnum_type": "tcp_net_connection"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "type",
+          "type": "Cluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "timeout ms (25000)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "connection ID",
+          "type": "Refnum",
+          "refnum_type": "tcp_net_connection"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1721": {
+      "name": "TCP Flex Write",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "connection ID out",
+          "type": "Refnum",
+          "refnum_type": "tcp_net_connection"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "timeout ms (25000)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "data in",
+          "type": "Cluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "connection ID",
+          "type": "Refnum",
+          "refnum_type": "tcp_net_connection"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1722": {
+      "name": "Wait For Activity",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "connection IDs active",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "listener IDs active",
+          "type": "Array"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "timeout",
+          "type": "NumInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "connection IDs",
+          "type": "Array"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "listener IDs",
+          "type": "Array"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1723": {
+      "name": "UDP Open",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "service name",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "port",
+          "type": "Refnum",
+          "refnum_type": "udp_net_connection"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "net address",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "",
+          "type": "String"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "",
+          "type": "NumUInt16"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1724": {
+      "name": "UDP Read",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "data out",
+          "type": "String"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "connection ID out",
+          "type": "Refnum",
+          "refnum_type": "udp_net_connection"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "port",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "address",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "timeout ms (25000)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "max size (548)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "connection ID",
+          "type": "Refnum",
+          "refnum_type": "udp_net_connection"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1725": {
+      "name": "UDP Write",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "connection ID out",
+          "type": "Refnum",
+          "refnum_type": "udp_net_connection"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "port or service name",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "address",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "timeout ms (25000)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "data in",
+          "type": "String"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "connection ID",
+          "type": "Refnum",
+          "refnum_type": "udp_net_connection"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1726": {
+      "name": "UDP Close",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "connection ID out",
+          "type": "Refnum",
+          "refnum_type": "udp_net_connection"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "connection ID",
+          "type": "Refnum",
+          "refnum_type": "udp_net_connection"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1727": {
+      "name": "UDP Multicast Open",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "port",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "connection ID",
+          "type": "Refnum",
+          "refnum_type": "udp_net_connection"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "net address",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "time-to-live",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "multicast addr",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "port",
+          "type": "NumUInt16"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1730": {
+      "name": "New TLS Configuration",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "TLS configuration out",
+          "type": "Refnum",
+          "refnum_type": "tls_configuration"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "load OS trusted CAs?",
+          "type": "Boolean"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1731": {
+      "name": "Start TLS",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "server certificate chain",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "TLS connection",
+          "type": "Refnum",
+          "refnum_type": "tcp_net_connection"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "server certificate validation",
+          "type": "Enum32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "timeout ms",
+          "type": "NumInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "server hostname",
+          "type": "String"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "immutable TLS configuration",
+          "type": "Refnum",
+          "refnum_type": "tls_configuration"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "TCP connection",
+          "type": "Refnum",
+          "refnum_type": "tcp_net_connection"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1732": {
+      "name": "Accept TLS",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "client certificate chain",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "TLS connection",
+          "type": "Refnum",
+          "refnum_type": "tcp_net_connection"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "timeout ms (300000)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "immutable TLS configuration",
+          "type": "Refnum",
+          "refnum_type": "tls_configuration"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "TCP connection",
+          "type": "Refnum",
+          "refnum_type": "tcp_net_connection"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1733": {
+      "name": "Load Private Key Into Memory",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "private key",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "password",
+          "type": "String"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "format",
+          "type": "Enum32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "path to private key",
+          "type": "Path"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1734": {
+      "name": "Load Certificates Into Memory",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "certificates",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "format",
+          "type": "Enum32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "path to certificates",
+          "type": "Path"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1735": {
+      "name": "Add Private Key To TLS Configuration",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "TLS configuration out",
+          "type": "Refnum",
+          "refnum_type": "tls_configuration"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "certificate chain",
+          "type": "Array"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "private key",
+          "type": "Array"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "TLS configuration",
+          "type": "Refnum",
+          "refnum_type": "tls_configuration"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1736": {
+      "name": "Add Trusted Certificate To TLS Configuration",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "TLS configuration out",
+          "type": "Refnum",
+          "refnum_type": "tls_configuration"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "certificate",
+          "type": "Array"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "TLS configuration",
+          "type": "Refnum",
+          "refnum_type": "tls_configuration"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1737": {
+      "name": "Make TLS Configuration Immutable",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "immutable TLS configuration",
+          "type": "Refnum",
+          "refnum_type": "tls_configuration"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "TLS configuration",
+          "type": "Refnum",
+          "refnum_type": "tls_configuration"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1738": {
+      "name": "Add Entropy",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "entropy",
+          "type": "Array"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1739": {
+      "name": "Re-accept TLS",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "client certificate chain",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "TLS connection out",
+          "type": "Refnum",
+          "refnum_type": "tcp_net_connection"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "timeout ms",
+          "type": "NumInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "",
+          "type": "Array"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "CA certificates",
+          "type": "Refnum",
+          "refnum_type": "tls_configuration"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "TLS connection",
+          "type": "Refnum",
+          "refnum_type": "tcp_net_connection"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1740": {
+      "name": "TLS Connection?",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "TLS?",
           "type": "Boolean"
         },
         {
           "index": 1,
           "direction": "in",
-          "name": "boolean_array",
-          "type": "Array"
+          "name": "TCP connection",
+          "type": "Refnum",
+          "refnum_type": "tcp_net_connection"
         }
       ],
-      "python_code": {
-        "logical_or": "any(in_1)"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/or-array-elements.html"
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
     },
-    "1911": {
-      "name": "And Array Elements",
+    "1741": {
+      "name": "Close TLS Configuration",
       "terminals": [
         {
           "index": 0,
           "direction": "out",
-          "name": "logical_and",
-          "type": "Boolean"
+          "name": "error out",
+          "type": "ErrorCluster"
         },
         {
           "index": 1,
           "direction": "in",
-          "name": "boolean_array",
-          "type": "Array"
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "TLS configuration",
+          "type": "Refnum",
+          "refnum_type": "tls_configuration"
         }
       ],
-      "python_code": {
-        "logical_and": "all(in_1)"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/and-array-elements.html"
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
     },
-    "1903": {
-      "name": "Add Array Elements",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/add-array-elements.html",
-      "guess_reason": "Was mislabeled 'Array Size'. Raw typeDesc proves the output is element-typed (Array[NumFloat64] -> NumFloat64), not an I32 count, so it is a numeric reduction, not Array Size (the real Array Size is primResID 1809, Array[X] -> I32). Sits in the array-reduction cluster (1910 Or Array Elements, 1911 And Array Elements). Forced by this VI's logic: sum of per-step Sign(deltas) gives a wrap-robust direction vote. Corpus I32-array instances (sum of int array -> int) are consistent.",
+    "1809": {
+      "name": "Array Size",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/array-size.html",
+      "guess_reason": "class=prim primResID 1809 is Array Size (Array[X] -> NumInt32), verified across many samples with varied element types (Path/Refnum/String/Cluster/NumInt32) all yielding a single I32 output. The expandable Index Array is XML class aIndx (resolved by node_type), not this primResID.",
       "terminals": [
         {
           "index": 0,
           "direction": "out",
-          "name": "sum",
+          "name": "size",
+          "type": "NumInt32"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "array",
+          "type": "array"
+        }
+      ],
+      "python_code": "len(in_1)",
+      "inline": true,
+      "verified": true
+    },
+    "1814": {
+      "name": "Number To Boolean Array",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/number-to-boolean-array.html",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "boolean array",
+          "type": "Array"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "number",
+          "type": "polymorphic"
+        }
+      ],
+      "python_code": {
+        "boolean array": "[bool((in_1 >> i) & 1) for i in range(in_1.bit_length() or 8)]"
+      },
+      "verified": false
+    },
+    "1815": {
+      "name": "Boolean Array To Number",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/boolean-array-to-number.html",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "number",
           "type": "polymorphic"
         },
         {
           "index": 1,
           "direction": "in",
-          "name": "array",
+          "name": "boolean array",
           "type": "Array"
         }
       ],
       "python_code": {
-        "sum": "sum(in_1)"
+        "number": "sum((1 << i) for i, b in enumerate(in_1) if b)"
       },
-      "inline": true,
-      "verified": true
+      "verified": false
     },
-    "1120": {
-      "name": "Sort 1D Array",
+    "1830": {
+      "name": "String to Shared Variable",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "string",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "valid Shared Variable?",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "Shared Variable",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1831": {
+      "name": "Shared Variable to String",
       "terminals": [
         {
           "index": 0,
           "direction": "out",
-          "name": "sorted_array",
-          "type": "Array"
+          "name": "string",
+          "type": "String"
         },
         {
           "index": 1,
           "direction": "in",
-          "name": "array",
-          "type": "Array"
+          "name": "Shared Variable",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
         }
       ],
-      "python_code": {
-        "sorted_array": "sorted(in_1)"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/sort-1d-array.html",
-      "note": "Sort 1D Array (sorts ascending) -- in OpenG Sort wrappers, the separate 1900 (Reverse 1D Array) flips to descending (case frame 1)."
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
     },
     "1900": {
       "name": "Reverse 1D Array",
@@ -2229,181 +7626,8544 @@
       "verified": true,
       "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/transpose-2d-array.html"
     },
-    "1128": {
-      "name": "Not A Number/Path/Refnum?",
+    "1903": {
+      "name": "Add Array Elements",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/add-array-elements.html",
+      "guess_reason": "Was mislabeled 'Array Size'. Raw typeDesc proves the output is element-typed (Array[NumFloat64] -> NumFloat64), not an I32 count, so it is a numeric reduction, not Array Size (the real Array Size is primResID 1809, Array[X] -> I32). Sits in the array-reduction cluster (1910 Or Array Elements, 1911 And Array Elements). Forced by this VI's logic: sum of per-step Sign(deltas) gives a wrap-robust direction vote. Corpus I32-array instances (sum of int array -> int) are consistent.",
       "terminals": [
         {
           "index": 0,
           "direction": "out",
-          "name": "not_a_refnum",
+          "name": "sum",
+          "type": "polymorphic"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "array",
+          "type": "Array"
+        }
+      ],
+      "python_code": {
+        "sum": "sum(in_1)"
+      },
+      "inline": true,
+      "verified": true
+    },
+    "1904": {
+      "name": "Multiply Array Elements",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/multiply-array-elements.html",
+      "guess_reason": "Was mislabeled 'Array Size'. Output tracks the element type (Array[UInt32]->UInt32, Array[Int32]->Int32), so it is a numeric reduction, not an I32 count. Sibling of Add Array Elements (1903) in the array-reduction cluster (1910 Or, 1911 And Array Elements). Sum-vs-product settled by context: in 'MultiD Array to 1D Array', 1904(dimension_sizes) feeds a For Loop count -- the total element count of an n-D array is the PRODUCT of its dimension sizes. Empty array -> 1 (math.prod identity), matching LabVIEW.",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "product",
+          "type": "polymorphic"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "array",
+          "type": "Array"
+        }
+      ],
+      "python_code": {
+        "_import": "import math",
+        "product": "math.prod(in_1)"
+      },
+      "inline": true,
+      "verified": true
+    },
+    "1905": {
+      "name": "Interpolate 1D Array",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "y value",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "fractional index or x",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "array of numbers or points",
+          "type": "Array"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1906": {
+      "name": "Rotate 1D Array",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/rotate-1d-array.html",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "array (rotated)",
+          "type": "Array"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "array",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "n",
+          "type": "NumInt32"
+        }
+      ],
+      "python_code": {
+        "array (rotated)": "in_1[-in_2 % len(in_1):] + in_1[:-in_2 % len(in_1)] if in_1 else in_1"
+      },
+      "verified": false
+    },
+    "1907": {
+      "name": "Array Max & Min",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/array-max-min.html",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "array",
+          "type": "polymorphic"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "max value",
+          "type": "polymorphic"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "max index",
+          "type": "NumInt32"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "min value",
+          "type": "polymorphic"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "min index",
+          "type": "NumInt32"
+        }
+      ],
+      "python_code": {
+        "max_value": "(max(in_0) if in_0 else 0)",
+        "max_index": "(in_0.index(max(in_0)) if in_0 else -1)",
+        "min_value": "(min(in_0) if in_0 else 0)",
+        "min_index": "(in_0.index(min(in_0)) if in_0 else -1)"
+      },
+      "inline": true,
+      "verified": true,
+      "note": "Array Max & Min -- returns max value & its first index, min value & its first index (NI array-max-min doc); terminals from OpenG samples 'limitDecendantsTo1Level', 'Fit VI window to Largest Dec'."
+    },
+    "1908": {
+      "name": "Split 1D Array",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/split-1d-array.html",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "first subarray",
+          "type": "polymorphic"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "second subarray",
+          "type": "polymorphic"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "index",
+          "type": "polymorphic"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "array",
+          "type": "polymorphic"
+        }
+      ],
+      "python_code": {
+        "first subarray": "in_3[:in_2]",
+        "second subarray": "in_3[in_2:]"
+      },
+      "verified": false
+    },
+    "1909": {
+      "name": "Threshold 1D Array",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "fractional index or x",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "start index (0)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "threshold y",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "array of numbers or points",
+          "type": "Array"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1910": {
+      "name": "Or Array Elements",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "logical_or",
           "type": "Boolean"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "boolean_array",
+          "type": "Array"
+        }
+      ],
+      "python_code": {
+        "logical_or": "any(in_1)"
+      },
+      "inline": true,
+      "verified": true,
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/or-array-elements.html"
+    },
+    "1911": {
+      "name": "And Array Elements",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "logical_and",
+          "type": "Boolean"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "boolean_array",
+          "type": "Array"
+        }
+      ],
+      "python_code": {
+        "logical_and": "all(in_1)"
+      },
+      "inline": true,
+      "verified": true,
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/and-array-elements.html"
+    },
+    "1912": {
+      "name": "Swap Vector Element",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "swapped element value",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "returned index",
+          "type": "NumInt32"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "changed vector",
+          "type": "Array"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "element value",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "index",
+          "type": "NumInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "vector",
+          "type": "Array"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1920": {
+      "name": "Property Node",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "reference",
+          "type": "Refnum",
+          "refnum_type": "vi_server",
+          "class_id": 1,
+          "class_name": "Application"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "reference out",
+          "type": "Refnum",
+          "refnum_type": "vi_server",
+          "class_id": 1,
+          "class_name": "Application"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "Property",
+          "type": "Void"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1921": {
+      "name": "Old VISA Open",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "timeout (0)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "access mode",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "resource name (\"\")",
+          "type": "String"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "VISA resource name (for class)",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1922": {
+      "name": "VISA Close",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1923": {
+      "name": "VISA Find Resource",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "return count",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "find list",
+          "type": "Array"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "search mode (0)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "expression (\"\")",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1924": {
+      "name": "VISA Status Description",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "status description",
+          "type": "String"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1925": {
+      "name": "VISA Read",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "return count",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "read buffer",
+          "type": "String"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "byte count",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1926": {
+      "name": "VISA Write",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "return count",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "write buffer",
+          "type": "String"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1927": {
+      "name": "VISA Clear",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1928": {
+      "name": "VISA Read STB",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "status byte",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1929": {
+      "name": "VISA Assert Trigger",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "protocol (default:  0)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1930": {
+      "name": "VISA In 16",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "value",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "address space (A16:  1)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "offset (0)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1931": {
+      "name": "VISA Out 16",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "address space (A16:  1)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "value (0)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "offset (0)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1932": {
+      "name": "VISA Map Address",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "access (False)",
+          "type": "Boolean"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "address space (A16:  1)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "map size (0)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "map base (0)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1933": {
+      "name": "VISA Unmap Address",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1934": {
+      "name": "VISA Peek 16",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "value",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "offset (0)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1935": {
+      "name": "VISA Poke 16",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "value (0)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "offset (0)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1936": {
+      "name": "VISA In 8",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "value",
+          "type": "NumUInt8"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "address space (A16:  1)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "offset (0)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1937": {
+      "name": "VISA Out 8",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "address space (A16:  1)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "value (0)",
+          "type": "NumUInt8"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "offset (0)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1938": {
+      "name": "VISA Peek 8",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "value",
+          "type": "NumUInt8"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "offset (0)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1939": {
+      "name": "VISA Poke 8",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "value (0)",
+          "type": "NumUInt8"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "offset (0)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1940": {
+      "name": "VISA Disable Event",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "mechanism (1:  VI_QUEUE)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "event type (all enabled)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1941": {
+      "name": "VISA Discard Events",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "mechanism  (1:  VI_QUEUE)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "event type (all enabled)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1942": {
+      "name": "VISA Enable Event",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "mechanism (1:  VI_QUEUE)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "event type",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1943": {
+      "name": "VISA Wait on Event",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "event  resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "event type",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "timeout (0)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "event  resource name (for class)",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "event type (all enabled)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1944": {
+      "name": "VISA In 32",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "value",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "address space (A16:  1)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "offset (0)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1945": {
+      "name": "VISA Out 32",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "address space (A16:  1)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "value (0)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "offset (0)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1946": {
+      "name": "VISA Move In 8",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "data",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "address space (A16:  1)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "count",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "offset (0)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1947": {
+      "name": "VISA Move Out 8",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "address space (A16:  1)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "data",
+          "type": "Array"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "offset (0)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1948": {
+      "name": "VISA Move In 16",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "data",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "address space (A16:  1)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "count",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "offset (0)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1949": {
+      "name": "VISA Move Out 16",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "address space (A16:  1)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "data",
+          "type": "Array"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "offset (0)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1950": {
+      "name": "GPIB Write",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "address string",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "data",
+          "type": "String"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "mode (0)",
+          "type": "NumInt16"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "timeout ms (488.2 global)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 5,
+          "direction": "out",
+          "name": "status",
+          "type": "Array"
+        },
+        {
+          "index": 6,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1951": {
+      "name": "GPIB Read",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "address string",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "byte count",
+          "type": "NumInt32"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "mode (0)",
+          "type": "NumInt16"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "timeout ms (488.2 global)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 5,
+          "direction": "out",
+          "name": "data",
+          "type": "String"
+        },
+        {
+          "index": 6,
+          "direction": "out",
+          "name": "status",
+          "type": "Array"
+        },
+        {
+          "index": 7,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1952": {
+      "name": "Wait for GPIB RQS",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "poll response byte",
+          "type": "NumInt16"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "timeout ms (488.2 global)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "address string",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1953": {
+      "name": "GPIB Trigger",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "status",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "address string",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1954": {
+      "name": "GPIB Clear",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "status",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "address string",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1955": {
+      "name": "GPIB Serial Poll",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "address string",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "serial poll byte",
+          "type": "NumInt16"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "status",
+          "type": "Array"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1956": {
+      "name": "GPIB Misc",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "command string",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "output string",
+          "type": "String"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "status",
+          "type": "Array"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1957": {
+      "name": "GPIB Initialization",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "require re-addressing (T)",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "disallow DMA (F)",
+          "type": "Boolean"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "assert REN with IFC (T)",
+          "type": "Boolean"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "IST bit sense (T)",
+          "type": "Boolean"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "address string",
+          "type": "String"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "system controller (T)",
+          "type": "Boolean"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1958": {
+      "name": "GPIB Wait",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "status",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "timeout ms (488.2 global)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "wait state vector",
+          "type": "Array"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "address string",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1959": {
+      "name": "GPIB Status",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "address string",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "status",
+          "type": "Array"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "GPIB error",
+          "type": "NumInt16"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "byte count",
+          "type": "NumInt32"
+        },
+        {
+          "index": 5,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1960": {
+      "name": "AllSpoll",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "bus",
+          "type": "NumInt32"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "address list",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "serial poll byte list",
+          "type": "Array"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "status",
+          "type": "Array"
+        },
+        {
+          "index": 5,
+          "direction": "out",
+          "name": "byte count",
+          "type": "NumInt32"
+        },
+        {
+          "index": 6,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1961": {
+      "name": "DevClear",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "status",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "address",
+          "type": "NumInt16"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "bus",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1962": {
+      "name": "DevClearList",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "status",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "address list",
+          "type": "Array"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "bus",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1963": {
+      "name": "EnableLocal",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "status",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "address list",
+          "type": "Array"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "bus",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1964": {
+      "name": "EnableRemote",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "status",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "address list",
+          "type": "Array"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "bus",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1965": {
+      "name": "FindLstn",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "number of listeners",
+          "type": "NumInt32"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "status",
+          "type": "Array"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "listener address list",
+          "type": "Array"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "limit",
+          "type": "NumInt16"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "address list",
+          "type": "Array"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "bus",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1966": {
+      "name": "FindRQS",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "bus",
+          "type": "NumInt32"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "address list",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "requester status byte",
+          "type": "NumInt16"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "status",
+          "type": "Array"
+        },
+        {
+          "index": 5,
+          "direction": "out",
+          "name": "requester index",
+          "type": "NumInt32"
+        },
+        {
+          "index": 6,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1967": {
+      "name": "MakeAddr",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "packed address",
+          "type": "NumInt16"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "secondary address",
+          "type": "NumInt16"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "primary address",
+          "type": "NumInt16"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1968": {
+      "name": "PassControl",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "status",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "address",
+          "type": "NumInt16"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "bus",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1969": {
+      "name": "PPoll",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "bus",
+          "type": "NumInt32"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "parallel poll byte",
+          "type": "NumInt16"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "status",
+          "type": "Array"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1970": {
+      "name": "PPollConfig",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "status",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "sense",
+          "type": "Boolean"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "dataline",
+          "type": "NumInt16"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "address",
+          "type": "NumInt16"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "bus",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1971": {
+      "name": "PPollUnconfig",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "status",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "address list",
+          "type": "Array"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "bus",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1972": {
+      "name": "RcvRespMsg",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "byte count",
+          "type": "NumInt32"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "status",
+          "type": "Array"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "data string",
+          "type": "String"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "count",
+          "type": "NumInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "mode",
+          "type": "NumInt16"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "bus",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1973": {
+      "name": "ReadStatus",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "status",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "serial poll response",
+          "type": "NumInt16"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "address",
+          "type": "NumInt16"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "bus",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1974": {
+      "name": "Receive",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "byte count",
+          "type": "NumInt32"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "status",
+          "type": "Array"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "data string",
+          "type": "String"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "count",
+          "type": "NumInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "mode",
+          "type": "NumInt16"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "address",
+          "type": "NumInt16"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "bus",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1975": {
+      "name": "ReceiveSetup",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "status",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "address",
+          "type": "NumInt16"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "bus",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1976": {
+      "name": "ResetSys",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "status",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "address list",
+          "type": "Array"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "bus",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1977": {
+      "name": "Send",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "bus",
+          "type": "NumInt32"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "address",
+          "type": "NumInt16"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "mode",
+          "type": "NumInt16"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "data string",
+          "type": "String"
+        },
+        {
+          "index": 5,
+          "direction": "out",
+          "name": "status",
+          "type": "Array"
+        },
+        {
+          "index": 6,
+          "direction": "out",
+          "name": "byte count",
+          "type": "NumInt32"
+        },
+        {
+          "index": 7,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1978": {
+      "name": "SendCmds",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "byte count",
+          "type": "NumInt32"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "status",
+          "type": "Array"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "command string",
+          "type": "String"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "bus",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1979": {
+      "name": "SendDataBytes",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "byte count",
+          "type": "NumInt32"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "status",
+          "type": "Array"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "data string",
+          "type": "String"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "mode",
+          "type": "NumInt16"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "bus",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1980": {
+      "name": "SendIFC",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "status",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "bus",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1981": {
+      "name": "SendList",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "bus",
+          "type": "NumInt32"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "address list",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "mode",
+          "type": "NumInt16"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "data string",
+          "type": "String"
+        },
+        {
+          "index": 5,
+          "direction": "out",
+          "name": "status",
+          "type": "Array"
+        },
+        {
+          "index": 6,
+          "direction": "out",
+          "name": "byte count",
+          "type": "NumInt32"
+        },
+        {
+          "index": 7,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1982": {
+      "name": "SendLLO",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "status",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "bus",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1983": {
+      "name": "SendSetup",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "status",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "address list",
+          "type": "Array"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "bus",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1984": {
+      "name": "SetRWLS",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "status",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "address list",
+          "type": "Array"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "bus",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1985": {
+      "name": "SetTimeOut",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "previous timeout",
+          "type": "NumInt32"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "new timeout (10000)",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1986": {
+      "name": "TestSRQ",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "bus",
+          "type": "NumInt32"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "SRQ",
+          "type": "Boolean"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "status",
+          "type": "Array"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1987": {
+      "name": "TestSys",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "bus",
+          "type": "NumInt32"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "address list",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "result list",
+          "type": "Array"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "status",
+          "type": "Array"
+        },
+        {
+          "index": 5,
+          "direction": "out",
+          "name": "failed devices",
+          "type": "NumInt32"
+        },
+        {
+          "index": 6,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1988": {
+      "name": "Trigger",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "status",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "address",
+          "type": "NumInt16"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "bus",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1989": {
+      "name": "TriggerList",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "status",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "address list",
+          "type": "Array"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "bus",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1990": {
+      "name": "WaitSRQ",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "bus",
+          "type": "NumInt32"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "SRQ",
+          "type": "Boolean"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "status",
+          "type": "Array"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1991": {
+      "name": "VISA Move In 32",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "data",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "address space (A16:  1)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "count",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "offset (0)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1992": {
+      "name": "VISA Move Out 32",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "address space (A16:  1)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "data",
+          "type": "Array"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "offset (0)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1993": {
+      "name": "VISA Lock",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "access key",
+          "type": "String"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "lock type (exclusive:  1)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "requested key",
+          "type": "String"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "timeout (0)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1994": {
+      "name": "VISA Unlock",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1995": {
+      "name": "VISA Peek 32",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "value",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "offset (0)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1996": {
+      "name": "VISA Poke 32",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "value (0)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "offset (0)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1997": {
+      "name": "VISA Mem Alloc",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "offset",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "size",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1998": {
+      "name": "VISA Mem Free",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "offset",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "1999": {
+      "name": "Call Chain",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "call chain",
+          "type": "Array"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025",
+      "note": "corrected from VI-Scripting nodes export (#59); codegen dropped pending re-derivation"
+    },
+    "2040": {
+      "name": "Concatenate Strings",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "concatenated string",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "string",
+          "type": "String"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "string",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2041": {
+      "name": "Build Array",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "appended array",
+          "type": "Array"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "element",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2042": {
+      "name": "Index Array",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "array",
+          "type": "Array"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "element",
+          "type": "Void"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "index",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2044": {
+      "name": "Array Subset",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "array",
+          "type": "Array"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "subarray",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "index",
+          "type": "NumInt32"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "length",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2045": {
+      "name": "Interleave 1D Arrays",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "interleaved array",
+          "type": "Array"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "array",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "array",
+          "type": "Array"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2046": {
+      "name": "Decimate 1D Array",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "array",
+          "type": "Array"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "decimated array",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "decimated array",
+          "type": "Array"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2047": {
+      "name": "Build Cluster Array",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "array of clusters",
+          "type": "Array"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "component element",
+          "type": "Void"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2048": {
+      "name": "Unbundle",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "cluster",
+          "type": "Cluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "element",
+          "type": "Void"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "element",
+          "type": "Void"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2049": {
+      "name": "Bundle",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "output cluster",
+          "type": "Cluster"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "cluster",
+          "type": "Cluster"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "element",
+          "type": "Void"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "element",
+          "type": "Void"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2050": {
+      "name": "Code Interface Node",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "input",
+          "type": "Void"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "output",
+          "type": "Void"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2053": {
+      "name": "Initialize Array",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "element",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "initialized array",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "dimension size",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2055": {
+      "name": "Reshape Array",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "array",
+          "type": "Array"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "output array",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "dimension size",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2056": {
+      "name": "Index & Bundle Cluster Array",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "array of clusters",
+          "type": "Array"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "component array",
+          "type": "Void"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2057": {
+      "name": "Bundle By Name",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "output cluster",
+          "type": "Cluster"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "input cluster",
+          "type": "Cluster"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "element",
+          "type": "Void"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2058": {
+      "name": "Unbundle By Name",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "input cluster",
+          "type": "Cluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "element",
+          "type": "Void"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2059": {
+      "name": "Convert Unit",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2060": {
+      "name": "Global Variable",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "",
+          "type": "Void"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2061": {
+      "name": "Local Variable",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "",
+          "type": "Void"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2062": {
+      "name": "Call Library Function Node",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "path in",
+          "type": "Path",
+          "hidden": true
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "path out",
+          "type": "Path",
+          "hidden": true
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "",
+          "type": "Void"
+        },
+        {
+          "index": 5,
+          "direction": "out",
+          "name": "",
+          "type": "Void"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2065": {
+      "name": "Register For Events",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "event registration refnum",
+          "type": "Refnum",
+          "refnum_type": "event_reg"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "event registration refnum",
+          "type": "Refnum",
+          "refnum_type": "event_reg"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "event source",
+          "type": "Void"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2066": {
+      "name": "Build Waveform",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "output waveform",
+          "type": "Waveform"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "waveform",
+          "type": "Waveform"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "Y",
+          "type": "Array"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2067": {
+      "name": "Get Waveform Components",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "waveform",
+          "type": "Waveform"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "Y",
+          "type": "Array"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2073": {
+      "name": "Create User Event",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/create-user-event.html",
+      "verified": true,
+      "placeholder": true,
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "user_event_data_type",
+          "type": "polymorphic"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error_in",
+          "type": "Cluster"
+        },
+        {
+          "index": 8,
+          "direction": "out",
+          "name": "user_event_out",
+          "type": "Refnum"
+        },
+        {
+          "index": 11,
+          "direction": "out",
+          "name": "error_out",
+          "type": "Cluster"
+        }
+      ],
+      "python_code": "pass",
+      "note": "Create User Event (NI Create User Event doc) -- user event data-type -> UserEvent refnum out (ref_type=UserEvent is the identity). Terminals from 'Graphical Test Runner - Main UI - .vi', 'WaveGen.vi'. Placeholder codegen."
+    },
+    "2074": {
+      "name": "Generate User Event",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "user event",
+          "type": "Refnum",
+          "refnum_type": "user_event"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "event data cluster",
+          "type": "Cluster"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "priority (normal)",
+          "type": "Enum32"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "user event out",
+          "type": "Refnum",
+          "refnum_type": "user_event"
+        },
+        {
+          "index": 5,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025",
+      "note": "corrected from VI-Scripting nodes export (#59); codegen dropped pending re-derivation"
+    },
+    "2075": {
+      "name": "Destroy User Event",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/destroy-user-event.html",
+      "verified": true,
+      "placeholder": true,
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "user_event",
+          "type": "Refnum"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error_in",
+          "type": "Cluster"
+        },
+        {
+          "index": 7,
+          "direction": "out",
+          "name": "error_out",
+          "type": "Cluster"
+        }
+      ],
+      "python_code": "pass",
+      "note": "Destroy User Event (NI Destroy User Event doc) -- UserEvent refnum + error in -> error out only (destroying invalidates the ref). Terminals from 'Graphical Test Runner - Main UI - .vi', 'Run Client.vi'. Placeholder codegen."
+    },
+    "2076": {
+      "name": "Unregister For Events",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/unregister-for-events.html",
+      "verified": false,
+      "placeholder": true,
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "event_reg_refnum",
+          "type": "Refnum"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error_in",
+          "type": "Cluster"
+        },
+        {
+          "index": 7,
+          "direction": "out",
+          "name": "error_out",
+          "type": "Cluster"
+        }
+      ],
+      "python_code": "pass",
+      "note": "Unregister For Events -- event registration refnum + error in -> error out only; matches NI Unregister For Events doc. Terminals from 'DAQmx AO.vi' (lv-flex-channel-examples). Placeholder codegen (no lvkit event-registration runtime yet)."
+    },
+    "2078": {
+      "name": "Register Event Callback",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "event callback refnum",
+          "type": "Refnum",
+          "refnum_type": "callback"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "event callback refnum",
+          "type": "Refnum",
+          "refnum_type": "callback"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "event source",
+          "type": "Void"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "VI Ref",
+          "type": "Void"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "User Parameter",
+          "type": "LVVariant"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2080": {
+      "name": "Scan From String",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "format string",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "input string",
+          "type": "String"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "remaining string",
+          "type": "String"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "initial scan location",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "offset past scan",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 6,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "default value 14",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 8,
+          "direction": "out",
+          "name": "output 7",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2081": {
+      "name": "Format Into String",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "format string",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "initial string",
+          "type": "String"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "resulting string",
+          "type": "String"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "input 6",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2082": {
+      "name": "Scan From File",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "format string",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "input file",
+          "type": "Refnum",
+          "refnum_type": "byte_stream"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "output file refnum",
+          "type": "Refnum",
+          "refnum_type": "byte_stream"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "default value 14",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 6,
+          "direction": "out",
+          "name": "output 7",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2083": {
+      "name": "Format Into File",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "format string",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "input file",
+          "type": "Path"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "output file refnum",
+          "type": "Refnum",
+          "refnum_type": "byte_stream"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "input 6",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2084": {
+      "name": "Static VI Reference",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "vi reference",
+          "type": "Refnum",
+          "refnum_type": "vi_server",
+          "class_id": 2,
+          "class_name": "VI"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2086": {
+      "name": "VISA USB Control In",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "value (0)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "index (0)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "request type",
+          "type": "NumInt16"
+        },
+        {
+          "index": 5,
+          "direction": "out",
+          "name": "read buffer",
+          "type": "Array"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "request",
+          "type": "NumInt16"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "length (0)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 9,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2087": {
+      "name": "VISA USB Control Out",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "value (0)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "index (0)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "request type",
+          "type": "NumInt16"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "request",
+          "type": "NumInt16"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "length (0)",
+          "type": "Array"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 8,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2091": {
+      "name": "VI Server Reference",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "This VI",
+          "type": "Refnum",
+          "refnum_type": "vi_server",
+          "class_id": 2,
+          "class_name": "VI"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2135": {
+      "name": "Flush Event Queue",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "event registration refnum",
+          "type": "Refnum",
+          "refnum_type": "event_reg"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "include static events? (T)",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "event type or object",
+          "type": "Enum32"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "oldest event time",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "keep most recent",
+          "type": "NumInt32"
+        },
+        {
+          "index": 6,
+          "direction": "out",
+          "name": "event reg refnum out",
+          "type": "Refnum",
+          "refnum_type": "event_reg"
+        },
+        {
+          "index": 7,
+          "direction": "out",
+          "name": "number of events discarded",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 8,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025",
+      "note": "corrected from VI-Scripting nodes export (#59); codegen dropped pending re-derivation"
+    },
+    "2140": {
+      "name": "VISA In 64",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "value",
+          "type": "NumUInt64"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "address space (A16:  1)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "offset (0)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2141": {
+      "name": "VISA Out 64",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "address space (A16:  1)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "value (0)",
+          "type": "NumUInt64"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "offset (0)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2142": {
+      "name": "VISA Peek 64",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "value",
+          "type": "NumUInt64"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "offset (0)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2143": {
+      "name": "VISA Poke 64",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "value (0)",
+          "type": "NumUInt64"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "offset (0)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2144": {
+      "name": "VISA Move In 64",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "data",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "address space (A16:  1)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "count",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "offset (0)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2145": {
+      "name": "VISA Move Out 64",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "address space (A16:  1)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "data",
+          "type": "Array"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "offset (0)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2146": {
+      "name": "VISA Memory Allocation Ex",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "offset",
+          "type": "NumUInt64"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "size",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2147": {
+      "name": "Merge Errors",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2150": {
+      "name": "TDMS Advanced Asynchronous Write (Data Ref)",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "tdms file out",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "auto delete reference? (T)",
+          "type": "Boolean"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "data reference",
+          "type": "Refnum",
+          "refnum_type": "data_value"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "tdms file",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2151": {
+      "name": "TDMS Advanced Asynchronous Read (Data Ref)",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "tdms file out",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "read process finished?",
+          "type": "Boolean"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "auto delete reference? (T)",
+          "type": "Boolean"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "data reference",
+          "type": "Refnum",
+          "refnum_type": "data_value"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "tdms file",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2152": {
+      "name": "TDMS Configure Asynchronous Writes (Data Ref)",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "tdms file out",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "timeout (5 s)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "max asynchronous writes (4)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "tdms file",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2153": {
+      "name": "TDMS Configure Asynchronous Reads (Data Ref)",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "tdms file out",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "timeout (5 s)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "total size (in bytes) (-1)",
+          "type": "NumInt64"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "max asynchronous reads (4)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "tdms file",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2154": {
+      "name": "TDMS Get Asynchronous Write Status (Data Ref)",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "number of pending writes",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "tdms file out",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "tdms file",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2155": {
+      "name": "TDMS Get Asynchronous Read Status (Data Ref)",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "number of pending reads",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "tdms file out",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "tdms file",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2156": {
+      "name": "TDMS In Memory Open",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "tdms file out",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "byte array or file path",
+          "type": "Array"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2157": {
+      "name": "TDMS In Memory Close",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "overwrite (F)",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "file path",
+          "type": "Path"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "tdms file",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2158": {
+      "name": "TDMS In Memory Read Bytes",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "data",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "tdms file out",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "byte count (-1: all)",
+          "type": "NumInt64"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "offset (0)",
+          "type": "NumInt64"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "tdms file",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2159": {
+      "name": "TDMS Delete Data",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "file path out",
+          "type": "Path"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "count (-1: all)",
+          "type": "NumInt64"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "keep empty group/channel? (T)",
+          "type": "Boolean"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "from (0: start)",
+          "type": "Enum16"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "channel name(s) in",
+          "type": "Array"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "group name in",
+          "type": "String"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "file path",
+          "type": "Path"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2200": {
+      "name": "Compound Arithmetic",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "result",
+          "type": "NumFloat64"
         },
         {
           "index": 1,
           "direction": "in",
           "name": "value",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "not_a_refnum": "not bool(in_1)"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/not-a-number-path-refnum.html",
-      "note": "Polymorphic variant of 1112 for Refnum type."
-    },
-    "1064": {
-      "name": "Not",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "not_x",
-          "type": "Boolean"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "x",
-          "type": "Boolean"
-        }
-      ],
-      "python_code": {
-        "not_x": "not in_1"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/not.html"
-    },
-    "1419": {
-      "name": "Build Path",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "appended path",
-          "type": "Path"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "name or relative path",
-          "type": "polymorphic"
+          "type": "NumFloat64"
         },
         {
           "index": 2,
           "direction": "in",
-          "name": "base path",
-          "type": "Path",
-          "default_value": "''"
+          "name": "value",
+          "type": "NumFloat64"
         }
       ],
-      "python_code": {
-        "_import": "from pathlib import Path as _Path",
-        "appended_path": "_Path(in_2) / in_1"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/build-path.html"
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
     },
-    "1303": {
-      "name": "Get Date/Time In Seconds",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "current_time",
-          "type": "MeasureData"
-        }
-      ],
-      "python_code": {
-        "_import": "import time",
-        "current_time": "time.time()"
-      },
-      "imports": [
-        "import time"
-      ],
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/get-date-time-in-seconds.html"
-    },
-    "1420": {
-      "name": "Strip Path",
+    "2201": {
+      "name": "Expression Node",
       "terminals": [
         {
           "index": 0,
           "direction": "in",
-          "name": "path",
-          "type": "Path"
+          "name": "",
+          "type": "NumFloat64"
         },
         {
           "index": 1,
           "direction": "out",
-          "name": "stripped path",
-          "type": "Path"
+          "name": "",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2250": {
+      "name": "Generate User-Defined Trace Event",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "trace integer",
+          "type": "NumInt32"
         },
         {
-          "index": 2,
-          "direction": "out",
-          "name": "name",
+          "index": 1,
+          "direction": "in",
+          "name": "trace string",
           "type": "String"
         }
       ],
-      "python_code": {
-        "_import": "from pathlib import Path as _Path",
-        "stripped_path": "_Path(in_0).parent",
-        "name": "_Path(in_0).name"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/strip-path.html"
-    },
-    "1426": {
-      "name": "Current VI's Path",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "path",
-          "type": "Path"
-        }
-      ],
-      "python_code": {
-        "_import": "from pathlib import Path as _Path",
-        "path": "_Path(__file__)"
-      },
-      "inline": true,
       "verified": false,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/current-vi-s-path.html"
+      "source": "vi-scripting-nodes-lv2025"
     },
-    "1302": {
-      "name": "Wait (ms)",
+    "2300": {
+      "name": "VISA Refnum to Session",
       "terminals": [
         {
           "index": 0,
           "direction": "out",
-          "name": "millisecond_timer_value",
+          "name": "session",
           "type": "NumUInt32"
         },
         {
           "index": 1,
           "direction": "in",
-          "name": "milliseconds_to_wait",
+          "name": "Visa Refnum",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2301": {
+      "name": "VISA Set I/O Buffer Size",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "size (4096)",
           "type": "NumUInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "mask (16)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2302": {
+      "name": "VISA Flush I/O Buffer",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "mask (16)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2303": {
+      "name": "VISA Move",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "source space (A16:  1)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "source width (8)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "source offset (0)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "length",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "dest offset (0)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "dest space (A16:  1)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 9,
+          "direction": "in",
+          "name": "dest width (same as source)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 10,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2304": {
+      "name": "VISA GPIB Control REN",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "mode",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2305": {
+      "name": "VISA VXI Cmd or Query",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "response",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "command",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "mode (x200: 16-bit cmd)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2306": {
+      "name": "Refnum to Session",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "Session",
+          "type": "NumUInt64"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in(no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "Refnum",
+          "type": "Refnum",
+          "refnum_type": "ivi"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2307": {
+      "name": "Session to Refnum",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "Refnum",
+          "type": "Refnum",
+          "refnum_type": "ivi"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in(no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "Session",
+          "type": "NumUInt64"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "Class Type",
+          "type": "Refnum",
+          "refnum_type": "ivi"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2308": {
+      "name": "VISA Open",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "timeout (0)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "access mode",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "duplicate session (F)",
+          "type": "Boolean"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2309": {
+      "name": "VISA Assert Interrupt Signal",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "status ID",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "mode",
+          "type": "NumInt16"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2310": {
+      "name": "VISA Assert Utility Signal",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "bus signal",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2311": {
+      "name": "VISA Map Trigger",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "mode",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "trigger destination",
+          "type": "NumInt16"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "trigger source",
+          "type": "NumInt16"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2312": {
+      "name": "VISA Unmap Trigger",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "trigger destination (all)",
+          "type": "NumInt16"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "trigger source",
+          "type": "NumInt16"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2313": {
+      "name": "VISA Read To File",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "return count",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "byte count",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "filename",
+          "type": "Path"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2314": {
+      "name": "VISA Write From File",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "return count",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "count (entire file)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "filename",
+          "type": "Path"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2315": {
+      "name": "VISA GPIB Command",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "return count",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "command",
+          "type": "String"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2316": {
+      "name": "VISA GPIB Control ATN",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "mode",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2317": {
+      "name": "VISA GPIB Pass Control",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "secondary address (none)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "primary address",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2318": {
+      "name": "VISA GPIB Send IFC",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "VISA resource name out",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "VISA resource name",
+          "type": "Refnum",
+          "refnum_type": "visa"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2319": {
+      "name": "Register Session",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "duplicate refnum",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "cleanup mode (default to class = 0)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "session",
+          "type": "NumUInt64"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "resource name",
+          "type": "String"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "refnum",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2320": {
+      "name": "Unregister Session",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "refnum",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2322": {
+      "name": "FPGA Refnum to Session",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "Session",
+          "type": "NumUInt64"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in(no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "Refnum",
+          "type": "Refnum",
+          "refnum_type": "ivi"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2350": {
+      "name": "Merge Signals",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "combined signal",
+          "type": "ExpressData"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "input signal",
+          "type": "ExpressData"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "input signal",
+          "type": "ExpressData"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2351": {
+      "name": "Split Signals",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "combined signal",
+          "type": "ExpressData"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "output signal",
+          "type": "ExpressData"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "combined signal",
+          "type": "ExpressData",
+          "hidden": true
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2353": {
+      "name": "Feedback Node",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "",
+          "type": "Void"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "",
+          "type": "Void"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "",
+          "type": "Void"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2354": {
+      "name": "Call Parent Class Method",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "",
+          "type": "Void"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2372": {
+      "name": "Unknown",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2400": {
+      "name": "Always Copy",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "Output",
+          "type": "NumInt32"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "Input",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2401": {
+      "name": "Swap Values",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": " y'",
+          "type": "NumInt32"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": " x'  ",
+          "type": "NumInt32"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "y",
+          "type": "NumInt32"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "?(T)",
+          "type": "Boolean"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "x",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025",
+      "note": "corrected from VI-Scripting nodes export (#59); codegen dropped pending re-derivation"
+    },
+    "2402": {
+      "name": "Coerce To Type",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloatExt"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "type",
+          "type": "NumFloatExt"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "coerced x",
+          "type": "NumFloatExt"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025",
+      "note": "corrected from VI-Scripting nodes export (#59); codegen dropped pending re-derivation"
+    },
+    "2403": {
+      "name": "IsDebuggingActive",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "debugging?",
+          "type": "Boolean"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2408": {
+      "name": "New Data Value Reference",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/new-data-value-reference.html",
+      "terminals": [
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error_in",
+          "type": "cluster"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "data_value",
+          "type": "polymorphic"
+        },
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error_out",
+          "type": "cluster"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "data_value_reference",
+          "type": "Refnum"
         }
       ],
       "python_code": {
-        "_import": "import time",
-        "_body": "time.sleep(in_1 / 1000)",
-        "millisecond_timer_value": "0"
+        "data_value_reference": "[in_7]",
+        "error_out": "in_4"
       },
-      "imports": [
-        "import time"
+      "inline": true,
+      "verified": false,
+      "note": "New Data Value Reference -- identity from ref_type=DataValueRef on the out#3 refnum; every call site is a *_New.vi LVOOP constructor. python_code models the DVR as a 1-element list and is PROVISIONAL (belongs with the lvkit runtime decision)."
+    },
+    "2409": {
+      "name": "Delete Data Value Reference",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "data value",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "data value reference",
+          "type": "Refnum",
+          "refnum_type": "data_value"
+        }
       ],
-      "inline": false,
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2410": {
+      "name": "Leak Variant Value Reference",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "variant value ref out",
+          "type": "Refnum",
+          "refnum_type": "data_value"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "variant value ref in",
+          "type": "Refnum",
+          "refnum_type": "data_value"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2411": {
+      "name": "Unleak Variant Value Reference",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "variant value reference out",
+          "type": "Refnum",
+          "refnum_type": "data_value"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "variant value reference in",
+          "type": "Refnum",
+          "refnum_type": "data_value"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2412": {
+      "name": "ArrayMemInfo",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "mem info out",
+          "type": "Cluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "array out",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "array in",
+          "type": "Array"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2413": {
+      "name": "To Probe String",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "probe string",
+          "type": "String"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "maximum string length",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "data value",
+          "type": "LVVariant"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2414": {
+      "name": "Type Of",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "type",
+          "type": "LVVariant"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "any",
+          "type": "LVVariant"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2415": {
+      "name": "Type Error",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "bool const",
+          "type": "Boolean"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2416": {
+      "name": "Assert Structural Type Match",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "reference",
+          "type": "LVVariant"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "anything",
+          "type": "LVVariant"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2417": {
+      "name": "Type Must Be Array",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "any",
+          "type": "LVVariant"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2418": {
+      "name": "Type Must Be Cluster",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "any",
+          "type": "LVVariant"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2450": {
+      "name": "Collection Size",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "size",
+          "type": "NumInt32"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "collection",
+          "type": "SetCollection"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2451": {
+      "name": "Empty Collection?",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "empty?",
+          "type": "Boolean"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "collection",
+          "type": "SetCollection"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2452": {
+      "name": "Insert Into Set",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "already included?",
+          "type": "Boolean"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "set out",
+          "type": "SetCollection"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "element",
+          "type": "String"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "set in",
+          "type": "SetCollection"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2453": {
+      "name": "Remove From Set",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "not included?",
+          "type": "Boolean"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "set out",
+          "type": "SetCollection"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "element",
+          "type": "String"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "set in",
+          "type": "SetCollection"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2454": {
+      "name": "Element of Set?",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "found?",
+          "type": "Boolean"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "element",
+          "type": "String"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "set",
+          "type": "SetCollection"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2455": {
+      "name": "Read Set Max & Min",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "minimum",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "maximum",
+          "type": "String"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "set",
+          "type": "SetCollection"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2456": {
+      "name": "Insert Into Map",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "value unchanged?",
+          "type": "Boolean"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "key already included?",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "map out",
+          "type": "MapCollection"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "value",
+          "type": "NumInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "key",
+          "type": "String"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "map in",
+          "type": "MapCollection"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2457": {
+      "name": "Remove From Map",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "value",
+          "type": "NumInt32"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "key not found?",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "map out",
+          "type": "MapCollection"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "key",
+          "type": "String"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "map in",
+          "type": "MapCollection"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2458": {
+      "name": "Look In Map",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "value",
+          "type": "NumInt32"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "key not found?",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "default value",
+          "type": "NumInt32"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "key",
+          "type": "String"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "map",
+          "type": "MapCollection"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2459": {
+      "name": "Read Map Max & Min Keys",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "minimum",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "maximum",
+          "type": "String"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "map",
+          "type": "MapCollection"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2462": {
+      "name": "Build Set",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "set",
+          "type": "SetCollection"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "element",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2463": {
+      "name": "Build Map",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "map",
+          "type": "MapCollection"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "key",
+          "type": "String"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "value",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "2464": {
+      "name": "Assert Structural Type Mismatch",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "mismatch",
+          "type": "NumInt32",
+          "hidden": true
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "type",
+          "type": "LVVariant"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "mismatch",
+          "type": "LVVariant"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "3135": {
+      "name": "Bitpack to Array",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "bparray",
+          "type": "Array"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "data",
+          "type": "Cluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "3136": {
+      "name": "Unbitpack from Array",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "data",
+          "type": "Cluster"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "type",
+          "type": "Cluster"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "bparray",
+          "type": "Array"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "3900": {
+      "name": "Invoke Node",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "reference",
+          "type": "Refnum",
+          "refnum_type": "vi_server",
+          "class_id": 1,
+          "class_name": "Application"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "reference out",
+          "type": "Refnum",
+          "refnum_type": "vi_server",
+          "class_id": 1,
+          "class_name": "Application"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "Method",
+          "type": "Void"
+        },
+        {
+          "index": 5,
+          "direction": "out",
+          "name": "Method",
+          "type": "Void"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "3901": {
+      "name": "Call By Reference",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "reference",
+          "type": "Refnum",
+          "refnum_type": "vi_server",
+          "class_id": 2,
+          "class_name": "VI"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "reference out",
+          "type": "Refnum",
+          "refnum_type": "vi_server",
+          "class_id": 2,
+          "class_name": "VI"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "3904": {
+      "name": "Constructor Node",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "new reference",
+          "type": "Refnum",
+          "refnum_type": "dot_net"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "3910": {
+      "name": "Replace Array Subset",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "array",
+          "type": "Array"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "output array",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "new element/subarray",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "index",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "3911": {
+      "name": "Insert Into Array",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "array",
+          "type": "Array"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "output array",
+          "type": "Void"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "index",
+          "type": "NumInt32"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "new element/subarray",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "3912": {
+      "name": "Delete From Array",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "deleted portion",
+          "type": "Void"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "array",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "length",
+          "type": "NumInt32"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "array w/ subset deleted",
+          "type": "Void"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "index",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "3913": {
+      "name": "Replace Substring",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "replaced substring",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "result string",
+          "type": "String"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "length",
+          "type": "NumInt32"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "offset",
+          "type": "NumInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "substring",
+          "type": "String"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "string",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "3914": {
+      "name": "Search and Replace String",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "input string",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "replace all?",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "case sensitive?",
+          "type": "Boolean"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "multiline?",
+          "type": "Boolean",
+          "hidden": true
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "result string",
+          "type": "String"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "search string",
+          "type": "String"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "replace string",
+          "type": "String"
+        },
+        {
+          "index": 7,
+          "direction": "out",
+          "name": "number of replacements",
+          "type": "NumInt32"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "offset",
+          "type": "NumInt32"
+        },
+        {
+          "index": 9,
+          "direction": "out",
+          "name": "offset past replacement",
+          "type": "NumInt32"
+        },
+        {
+          "index": 10,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 11,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025",
+      "note": "corrected from VI-Scripting nodes export (#59); codegen dropped pending re-derivation"
+    },
+    "3915": {
+      "name": "Add",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "x+y",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "y",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "3916": {
+      "name": "Subtract",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "x-y",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "y",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "3917": {
+      "name": "Multiply",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "x*y",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "y",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "3918": {
+      "name": "Divide",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "x/y",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "y",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "5560": {
+      "name": "To Time Stamp",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "Time Stamp",
+          "type": "Timestamp"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "number",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "5561": {
+      "name": "To Fixed-Point",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "number",
+          "type": "FixedPoint"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "fixed-point type",
+          "type": "FixedPoint"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "fixed-point",
+          "type": "FixedPoint"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "5562": {
+      "name": "Clear Fixed-Point Overflow Status",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "overflow?",
+          "type": "Boolean"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "FXP with overflow cleared",
+          "type": "FixedPoint"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "FXP",
+          "type": "FixedPoint"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "5563": {
+      "name": "Remove Fixed-Point Overflow Status",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "overflow?",
+          "type": "Boolean"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "FXP with overflow removed",
+          "type": "FixedPoint"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "FXP",
+          "type": "FixedPoint"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "5564": {
+      "name": "Include Fixed-Point Overflow Status",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "FXP with overflow included",
+          "type": "FixedPoint"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "overflow",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "FXP",
+          "type": "FixedPoint"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "5565": {
+      "name": "Fixed-Point Overflowed?",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "overflow?",
+          "type": "Boolean"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "FXP",
+          "type": "FixedPoint"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "5566": {
+      "name": "Fixed-Point to Integer Cast",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "integer",
+          "type": "NumInt32"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "fixed-point",
+          "type": "FixedPoint"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "5567": {
+      "name": "Integer to Fixed-Point Cast",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "integer",
+          "type": "NumInt32"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "fixed-point type",
+          "type": "FixedPoint"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "fixed-point",
+          "type": "FixedPoint"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "5690": {
+      "name": "Dynamic FPGA Interface Cast",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "Type",
+          "type": "Refnum",
+          "refnum_type": "generic_class"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "Session In",
+          "type": "Refnum",
+          "refnum_type": "generic_class"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "Session Out",
+          "type": "Refnum",
+          "refnum_type": "generic_class"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "5691": {
+      "name": "Open Dynamic Bitfile Reference",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "Device address",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "Bitfile path",
+          "type": "Path"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "Run When Loaded",
+          "type": "Boolean"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "Error In",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "Type",
+          "type": "Refnum",
+          "refnum_type": "generic_class"
+        },
+        {
+          "index": 5,
+          "direction": "out",
+          "name": "Refnum",
+          "type": "Refnum",
+          "refnum_type": "generic_class"
+        },
+        {
+          "index": 6,
+          "direction": "out",
+          "name": "Error Out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "8000": {
+      "name": "Automation Open",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "Automation Refnum",
+          "type": "Refnum",
+          "refnum_type": "auto"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "",
+          "type": "Boolean"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "machine name",
+          "type": "String"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "Automation Refnum",
+          "type": "Refnum",
+          "refnum_type": "auto"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "8001": {
+      "name": "Automation Close",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "error in(no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "Automation Refnum",
+          "type": "Refnum",
+          "refnum_type": "auto"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "8002": {
+      "name": "To OLE Variant",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "x",
+          "type": "LVVariant"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "vt VARTYPE",
+          "type": "NumInt32"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "OLE Variant",
+          "type": "LVVariant"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "8003": {
+      "name": "Variant To Data",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "error in",
+          "type": "cluster"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "error out",
+          "type": "cluster"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "variant",
+          "type": "polymorphic"
+        },
+        {
+          "index": 9,
+          "direction": "in",
+          "name": "type",
+          "type": "polymorphic"
+        },
+        {
+          "index": 11,
+          "direction": "out",
+          "name": "data",
+          "type": "polymorphic"
+        }
+      ],
+      "python_code": {
+        "data": "in_8"
+      },
+      "inline": true,
       "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/wait-ms.html"
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/variant-to-data.html",
+      "note": "primResID 8003 is file I/O range but this instance has variant terminals. Variant To Data confirmed by terminal signature and PDF."
     },
     "8010": {
       "name": "Open VI Reference",
@@ -2491,1205 +16251,372 @@
       "verified": false,
       "note": "Close Reference (renamed from a mislabelled 'Close File') -- in#11 accepts Array|Refnum; all call sites are VI-server/appcontrol. Placeholder codegen (no lvkit VI-server runtime yet)."
     },
-    "9111": {
-      "name": "Enqueue Element",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/enqueue-element.html",
-      "verified": true,
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "in",
-          "name": "queue",
-          "type": "Refnum"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "element",
-          "type": "Cluster"
-        },
-        {
-          "index": 2,
-          "direction": "in",
-          "name": "timeout_ms",
-          "type": "NumInt32"
-        },
-        {
-          "index": 3,
-          "direction": "in",
-          "name": "error_in",
-          "type": "Cluster"
-        },
-        {
-          "index": 8,
-          "direction": "out",
-          "name": "queue_out",
-          "type": "Refnum"
-        },
-        {
-          "index": 10,
-          "direction": "out",
-          "name": "timed_out",
-          "type": "Boolean"
-        },
-        {
-          "index": 11,
-          "direction": "out",
-          "name": "error_out",
-          "type": "Cluster"
-        }
-      ],
-      "python_code": {
-        "_body": "raise RuntimeError('Enqueue Element (9111) should be dispatched to codegen/nodes/queue_ops.py by primResID -- this stub should be unreachable')"
-      },
-      "note": "Queue op. Handled by codegen/nodes/queue_ops.py (dispatched by primResID, not this template) -- calls lvkit.labview_queue.enqueue_element()."
-    },
-    "9113": {
-      "name": "Dequeue Element",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/dequeue-element.html",
-      "verified": true,
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "in",
-          "name": "queue",
-          "type": "Refnum"
-        },
-        {
-          "index": 2,
-          "direction": "in",
-          "name": "timeout_ms",
-          "type": "NumInt32"
-        },
-        {
-          "index": 3,
-          "direction": "in",
-          "name": "error_in",
-          "type": "Cluster"
-        },
-        {
-          "index": 8,
-          "direction": "out",
-          "name": "queue_out",
-          "type": "Refnum"
-        },
-        {
-          "index": 9,
-          "direction": "out",
-          "name": "element",
-          "type": "Cluster"
-        },
-        {
-          "index": 10,
-          "direction": "out",
-          "name": "timed_out",
-          "type": "Boolean"
-        },
-        {
-          "index": 11,
-          "direction": "out",
-          "name": "error_out",
-          "type": "Cluster"
-        }
-      ],
-      "python_code": {
-        "_body": "raise RuntimeError('Dequeue Element (9113) should be dispatched to codegen/nodes/queue_ops.py by primResID -- this stub should be unreachable')"
-      },
-      "note": "Queue op. Handled by codegen/nodes/queue_ops.py (dispatched by primResID, not this template) -- calls lvkit.labview_queue.dequeue_element()."
-    },
-    "9129": {
-      "name": "Enqueue Element At Opposite End",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/enqueue-element-at-opposite-end.html",
-      "verified": true,
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "in",
-          "name": "queue",
-          "type": "Refnum"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "element",
-          "type": "Cluster"
-        },
-        {
-          "index": 2,
-          "direction": "in",
-          "name": "timeout_ms",
-          "type": "NumInt32"
-        },
-        {
-          "index": 3,
-          "direction": "in",
-          "name": "error_in",
-          "type": "Cluster"
-        },
-        {
-          "index": 8,
-          "direction": "out",
-          "name": "queue_out",
-          "type": "Refnum"
-        },
-        {
-          "index": 10,
-          "direction": "out",
-          "name": "timed_out",
-          "type": "Boolean"
-        },
-        {
-          "index": 11,
-          "direction": "out",
-          "name": "error_out",
-          "type": "Cluster"
-        }
-      ],
-      "python_code": {
-        "_body": "raise RuntimeError('Enqueue Element At Opposite End (9129) should be dispatched to codegen/nodes/queue_ops.py by primResID -- this stub should be unreachable')"
-      },
-      "note": "Queue op (LIFO push for the parser stack). Handled by codegen/nodes/queue_ops.py -> lvkit.labview_queue.enqueue_element_at_opposite_end()."
-    },
-    "9108": {
-      "name": "Obtain Queue",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/obtain-queue.html",
-      "verified": true,
-      "terminals": [
-        {
-          "index": 4,
-          "direction": "in",
-          "name": "max_queue_size",
-          "type": "NumInt32"
-        },
-        {
-          "index": 0,
-          "direction": "in",
-          "name": "name",
-          "type": "String"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "element_data_type",
-          "type": "Cluster"
-        },
-        {
-          "index": 2,
-          "direction": "in",
-          "name": "create_if_not_found",
-          "type": "Boolean"
-        },
-        {
-          "index": 3,
-          "direction": "in",
-          "name": "error_in",
-          "type": "Cluster"
-        },
-        {
-          "index": 8,
-          "direction": "out",
-          "name": "queue_out",
-          "type": "Refnum"
-        },
-        {
-          "index": 10,
-          "direction": "out",
-          "name": "created",
-          "type": "Boolean"
-        },
-        {
-          "index": 11,
-          "direction": "out",
-          "name": "error_out",
-          "type": "Cluster"
-        }
-      ],
-      "python_code": {
-        "_body": "raise RuntimeError('Obtain Queue (9108) should be dispatched to codegen/nodes/queue_ops.py by primResID -- this stub should be unreachable')"
-      },
-      "note": "Queue op (ref_type=Queue on idx8). Handled by codegen/nodes/queue_ops.py (dispatched by primResID, not this template) -- calls lvkit.labview_queue.obtain_queue()."
-    },
-    "9109": {
-      "name": "Release Queue",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/release-queue.html",
-      "verified": true,
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "in",
-          "name": "queue",
-          "type": "Refnum"
-        },
-        {
-          "index": 2,
-          "direction": "in",
-          "name": "force_destroy",
-          "type": "Boolean"
-        },
-        {
-          "index": 3,
-          "direction": "in",
-          "name": "error_in",
-          "type": "Cluster"
-        },
-        {
-          "index": 8,
-          "direction": "out",
-          "name": "queue_name",
-          "type": "String"
-        },
-        {
-          "index": 9,
-          "direction": "out",
-          "name": "remaining_elements",
-          "type": "Array"
-        },
-        {
-          "index": 11,
-          "direction": "out",
-          "name": "error_out",
-          "type": "Cluster"
-        }
-      ],
-      "placeholder": true,
-      "python_code": "pass",
-      "note": "Release Queue (NI Release Queue doc; corrected from a mislabeled 'Get Queue Status') -- 6-terminal pane with no queue_out output (releasing invalidates the ref), distinct from Get Queue Status/9110."
-    },
-    "9101": {
-      "name": "Obtain Notifier",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/obtain-notifier.html",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "in",
-          "name": "name",
-          "type": "String"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "element_data_type",
-          "type": "Boolean"
-        },
-        {
-          "index": 2,
-          "direction": "in",
-          "name": "create_if_not_found",
-          "type": "Boolean"
-        },
-        {
-          "index": 3,
-          "direction": "in",
-          "name": "error_in",
-          "type": "cluster"
-        },
-        {
-          "index": 8,
-          "direction": "out",
-          "name": "notifier_out",
-          "type": "Refnum"
-        },
-        {
-          "index": 10,
-          "direction": "out",
-          "name": "created_new",
-          "type": "Boolean"
-        },
-        {
-          "index": 11,
-          "direction": "out",
-          "name": "error_out",
-          "type": "cluster"
-        }
-      ],
-      "placeholder": true,
-      "python_code": "pass",
-      "verified": false,
-      "note": "Obtain Notifier -- Notifier family (ref_type=NotifierRef is the identity); lifecycle 9101 obtain -> 9104 send -> 9105 wait -> 9102 release, confirmed in VI-Tester. Placeholder codegen (no lvkit notifier runtime yet)."
-    },
-    "9102": {
-      "name": "Release Notifier",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/release-notifier.html",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "in",
-          "name": "notifier",
-          "type": "Refnum"
-        },
-        {
-          "index": 2,
-          "direction": "in",
-          "name": "force_destroy",
-          "type": "Boolean"
-        },
-        {
-          "index": 3,
-          "direction": "in",
-          "name": "error_in",
-          "type": "cluster"
-        },
-        {
-          "index": 8,
-          "direction": "out",
-          "name": "notifier_name",
-          "type": "String"
-        },
-        {
-          "index": 9,
-          "direction": "out",
-          "name": "last_notification",
-          "type": "Boolean"
-        },
-        {
-          "index": 11,
-          "direction": "out",
-          "name": "error_out",
-          "type": "cluster"
-        }
-      ],
-      "placeholder": true,
-      "python_code": "pass",
-      "verified": false,
-      "note": "Release Notifier -- Notifier family (ref_type=NotifierRef is the identity); lifecycle 9101 obtain -> 9104 send -> 9105 wait -> 9102 release, confirmed in VI-Tester. Placeholder codegen (no lvkit notifier runtime yet)."
-    },
-    "9105": {
-      "name": "Wait on Notification",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/wait-on-notification.html",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "in",
-          "name": "notifier",
-          "type": "Refnum"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "ignore_previous",
-          "type": "Boolean"
-        },
-        {
-          "index": 2,
-          "direction": "in",
-          "name": "timeout_ms",
-          "type": "NumInt32"
-        },
-        {
-          "index": 3,
-          "direction": "in",
-          "name": "error_in",
-          "type": "cluster"
-        },
-        {
-          "index": 8,
-          "direction": "out",
-          "name": "notifier_out",
-          "type": "Refnum"
-        },
-        {
-          "index": 9,
-          "direction": "out",
-          "name": "notification",
-          "type": "Boolean"
-        },
-        {
-          "index": 10,
-          "direction": "out",
-          "name": "timed_out",
-          "type": "Boolean"
-        },
-        {
-          "index": 11,
-          "direction": "out",
-          "name": "error_out",
-          "type": "cluster"
-        }
-      ],
-      "placeholder": true,
-      "python_code": "pass",
-      "verified": false,
-      "note": "Wait on Notification -- Notifier family (ref_type=NotifierRef is the identity); lifecycle 9101 obtain -> 9104 send -> 9105 wait -> 9102 release, confirmed in VI-Tester. Placeholder codegen (no lvkit notifier runtime yet)."
-    },
-    "9104": {
-      "name": "Send Notification",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/send-notification.html",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "in",
-          "name": "notifier",
-          "type": "Refnum"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "notification",
-          "type": "Boolean"
-        },
-        {
-          "index": 3,
-          "direction": "in",
-          "name": "error_in",
-          "type": "cluster"
-        },
-        {
-          "index": 8,
-          "direction": "out",
-          "name": "notifier_out",
-          "type": "Refnum"
-        },
-        {
-          "index": 11,
-          "direction": "out",
-          "name": "error_out",
-          "type": "cluster"
-        }
-      ],
-      "placeholder": true,
-      "python_code": "pass",
-      "verified": false,
-      "note": "Send Notification -- Notifier family (ref_type=NotifierRef is the identity); lifecycle 9101 obtain -> 9104 send -> 9105 wait -> 9102 release, confirmed in VI-Tester. Placeholder codegen (no lvkit notifier runtime yet)."
-    },
-    "8017": {
-      "name": "Preserve Run-Time Class",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "in",
-          "name": "target_object",
-          "type": "Refnum"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "object_in",
-          "type": "Refnum"
-        },
-        {
-          "index": 2,
-          "direction": "out",
-          "name": "object_out",
-          "type": "Refnum"
-        }
-      ],
-      "python_code": {
-        "object_out": "in_1"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/preserve-run-time-class.html"
-    },
-    "1118": {
-      "name": "Less Than 0?",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/less-than-0.html",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "result",
-          "type": "Boolean"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "x",
-          "type": "numeric"
-        }
-      ],
-      "python_code": {
-        "result": "in_1 < 0"
-      },
-      "inline": true,
-      "verified": true
-    },
-    "8018": {
-      "name": "To More Specific Class",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/to-more-specific-class.html",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "output_object",
-          "type": "Refnum"
-        },
-        {
-          "index": 1,
-          "direction": "out",
-          "name": "error_out",
-          "type": "Cluster"
-        },
-        {
-          "index": 2,
-          "direction": "in",
-          "name": "type_specifier",
-          "type": "Refnum"
-        },
-        {
-          "index": 3,
-          "direction": "in",
-          "name": "input_object",
-          "type": "Refnum"
-        },
-        {
-          "index": 4,
-          "direction": "in",
-          "name": "error_in",
-          "type": "Cluster"
-        }
-      ],
-      "python_code": {
-        "output_object": "in_3"
-      },
-      "inline": true,
-      "verified": true
-    },
-    "8003": {
-      "name": "Variant To Data",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "in",
-          "name": "error in",
-          "type": "cluster"
-        },
-        {
-          "index": 3,
-          "direction": "out",
-          "name": "error out",
-          "type": "cluster"
-        },
-        {
-          "index": 8,
-          "direction": "in",
-          "name": "variant",
-          "type": "polymorphic"
-        },
-        {
-          "index": 9,
-          "direction": "in",
-          "name": "type",
-          "type": "polymorphic"
-        },
-        {
-          "index": 11,
-          "direction": "out",
-          "name": "data",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "data": "in_8"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/variant-to-data.html",
-      "note": "primResID 8003 is file I/O range but this instance has variant terminals. Variant To Data confirmed by terminal signature and PDF."
-    },
-    "8100": {
-      "name": "Format Date/Time String",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "datetime_string",
-          "type": "String"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "utc_format",
-          "type": "Boolean"
-        },
-        {
-          "index": 2,
-          "direction": "in",
-          "name": "timestamp",
-          "type": "MeasureData"
-        },
-        {
-          "index": 3,
-          "direction": "in",
-          "name": "time_format_string",
-          "type": "String"
-        }
-      ],
-      "python_code": {
-        "datetime_string": "in_2.strftime(in_3) if in_3 else str(in_2)"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/format-date-time-string.html"
-    },
-    "8201": {
-      "name": "To Variant",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "variant",
-          "type": "polymorphic"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "anything",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "variant": "in_1"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/to-variant.html"
-    },
-    "1165": {
-      "name": "Flatten To String",
+    "8012": {
+      "name": "Open Application Reference",
       "terminals": [
         {
           "index": 0,
           "direction": "out",
           "name": "error out",
-          "type": "cluster"
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "application reference",
+          "type": "Refnum",
+          "refnum_type": "vi_server",
+          "class_id": 1,
+          "class_name": "Application"
         },
         {
           "index": 2,
-          "direction": "out",
-          "name": "type string length",
-          "type": "polymorphic"
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
         },
         {
           "index": 3,
+          "direction": "in",
+          "name": "",
+          "type": "NumInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "port number or service name (3363)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "machine name (\"\":  open local reference)",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "8013": {
+      "name": "Open VI Object Reference",
+      "terminals": [
+        {
+          "index": 0,
           "direction": "out",
-          "name": "data string",
-          "type": "polymorphic"
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "object refnum",
+          "type": "Refnum",
+          "refnum_type": "vi_server",
+          "class_id": 3,
+          "class_name": "Generic"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "vi object class",
+          "type": "Refnum",
+          "refnum_type": "vi_server",
+          "class_id": 3,
+          "class_name": "Generic"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "name/order",
+          "type": "String"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "owner refnum",
+          "type": "Refnum",
+          "refnum_type": "vi_server",
+          "class_id": 3,
+          "class_name": "Generic"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "8014": {
+      "name": "New VI",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "vi refnum",
+          "type": "Refnum",
+          "refnum_type": "vi_server",
+          "class_id": 2,
+          "class_name": "VI"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "type specifier VI Refnum (for type only)",
+          "type": "Refnum",
+          "refnum_type": "vi_server",
+          "class_id": 2,
+          "class_name": "VI"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "password",
+          "type": "String"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "not connected",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "vi type (standard vi)",
+          "type": "Enum32"
         },
         {
           "index": 7,
           "direction": "in",
-          "name": "type string length",
-          "type": "polymorphic"
+          "name": "template",
+          "type": "Path"
         },
         {
           "index": 8,
           "direction": "in",
-          "name": "error in",
-          "type": "cluster"
+          "name": "application refnum",
+          "type": "Refnum",
+          "refnum_type": "vi_server",
+          "class_id": 1,
+          "class_name": "Application"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "8015": {
+      "name": "New VI Object",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "object refnum",
+          "type": "Refnum",
+          "refnum_type": "vi_server",
+          "class_id": 3,
+          "class_name": "Generic"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "bounds",
+          "type": "Cluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "auto wire? (F)",
+          "type": "Boolean"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "path",
+          "type": "Path"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "vi object class",
+          "type": "Refnum",
+          "refnum_type": "vi_server",
+          "class_id": 3,
+          "class_name": "Generic"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "position/next to",
+          "type": "Cluster"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "style",
+          "type": "NumUInt32"
         },
         {
           "index": 9,
           "direction": "in",
-          "name": "byte order",
-          "type": "polymorphic"
-        },
-        {
-          "index": 10,
-          "direction": "in",
-          "name": "prepend array or string size",
-          "type": "polymorphic"
-        },
-        {
-          "index": 11,
-          "direction": "in",
-          "name": "anything",
-          "type": "polymorphic"
+          "name": "owner refnum",
+          "type": "Refnum",
+          "refnum_type": "vi_server",
+          "class_id": 3,
+          "class_name": "Generic"
         }
       ],
-      "python_code": {
-        "data_string": "str(in_11)"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/flatten-to-string.html"
-    },
-    "8205": {
-      "name": "Get Variant Attribute",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "error_out",
-          "type": "cluster"
-        },
-        {
-          "index": 1,
-          "direction": "out",
-          "name": "attribute_value",
-          "type": "polymorphic"
-        },
-        {
-          "index": 2,
-          "direction": "out",
-          "name": "found",
-          "type": "polymorphic"
-        },
-        {
-          "index": 3,
-          "direction": "out",
-          "name": "duplicate_variant",
-          "type": "polymorphic"
-        },
-        {
-          "index": 4,
-          "direction": "in",
-          "name": "error_in",
-          "type": "cluster"
-        },
-        {
-          "index": 5,
-          "direction": "in",
-          "name": "default_value",
-          "type": "polymorphic"
-        },
-        {
-          "index": 6,
-          "direction": "in",
-          "name": "attribute_name",
-          "type": "polymorphic"
-        },
-        {
-          "index": 7,
-          "direction": "in",
-          "name": "variant",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "attribute_value": "getattr(in_7, in_6, in_5)",
-        "found": "hasattr(in_7, in_6)"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/get-variant-attribute.html"
-    },
-    "8204": {
-      "name": "Delete Variant Attribute",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "error_out",
-          "type": "Cluster"
-        },
-        {
-          "index": 2,
-          "direction": "out",
-          "name": "found",
-          "type": "Boolean"
-        },
-        {
-          "index": 3,
-          "direction": "out",
-          "name": "variant_out",
-          "type": "LVVariant"
-        },
-        {
-          "index": 4,
-          "direction": "in",
-          "name": "error_in",
-          "type": "Cluster"
-        },
-        {
-          "index": 5,
-          "direction": "in",
-          "name": "variant",
-          "type": "LVVariant"
-        },
-        {
-          "index": 6,
-          "direction": "in",
-          "name": "name",
-          "type": "String"
-        }
-      ],
-      "python_code": {
-        "variant_out": "in_5",
-        "found": "hasattr(in_5, in_6)"
-      },
-      "inline": false,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/delete-variant-attribute.html"
-    },
-    "8202": {
-      "name": "Set Variant Attribute",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "error_out",
-          "type": "Cluster"
-        },
-        {
-          "index": 3,
-          "direction": "out",
-          "name": "variant_out",
-          "type": "LVVariant"
-        },
-        {
-          "index": 4,
-          "direction": "in",
-          "name": "error_in",
-          "type": "Cluster"
-        },
-        {
-          "index": 6,
-          "direction": "in",
-          "name": "name",
-          "type": "String"
-        },
-        {
-          "index": 7,
-          "direction": "in",
-          "name": "variant",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "variant_out": "setattr(in_7, in_6, None) or in_7"
-      },
-      "inline": false,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/set-variant-attribute.html"
-    },
-    "8203": {
-      "name": "Get Type Information",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "in",
-          "name": "variant",
-          "type": "LVVariant"
-        },
-        {
-          "index": 1,
-          "direction": "out",
-          "name": "type",
-          "type": "Array"
-        },
-        {
-          "index": 2,
-          "direction": "out",
-          "name": "name",
-          "type": "String"
-        }
-      ],
-      "python_code": {
-        "type": "[type(in_0).__name__]",
-        "name": "type(in_0).__name__"
-      },
-      "inline": true,
       "verified": false,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/vi-lib/utility/data-type/get-type-information-vi.html",
-      "note": "Get Type Information -- pane observed identical across all call-sites; indices corrected from an invalid idx -1. python_code is best-effort for variant type info, not execution-verified."
-    },
-    "23063": {
-      "name": "Empty Array?",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "empty",
-          "type": "Boolean"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "array",
-          "type": "Array"
-        }
-      ],
-      "python_code": {
-        "empty": "len(in_1) == 0"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/empty-array.html"
+      "source": "vi-scripting-nodes-lv2025"
     },
     "8016": {
+      "name": "To More Specific Class",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "specific class reference",
+          "type": "Refnum",
+          "refnum_type": "vi_server",
+          "class_id": 3,
+          "class_name": "Generic"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "target class",
+          "type": "Refnum",
+          "refnum_type": "vi_server",
+          "class_id": 3,
+          "class_name": "Generic"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "reference",
+          "type": "Refnum",
+          "refnum_type": "vi_server",
+          "class_id": 3,
+          "class_name": "Generic"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025",
+      "note": "corrected from VI-Scripting nodes export (#59); codegen dropped pending re-derivation"
+    },
+    "8017": {
       "name": "To More Generic Class",
       "terminals": [
         {
           "index": 0,
+          "direction": "in",
+          "name": "reference",
+          "type": "Refnum",
+          "refnum_type": "vi_server",
+          "class_id": 3,
+          "class_name": "Generic"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "target class",
+          "type": "Refnum",
+          "refnum_type": "vi_server",
+          "class_id": 3,
+          "class_name": "Generic"
+        },
+        {
+          "index": 2,
           "direction": "out",
-          "name": "output_object",
-          "type": "Refnum"
+          "name": "generic class reference",
+          "type": "Refnum",
+          "refnum_type": "vi_server",
+          "class_id": 3,
+          "class_name": "Generic"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025",
+      "note": "corrected from VI-Scripting nodes export (#59); codegen dropped pending re-derivation"
+    },
+    "8018": {
+      "name": "Preserve Run-Time Class",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "object out",
+          "type": "Polymorphic",
+          "note": "data_type was null in the VI-Scripting export"
         },
         {
           "index": 1,
           "direction": "out",
-          "name": "error_out",
-          "type": "Cluster"
+          "name": "error out",
+          "type": "ErrorCluster"
         },
         {
           "index": 2,
           "direction": "in",
-          "name": "input_object",
-          "type": "Refnum"
+          "name": "target object",
+          "type": "Polymorphic",
+          "note": "data_type was null in the VI-Scripting export"
         },
         {
           "index": 3,
           "direction": "in",
-          "name": "target_class",
-          "type": "Refnum"
+          "name": "object in",
+          "type": "Polymorphic",
+          "note": "data_type was null in the VI-Scripting export"
         },
         {
           "index": 4,
           "direction": "in",
-          "name": "error_in",
-          "type": "Cluster"
+          "name": "error in",
+          "type": "ErrorCluster"
         }
       ],
-      "python_code": {
-        "output_object": "in_2"
-      },
-      "inline": true,
-      "verified": true,
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/to-more-generic-class.html"
-    },
-    "1171": {
-      "name": "Join Numbers",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/join-numbers.html",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "number",
-          "type": "polymorphic"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "hi",
-          "type": "polymorphic"
-        },
-        {
-          "index": 2,
-          "direction": "in",
-          "name": "lo",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "number": "(in_1 << (in_2.bit_length() or 8)) | in_2"
-      },
-      "verified": false
-    },
-    "1127": {
-      "name": "In Range and Coerce",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/in-range-and-coerce.html",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "in range?",
-          "type": "Boolean"
-        },
-        {
-          "index": 1,
-          "direction": "out",
-          "name": "coerced value",
-          "type": "polymorphic"
-        },
-        {
-          "index": 2,
-          "direction": "in",
-          "name": "x",
-          "type": "polymorphic"
-        },
-        {
-          "index": 3,
-          "direction": "in",
-          "name": "upper limit",
-          "type": "polymorphic"
-        },
-        {
-          "index": 4,
-          "direction": "in",
-          "name": "lower limit",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "in range?": "in_4 <= in_2 <= in_3",
-        "coerced value": "max(in_4, min(in_3, in_2))"
-      },
-      "verified": false
-    },
-    "1906": {
-      "name": "Rotate 1D Array",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/rotate-1d-array.html",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "array (rotated)",
-          "type": "Array"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "array",
-          "type": "Array"
-        },
-        {
-          "index": 2,
-          "direction": "in",
-          "name": "n",
-          "type": "NumInt32"
-        }
-      ],
-      "python_code": {
-        "array (rotated)": "in_1[-in_2 % len(in_1):] + in_1[:-in_2 % len(in_1)] if in_1 else in_1"
-      },
-      "verified": false
-    },
-    "1814": {
-      "name": "Number To Boolean Array",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/number-to-boolean-array.html",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "boolean array",
-          "type": "Array"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "number",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "boolean array": "[bool((in_1 >> i) & 1) for i in range(in_1.bit_length() or 8)]"
-      },
-      "verified": false
-    },
-    "1815": {
-      "name": "Boolean Array To Number",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/boolean-array-to-number.html",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "number",
-          "type": "polymorphic"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "boolean array",
-          "type": "Array"
-        }
-      ],
-      "python_code": {
-        "number": "sum((1 << i) for i, b in enumerate(in_1) if b)"
-      },
-      "verified": false
-    },
-    "1223": {
-      "name": "Power Of 2",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/power-of-2.html",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "two_pow_x",
-          "type": "NumFloat64"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "x",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "two_pow_x": "2.0 ** in_1"
-      },
-      "verified": false
-    },
-    "1908": {
-      "name": "Split 1D Array",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/split-1d-array.html",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "first subarray",
-          "type": "polymorphic"
-        },
-        {
-          "index": 1,
-          "direction": "out",
-          "name": "second subarray",
-          "type": "polymorphic"
-        },
-        {
-          "index": 2,
-          "direction": "in",
-          "name": "index",
-          "type": "polymorphic"
-        },
-        {
-          "index": 3,
-          "direction": "in",
-          "name": "array",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "first subarray": "in_3[:in_2]",
-        "second subarray": "in_3[in_2:]"
-      },
-      "verified": false
-    },
-    "1162": {
-      "name": "Swap Bytes",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/swap-bytes.html",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "swapped",
-          "type": "polymorphic"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "data",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "swapped": "[((v & 0x00FF00FF) << 8) | ((v >> 8) & 0x00FF00FF) for v in in_1]"
-      },
-      "note": "Swap Bytes -- endianness op; chained 1162->1163 gives a full 32-bit byte-reversal (MD5 little-endian words). Bytes=1162/Words=1163 follows NI palette order. Polymorphic: Array[U32] + cluster.",
-      "verified": false
-    },
-    "1163": {
-      "name": "Swap Words",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/swap-words.html",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "swapped",
-          "type": "polymorphic"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "data",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "swapped": "[((v & 0xFFFF) << 16) | ((v >> 16) & 0xFFFF) for v in in_1]"
-      },
-      "note": "Swap Words -- endianness op; chained 1162->1163 gives a full 32-bit byte-reversal (MD5 little-endian words). Bytes=1162/Words=1163 follows NI palette order. Polymorphic: Array[U32] + cluster.",
-      "verified": false
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025",
+      "note": "corrected from VI-Scripting nodes export (#59); codegen dropped pending re-derivation"
     },
     "8050": {
       "name": "Open/Create/Replace File",
@@ -3755,42 +16682,6 @@
         "error_out": "in_8"
       },
       "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/open-create-replace-file.html",
-      "verified": false
-    },
-    "8052": {
-      "name": "Close File",
-      "terminals": [
-        {
-          "index": 4,
-          "direction": "in",
-          "name": "error_in",
-          "type": "cluster"
-        },
-        {
-          "index": 7,
-          "direction": "in",
-          "name": "refnum",
-          "type": "Refnum"
-        },
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "error_out",
-          "type": "cluster"
-        },
-        {
-          "index": 3,
-          "direction": "out",
-          "name": "path",
-          "type": "Path"
-        }
-      ],
-      "python_code": {
-        "path": "getattr(in_7, 'name', None)",
-        "error_out": "in_4"
-      },
-      "note": "runtime: in_7.close(); path output is the closed file's path",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/close-file.html",
       "verified": false
     },
     "8051": {
@@ -3866,19 +16757,49 @@
       "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/read-from-binary-file.html",
       "verified": false
     },
-    "8078": {
-      "name": "Write to Binary File",
+    "8052": {
+      "name": "Close File",
       "terminals": [
         {
-          "index": 5,
+          "index": 4,
           "direction": "in",
-          "name": "prepend_size",
-          "type": "Boolean"
+          "name": "error_in",
+          "type": "cluster"
         },
         {
           "index": 7,
           "direction": "in",
-          "name": "byte_order",
+          "name": "refnum",
+          "type": "Refnum"
+        },
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error_out",
+          "type": "cluster"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "path",
+          "type": "Path"
+        }
+      ],
+      "python_code": {
+        "path": "getattr(in_7, 'name', None)",
+        "error_out": "in_4"
+      },
+      "note": "runtime: in_7.close(); path output is the closed file's path",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/close-file.html",
+      "verified": false
+    },
+    "8053": {
+      "name": "Copy",
+      "terminals": [
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "prompt",
           "type": "String"
         },
         {
@@ -3890,20 +16811,20 @@
         {
           "index": 9,
           "direction": "in",
-          "name": "datalog_type",
-          "type": "enum"
+          "name": "overwrite",
+          "type": "Boolean"
         },
         {
           "index": 10,
           "direction": "in",
-          "name": "data",
-          "type": "String"
+          "name": "target_path",
+          "type": "Path"
         },
         {
           "index": 11,
           "direction": "in",
-          "name": "refnum",
-          "type": "Refnum"
+          "name": "source_path",
+          "type": "Path"
         },
         {
           "index": 0,
@@ -3914,50 +16835,162 @@
         {
           "index": 1,
           "direction": "out",
-          "name": "eof",
+          "name": "cancelled",
           "type": "Boolean"
         },
         {
           "index": 3,
           "direction": "out",
-          "name": "refnum_out",
-          "type": "Refnum"
+          "name": "new_path",
+          "type": "Path"
         }
       ],
       "python_code": {
-        "refnum_out": "(in_11.write(in_10), in_11)[1]",
-        "error_out": "in_8",
-        "eof": "False"
+        "new_path": "__import__('shutil').copy2(in_11, in_10)",
+        "cancelled": "False",
+        "error_out": "in_8"
       },
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/write-to-binary-file.html",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/copy.html",
       "verified": false
     },
-    "8073": {
-      "name": "Set File Position",
+    "8054": {
+      "name": "Open/Create/Replace Datalog",
       "terminals": [
         {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "cancelled",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "refnum out",
+          "type": "Refnum",
+          "refnum_type": "datalog"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "record type",
+          "type": "Cluster"
+        },
+        {
           "index": 4,
+          "direction": "in",
+          "name": "prompt",
+          "type": "String"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "access (0:read/write)",
+          "type": "Enum16"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "operation (0:open)",
+          "type": "Enum16"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "datalog path (use dialog)",
+          "type": "Path"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "8055": {
+      "name": "Create Folder",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "cancelled",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "created path",
+          "type": "Path"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "prompt (Create Folder)",
+          "type": "String"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "path (use dialog)",
+          "type": "Path"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "8056": {
+      "name": "Delete",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/delete.html",
+      "terminals": [
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "prompt",
+          "type": "String"
+        },
+        {
+          "index": 8,
           "direction": "in",
           "name": "error_in",
           "type": "cluster"
         },
         {
-          "index": 5,
+          "index": 9,
           "direction": "in",
-          "name": "from",
-          "type": "enum"
+          "name": "entire_hierarchy",
+          "type": "Boolean"
         },
         {
-          "index": 6,
+          "index": 10,
           "direction": "in",
-          "name": "offset",
-          "type": "NumInt64"
+          "name": "confirm",
+          "type": "Boolean"
         },
         {
-          "index": 7,
+          "index": 11,
           "direction": "in",
-          "name": "refnum",
-          "type": "Refnum"
+          "name": "path",
+          "type": "Path"
         },
         {
           "index": 0,
@@ -3966,18 +16999,216 @@
           "type": "cluster"
         },
         {
+          "index": 1,
+          "direction": "out",
+          "name": "cancelled",
+          "type": "Boolean"
+        },
+        {
           "index": 3,
           "direction": "out",
-          "name": "refnum_out",
-          "type": "Refnum"
+          "name": "path_out",
+          "type": "Path"
         }
       ],
       "python_code": {
-        "refnum_out": "(in_7.seek(in_6, in_5), in_7)[1]",
-        "error_out": "in_4"
+        "path_out": "in_11",
+        "cancelled": "False",
+        "error_out": "in_8"
       },
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/set-file-position.html",
+      "note": "Delete (NI Delete doc; renamed from a mislabelled 'File Dialog'). in#9/in#10 Boolean order (entire-hierarchy vs confirm) not disambiguated. python_code is a no-op placeholder, not execution-verified.",
       "verified": false
+    },
+    "8057": {
+      "name": "Deny Access",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "refnum out",
+          "type": "Refnum",
+          "refnum_type": "byte_stream"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "deny mode (0:deny read/write)",
+          "type": "Enum16"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "refnum",
+          "type": "Refnum",
+          "refnum_type": "byte_stream"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "8058": {
+      "name": "File Dialog",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/vi-lib/express/express-input/filedialogblock-llb/file-dialog-source-vi.html",
+      "terminals": [
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "prompt",
+          "type": "String"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "pattern_label",
+          "type": "String"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "patterns",
+          "type": "String"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "button_label",
+          "type": "String"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "error_in",
+          "type": "cluster"
+        },
+        {
+          "index": 9,
+          "direction": "in",
+          "name": "default_name",
+          "type": "String"
+        },
+        {
+          "index": 11,
+          "direction": "in",
+          "name": "start_path",
+          "type": "Path"
+        },
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error_out",
+          "type": "cluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "cancelled",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "exists",
+          "type": "Boolean"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "selected_path",
+          "type": "Path"
+        }
+      ],
+      "python_code": {
+        "selected_path": "in_11",
+        "cancelled": "False",
+        "exists": "__import__('os').path.exists(in_11)",
+        "error_out": "in_8"
+      },
+      "note": "File Dialog -- identified by pane signature (file-pattern + start path -> path + cancelled?/exists?). Express-VI doc page has no backend connector pane, so verify names if refining.",
+      "verified": false
+    },
+    "8059": {
+      "name": "Flush File",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "refnum out",
+          "type": "Refnum",
+          "refnum_type": "byte_stream"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "refnum",
+          "type": "Refnum",
+          "refnum_type": "byte_stream"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "8061": {
+      "name": "Get Datalog Position",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "offset (in records)",
+          "type": "NumInt64"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "refnum out",
+          "type": "Refnum",
+          "refnum_type": "datalog"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "refnum",
+          "type": "Refnum",
+          "refnum_type": "datalog"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
     },
     "8062": {
       "name": "Get File Position",
@@ -4063,21 +17294,48 @@
       "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/get-file-size.html",
       "verified": false
     },
-    "8083": {
-      "name": "List Folder",
+    "8064": {
+      "name": "Get Number of Records",
       "terminals": [
         {
-          "index": 5,
-          "direction": "in",
-          "name": "datalog_type",
-          "type": "NumInt32"
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
         },
         {
-          "index": 6,
-          "direction": "in",
-          "name": "pattern",
-          "type": "String"
+          "index": 1,
+          "direction": "out",
+          "name": "# of records",
+          "type": "NumInt64"
         },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "refnum out",
+          "type": "Refnum",
+          "refnum_type": "datalog"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "refnum",
+          "type": "Refnum",
+          "refnum_type": "datalog"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "8065": {
+      "name": "Get Permissions",
+      "terminals": [
         {
           "index": 8,
           "direction": "in",
@@ -4099,30 +17357,792 @@
         {
           "index": 1,
           "direction": "out",
-          "name": "file_names",
-          "type": "Array"
+          "name": "owner",
+          "type": "String"
         },
         {
           "index": 2,
           "direction": "out",
-          "name": "folder_names",
-          "type": "Array"
+          "name": "group",
+          "type": "String"
         },
         {
           "index": 3,
           "direction": "out",
           "name": "path_out",
           "type": "Path"
+        },
+        {
+          "index": 5,
+          "direction": "out",
+          "name": "permissions",
+          "type": "NumInt16"
         }
       ],
       "python_code": {
-        "file_names": "[e.name for e in __import__('os').scandir(in_11) if e.is_file()]",
-        "folder_names": "[e.name for e in __import__('os').scandir(in_11) if e.is_dir()]",
+        "permissions": "__import__('os').stat(in_11).st_mode & 0o777",
+        "owner": "''",
+        "group": "''",
         "path_out": "in_11",
         "error_out": "in_8"
       },
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/list-folder.html",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/get-permissions.html",
       "verified": false
+    },
+    "8066": {
+      "name": "Get Type and Creator",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "creator",
+          "type": "String"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "type",
+          "type": "String"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "path out",
+          "type": "Path"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "path",
+          "type": "Path"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "8067": {
+      "name": "Get Volume Info",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "free (bytes)",
+          "type": "NumInt64"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "size (bytes)",
+          "type": "NumInt64"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "path out",
+          "type": "Path"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 5,
+          "direction": "out",
+          "name": "volume path",
+          "type": "Path"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "path",
+          "type": "Path"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "8068": {
+      "name": "Move",
+      "terminals": [
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "prompt",
+          "type": "String"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "error_in",
+          "type": "cluster"
+        },
+        {
+          "index": 9,
+          "direction": "in",
+          "name": "overwrite",
+          "type": "Boolean"
+        },
+        {
+          "index": 10,
+          "direction": "in",
+          "name": "target_path",
+          "type": "Path"
+        },
+        {
+          "index": 11,
+          "direction": "in",
+          "name": "source_path",
+          "type": "Path"
+        },
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error_out",
+          "type": "cluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "cancelled",
+          "type": "Boolean"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "new_path",
+          "type": "Path"
+        }
+      ],
+      "python_code": {
+        "new_path": "__import__('shutil').move(in_11, in_10)",
+        "cancelled": "False",
+        "error_out": "in_8"
+      },
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/move.html",
+      "verified": false
+    },
+    "8069": {
+      "name": "Read Datalog",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "record(s)",
+          "type": "Void"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "refnum out",
+          "type": "Refnum",
+          "refnum_type": "datalog"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "count (1)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "refnum",
+          "type": "Refnum",
+          "refnum_type": "datalog"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "8070": {
+      "name": "Read from Text File",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/read-from-text-file.html",
+      "terminals": [
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "prompt",
+          "type": "String"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "error_in",
+          "type": "cluster"
+        },
+        {
+          "index": 10,
+          "direction": "in",
+          "name": "count",
+          "type": "NumInt32"
+        },
+        {
+          "index": 11,
+          "direction": "in",
+          "name": "file",
+          "type": "polymorphic"
+        },
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error_out",
+          "type": "cluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "cancelled",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "text",
+          "type": "polymorphic"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "refnum_out",
+          "type": "Refnum"
+        }
+      ],
+      "python_code": {
+        "text": "(in_11.read() if hasattr(in_11, \"read\") else open(in_11).read())",
+        "refnum_out": "in_11",
+        "cancelled": "False",
+        "error_out": "in_8"
+      },
+      "note": "Read from Text File (renamed from a mislabelled 'List Folder') -- file (in#11) accepts a refnum or path; text (out#2) is a string, or array of strings when count is wired. Side-effecting IO, not execution-verified.",
+      "verified": false
+    },
+    "8072": {
+      "name": "Set Datalog Position",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "refnum out",
+          "type": "Refnum",
+          "refnum_type": "datalog"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "from (0:start)",
+          "type": "Enum16"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "offset (in records) (0)",
+          "type": "NumInt64"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "refnum",
+          "type": "Refnum",
+          "refnum_type": "datalog"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "8073": {
+      "name": "Set File Position",
+      "terminals": [
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error_in",
+          "type": "cluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "from",
+          "type": "enum"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "offset",
+          "type": "NumInt64"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "refnum",
+          "type": "Refnum"
+        },
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error_out",
+          "type": "cluster"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "refnum_out",
+          "type": "Refnum"
+        }
+      ],
+      "python_code": {
+        "refnum_out": "(in_7.seek(in_6, in_5), in_7)[1]",
+        "error_out": "in_4"
+      },
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/set-file-position.html",
+      "verified": false
+    },
+    "8074": {
+      "name": "Set File Size",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "refnum out",
+          "type": "Refnum",
+          "refnum_type": "byte_stream"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "size (in bytes)",
+          "type": "NumInt64"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "file",
+          "type": "Path"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "8075": {
+      "name": "Set Number of Records",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "refnum out",
+          "type": "Refnum",
+          "refnum_type": "datalog"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "# of records",
+          "type": "NumInt64"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "refnum",
+          "type": "Refnum",
+          "refnum_type": "datalog"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "8076": {
+      "name": "Set Permissions",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "path out",
+          "type": "Path"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "permissions",
+          "type": "NumInt16"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "new group",
+          "type": "String"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "new owner",
+          "type": "String"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "path",
+          "type": "Path"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025",
+      "note": "corrected from VI-Scripting nodes export (#59); codegen dropped pending re-derivation"
+    },
+    "8077": {
+      "name": "Set Type and Creator",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "path out",
+          "type": "Path"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "creator (no change)",
+          "type": "String"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "type (no change)",
+          "type": "String"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "path",
+          "type": "Path"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "8078": {
+      "name": "Write to Binary File",
+      "terminals": [
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "prepend_size",
+          "type": "Boolean"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "byte_order",
+          "type": "String"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "error_in",
+          "type": "cluster"
+        },
+        {
+          "index": 9,
+          "direction": "in",
+          "name": "datalog_type",
+          "type": "enum"
+        },
+        {
+          "index": 10,
+          "direction": "in",
+          "name": "data",
+          "type": "String"
+        },
+        {
+          "index": 11,
+          "direction": "in",
+          "name": "refnum",
+          "type": "Refnum"
+        },
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error_out",
+          "type": "cluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "eof",
+          "type": "Boolean"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "refnum_out",
+          "type": "Refnum"
+        }
+      ],
+      "python_code": {
+        "refnum_out": "(in_11.write(in_10), in_11)[1]",
+        "error_out": "in_8",
+        "eof": "False"
+      },
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/write-to-binary-file.html",
+      "verified": false
+    },
+    "8079": {
+      "name": "Write Datalog",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "refnum out",
+          "type": "Refnum",
+          "refnum_type": "datalog"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "record(s)",
+          "type": "Void"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "refnum",
+          "type": "Refnum",
+          "refnum_type": "datalog"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "8080": {
+      "name": "Write to Text File",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "cancelled",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "refnum out",
+          "type": "Refnum",
+          "refnum_type": "byte_stream"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "prompt (Choose or enter file path)",
+          "type": "String"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "text",
+          "type": "String"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "file (use dialog)",
+          "type": "Path"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "8081": {
+      "name": "File Dialog",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "cancelled",
+          "type": "Boolean"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "exists",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "path",
+          "type": "Path"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "pattern label",
+          "type": "String"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "button label",
+          "type": "String"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "datalog type",
+          "type": "NumInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "prompt",
+          "type": "String"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "pattern",
+          "type": "String"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "default name",
+          "type": "String"
+        },
+        {
+          "index": 9,
+          "direction": "in",
+          "name": "select mode (2)",
+          "type": "Enum32"
+        },
+        {
+          "index": 10,
+          "direction": "in",
+          "name": "start path",
+          "type": "Path"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
     },
     "8082": {
       "name": "File/Directory Info",
@@ -4194,129 +18214,21 @@
       "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/file-directory-info.html",
       "verified": false
     },
-    "8053": {
-      "name": "Copy",
+    "8083": {
+      "name": "List Folder",
       "terminals": [
         {
-          "index": 7,
+          "index": 5,
           "direction": "in",
-          "name": "prompt",
+          "name": "datalog_type",
+          "type": "NumInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "pattern",
           "type": "String"
         },
-        {
-          "index": 8,
-          "direction": "in",
-          "name": "error_in",
-          "type": "cluster"
-        },
-        {
-          "index": 9,
-          "direction": "in",
-          "name": "overwrite",
-          "type": "Boolean"
-        },
-        {
-          "index": 10,
-          "direction": "in",
-          "name": "target_path",
-          "type": "Path"
-        },
-        {
-          "index": 11,
-          "direction": "in",
-          "name": "source_path",
-          "type": "Path"
-        },
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "error_out",
-          "type": "cluster"
-        },
-        {
-          "index": 1,
-          "direction": "out",
-          "name": "cancelled",
-          "type": "Boolean"
-        },
-        {
-          "index": 3,
-          "direction": "out",
-          "name": "new_path",
-          "type": "Path"
-        }
-      ],
-      "python_code": {
-        "new_path": "__import__('shutil').copy2(in_11, in_10)",
-        "cancelled": "False",
-        "error_out": "in_8"
-      },
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/copy.html",
-      "verified": false
-    },
-    "8068": {
-      "name": "Move",
-      "terminals": [
-        {
-          "index": 7,
-          "direction": "in",
-          "name": "prompt",
-          "type": "String"
-        },
-        {
-          "index": 8,
-          "direction": "in",
-          "name": "error_in",
-          "type": "cluster"
-        },
-        {
-          "index": 9,
-          "direction": "in",
-          "name": "overwrite",
-          "type": "Boolean"
-        },
-        {
-          "index": 10,
-          "direction": "in",
-          "name": "target_path",
-          "type": "Path"
-        },
-        {
-          "index": 11,
-          "direction": "in",
-          "name": "source_path",
-          "type": "Path"
-        },
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "error_out",
-          "type": "cluster"
-        },
-        {
-          "index": 1,
-          "direction": "out",
-          "name": "cancelled",
-          "type": "Boolean"
-        },
-        {
-          "index": 3,
-          "direction": "out",
-          "name": "new_path",
-          "type": "Path"
-        }
-      ],
-      "python_code": {
-        "new_path": "__import__('shutil').move(in_11, in_10)",
-        "cancelled": "False",
-        "error_out": "in_8"
-      },
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/move.html",
-      "verified": false
-    },
-    "8065": {
-      "name": "Get Permissions",
-      "terminals": [
         {
           "index": 8,
           "direction": "in",
@@ -4338,71 +18250,320 @@
         {
           "index": 1,
           "direction": "out",
-          "name": "owner",
-          "type": "String"
+          "name": "file_names",
+          "type": "Array"
         },
         {
           "index": 2,
           "direction": "out",
-          "name": "group",
-          "type": "String"
+          "name": "folder_names",
+          "type": "Array"
         },
         {
           "index": 3,
           "direction": "out",
           "name": "path_out",
           "type": "Path"
-        },
-        {
-          "index": 5,
-          "direction": "out",
-          "name": "permissions",
-          "type": "NumInt16"
         }
       ],
       "python_code": {
-        "permissions": "__import__('os').stat(in_11).st_mode & 0o777",
-        "owner": "''",
-        "group": "''",
+        "file_names": "[e.name for e in __import__('os').scandir(in_11) if e.is_file()]",
+        "folder_names": "[e.name for e in __import__('os').scandir(in_11) if e.is_dir()]",
         "path_out": "in_11",
         "error_out": "in_8"
       },
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/get-permissions.html",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/list-folder.html",
       "verified": false
     },
-    "8076": {
-      "name": "Create Folder",
+    "8100": {
+      "name": "Format Date/Time String",
       "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "datetime_string",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "utc_format",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "timestamp",
+          "type": "MeasureData"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "time_format_string",
+          "type": "String"
+        }
+      ],
+      "python_code": {
+        "datetime_string": "in_2.strftime(in_3) if in_3 else str(in_2)"
+      },
+      "inline": true,
+      "verified": true,
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/format-date-time-string.html"
+    },
+    "8101": {
+      "name": "Scan String For Tokens",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "token index",
+          "type": "NumInt32"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "token string",
+          "type": "String"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "offset past token",
+          "type": "NumInt32"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "string out",
+          "type": "String"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "use cached delim/oper data? (F)",
+          "type": "Boolean"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "allow empty tokens? (F)",
+          "type": "Boolean"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "delimiters (\\s,\\t,\\r,\\n)",
+          "type": "Array"
+        },
         {
           "index": 7,
           "direction": "in",
-          "name": "permissions",
-          "type": "NumInt16"
+          "name": "operators (none)",
+          "type": "Array"
         },
         {
           "index": 8,
           "direction": "in",
-          "name": "error_in",
-          "type": "cluster"
+          "name": "offset",
+          "type": "NumInt32"
         },
         {
           "index": 9,
           "direction": "in",
-          "name": "group",
+          "name": "input string",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "8102": {
+      "name": "IVI New Session",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "IVI session",
+          "type": "Refnum",
+          "refnum_type": "ivi"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "IVI session handle",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "resource name (\"\")",
           "type": "String"
         },
         {
-          "index": 10,
+          "index": 3,
           "direction": "in",
-          "name": "owner",
+          "name": "IVI session (for class)",
+          "type": "Refnum",
+          "refnum_type": "ivi"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "8103": {
+      "name": "IVI Delete Session",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "IVI session",
+          "type": "Refnum",
+          "refnum_type": "ivi"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "8201": {
+      "name": "To Variant",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "variant",
+          "type": "polymorphic"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "anything",
+          "type": "polymorphic"
+        }
+      ],
+      "python_code": {
+        "variant": "in_1"
+      },
+      "inline": true,
+      "verified": true,
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/to-variant.html"
+    },
+    "8202": {
+      "name": "Flattened String To Variant",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "Variant",
+          "type": "LVVariant"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "data string",
           "type": "String"
         },
         {
-          "index": 11,
+          "index": 4,
           "direction": "in",
-          "name": "path",
-          "type": "Path"
+          "name": "type string",
+          "type": "Array"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025",
+      "note": "corrected from VI-Scripting nodes export (#59); codegen dropped pending re-derivation"
+    },
+    "8203": {
+      "name": "Variant To Flattened String",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "Variant",
+          "type": "LVVariant"
         },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "type string",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "data string",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025",
+      "note": "corrected from VI-Scripting nodes export (#59); codegen dropped pending re-derivation"
+    },
+    "8204": {
+      "name": "Set Variant Attribute",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "replaced",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "Variant out",
+          "type": "LVVariant"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "value",
+          "type": "Cluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "name",
+          "type": "String"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "Variant",
+          "type": "LVVariant"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025",
+      "note": "corrected from VI-Scripting nodes export (#59); codegen dropped pending re-derivation"
+    },
+    "8205": {
+      "name": "Get Variant Attribute",
+      "terminals": [
         {
           "index": 0,
           "direction": "out",
@@ -4410,1007 +18571,642 @@
           "type": "cluster"
         },
         {
-          "index": 3,
-          "direction": "out",
-          "name": "path_out",
-          "type": "Path"
-        }
-      ],
-      "python_code": {
-        "path_out": "(__import__('os').makedirs(in_11, exist_ok=True), in_11)[1]",
-        "error_out": "in_8"
-      },
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/create-folder.html",
-      "verified": false
-    },
-    "1146": {
-      "name": "To Single Precision Float",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/to-single-precision-float.html",
-      "terminals": [
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "number",
-          "type": "polymorphic"
-        },
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "result",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "result": "float(in_1)"
-      },
-      "verified": true
-    },
-    "1147": {
-      "name": "To Double Precision Float",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/to-double-precision-float.html",
-      "terminals": [
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "number",
-          "type": "polymorphic"
-        },
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "result",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "result": "float(in_1)"
-      },
-      "verified": true
-    },
-    "1149": {
-      "name": "To Extended Precision Float",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/to-extended-precision-float.html",
-      "terminals": [
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "number",
-          "type": "polymorphic"
-        },
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "result",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "result": "float(in_1)"
-      },
-      "verified": true
-    },
-    "1151": {
-      "name": "To Single Precision Complex",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/to-single-precision-complex.html",
-      "terminals": [
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "number",
-          "type": "polymorphic"
-        },
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "result",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "result": "complex(in_1)"
-      },
-      "verified": true
-    },
-    "1152": {
-      "name": "To Double Precision Complex",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/to-double-precision-complex.html",
-      "terminals": [
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "number",
-          "type": "polymorphic"
-        },
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "result",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "result": "complex(in_1)"
-      },
-      "verified": true
-    },
-    "1154": {
-      "name": "To Extended Precision Complex",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/to-extended-precision-complex.html",
-      "terminals": [
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "number",
-          "type": "polymorphic"
-        },
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "result",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "result": "complex(in_1)"
-      },
-      "verified": true
-    },
-    "1044": {
-      "name": "Complex To Re/Im",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/complex-to-re-im.html",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "in",
-          "name": "x",
-          "type": "NumComplex"
-        },
-        {
           "index": 1,
           "direction": "out",
-          "name": "re",
-          "type": "NumFloat64"
+          "name": "attribute_value",
+          "type": "polymorphic"
         },
         {
           "index": 2,
           "direction": "out",
-          "name": "im",
-          "type": "NumFloat64"
+          "name": "found",
+          "type": "polymorphic"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "duplicate_variant",
+          "type": "polymorphic"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error_in",
+          "type": "cluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "default_value",
+          "type": "polymorphic"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "attribute_name",
+          "type": "polymorphic"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "variant",
+          "type": "polymorphic"
         }
       ],
       "python_code": {
-        "re": "in_0.real",
-        "im": "in_0.imag"
+        "attribute_value": "getattr(in_7, in_6, in_5)",
+        "found": "hasattr(in_7, in_6)"
       },
-      "note": "re/im output index order (out1=re,out2=im) assumed by convention; confirm geometry.",
-      "verified": false
+      "inline": true,
+      "verified": true,
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/get-variant-attribute.html"
     },
-    "1421": {
-      "name": "Path Type",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/path-type.html",
+    "8206": {
+      "name": "Delete Variant Attribute",
       "terminals": [
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "path",
-          "type": "Path"
-        },
         {
           "index": 0,
           "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "found",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "Variant out",
+          "type": "LVVariant"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "name (all attributes)",
+          "type": "String"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "Variant",
+          "type": "LVVariant"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "8207": {
+      "name": "Set Waveform Attribute",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "replaced",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "waveform out",
+          "type": "Waveform"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "value",
+          "type": "Cluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "name",
+          "type": "String"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "waveform",
+          "type": "Waveform"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "8208": {
+      "name": "Get Waveform Attribute",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "values",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "names",
+          "type": "Array"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "duplicate waveform",
+          "type": "Waveform"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "default value (empty Variant)",
+          "type": "LVVariant"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "name",
+          "type": "String"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "waveform",
+          "type": "Waveform"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "8209": {
+      "name": "Delete Waveform Attribute",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "no found",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "waveform out",
+          "type": "Waveform"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "name (all attributes)",
+          "type": "String"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "waveform",
+          "type": "Waveform"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "8400": {
+      "name": "Flatten To XML",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "xml string",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "anything",
+          "type": "Cluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "8401": {
+      "name": "Unflatten From XML",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "value",
+          "type": "Cluster"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
           "name": "type",
-          "type": "NumInt16"
+          "type": "Cluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "xml string",
+          "type": "String"
         }
       ],
-      "python_code": {
-        "type": "(0 if __import__('os').path.isabs(in_1) else 1)"
-      },
-      "note": "type code: 0=absolute,1=relative,2=UNC,3=not a path (confirm exact mapping vs doc).",
-      "verified": false
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
     },
-    "1327": {
-      "name": "Wait Until Next ms Multiple",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/wait-until-next-ms-multiple.html",
+    "8402": {
+      "name": "Flatten To XML",
       "terminals": [
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "ms_multiple",
-          "type": "NumUInt32"
-        },
         {
           "index": 0,
           "direction": "out",
-          "name": "millisecond_timer_value",
-          "type": "NumUInt32"
-        }
-      ],
-      "python_code": {
-        "millisecond_timer_value": "__import__('time').monotonic_ns() // 1_000_000"
-      },
-      "note": "sleeps until the ms timer is a multiple of ms_multiple; returns the timer value.",
-      "verified": false
-    },
-    "1701": {
-      "name": "Wait on Occurrence",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/wait-on-occurrence.html",
-      "terminals": [
+          "name": "xml string",
+          "type": "String"
+        },
         {
           "index": 1,
           "direction": "in",
-          "name": "ignore_previous",
-          "type": "Boolean"
+          "name": "anything",
+          "type": "Cluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "8500": {
+      "name": "Build Matrix",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "appended array",
+          "type": "Array"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "element",
+          "type": "Array"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "8501": {
+      "name": "Get Matrix Diagonal",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "matrix",
+          "type": "Array"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "diagonal",
+          "type": "Array"
         },
         {
           "index": 2,
           "direction": "in",
-          "name": "occurrence",
-          "type": "Refnum"
+          "name": "index (row)",
+          "type": "NumInt32"
         },
         {
           "index": 3,
           "direction": "in",
-          "name": "ms_timeout",
+          "name": "index (col)",
           "type": "NumInt32"
-        },
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "timed_out",
-          "type": "Boolean"
         }
       ],
-      "python_code": {
-        "timed_out": "in_2.wait(None if in_3 < 0 else in_3 / 1000.0) is False"
-      },
-      "note": "waits on an Occurrence refnum (mapped to threading.Event); returns timed_out.",
-      "verified": false
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
     },
-    "1200": {
-      "name": "Sine",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/sine.html",
+    "8502": {
+      "name": "Get Matrix Elements",
       "terminals": [
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "x",
-          "type": "NumFloat64"
-        },
         {
           "index": 0,
-          "direction": "out",
-          "name": "result",
-          "type": "NumFloat64"
-        }
-      ],
-      "python_code": {
-        "result": "__import__('math').sin(in_1)"
-      },
-      "verified": true
-    },
-    "1074": {
-      "name": "Scale By Power Of 2",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/scale-by-power-of-2.html",
-      "terminals": [
+          "direction": "in",
+          "name": "matrix",
+          "type": "Array"
+        },
         {
           "index": 1,
-          "direction": "in",
-          "name": "n",
-          "type": "NumFloat64"
+          "direction": "out",
+          "name": "output matrix",
+          "type": "Array"
         },
         {
           "index": 2,
           "direction": "in",
-          "name": "x",
+          "name": "index (row)",
           "type": "NumInt32"
         },
         {
-          "index": 0,
-          "direction": "out",
-          "name": "result",
-          "type": "NumFloat64"
+          "index": 3,
+          "direction": "in",
+          "name": "index (col)",
+          "type": "NumInt32"
         }
       ],
-      "python_code": {
-        "result": "in_2 * (2.0 ** in_1)"
-      },
-      "verified": true,
-      "note": "Input slots run Bottom->Top, so the upper input `x` takes the higher index."
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
     },
-    "1181": {
-      "name": "Number To Hexadecimal String",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/number-to-hexadecimal-string.html",
+    "8503": {
+      "name": "Get Submatrix",
       "terminals": [
         {
-          "index": 1,
+          "index": 0,
           "direction": "in",
-          "name": "width",
-          "type": "NumInt16"
+          "name": "matrix",
+          "type": "Array"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "submatrix",
+          "type": "Array"
         },
         {
           "index": 2,
           "direction": "in",
-          "name": "number",
-          "type": "Array"
-        },
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "hex_string",
-          "type": "Array"
-        }
-      ],
-      "python_code": {
-        "hex_string": "['%0*X' % (in_1, b) for b in in_2]"
-      },
-      "note": "polymorphic: scalar number->hex string, or array->array of hex strings; width pads digits.",
-      "verified": false
-    },
-    "1225": {
-      "name": "Logarithm Base 2",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/logarithm-base-2.html",
-      "terminals": [
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "x",
+          "name": "row 1",
           "type": "NumInt32"
         },
         {
-          "index": 0,
-          "direction": "out",
-          "name": "result",
-          "type": "NumFloat64"
-        }
-      ],
-      "python_code": {
-        "result": "__import__('math').log2(in_1)"
-      },
-      "note": "context-inferred: GIF min-code-size = ceil(log2(colors)); feeds a round op.",
-      "verified": false
-    },
-    "8058": {
-      "name": "File Dialog",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/vi-lib/express/express-input/filedialogblock-llb/file-dialog-source-vi.html",
-      "terminals": [
+          "index": 3,
+          "direction": "in",
+          "name": "row N",
+          "type": "NumInt32"
+        },
         {
           "index": 4,
           "direction": "in",
-          "name": "prompt",
-          "type": "String"
+          "name": "column 1",
+          "type": "NumInt32"
         },
         {
           "index": 5,
           "direction": "in",
-          "name": "pattern_label",
-          "type": "String"
+          "name": "column N",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "8504": {
+      "name": "Set Matrix Diagonal",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "matrix",
+          "type": "Array"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "output matrix",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "new diagonal/fill element",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "disabled index (row)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "index (col)",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "8505": {
+      "name": "Set Matrix Elements",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "matrix",
+          "type": "Array"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "output matrix",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "new element/submatrix",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "disabled index (row)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "index (col)",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "8506": {
+      "name": "Set Submatrix",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "matrix",
+          "type": "Array"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "output matrix",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "new submatrix/fill element",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "row 1",
+          "type": "NumInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "row N",
+          "type": "NumInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "column 1",
+          "type": "NumInt32"
         },
         {
           "index": 6,
           "direction": "in",
-          "name": "patterns",
-          "type": "String"
-        },
-        {
-          "index": 7,
-          "direction": "in",
-          "name": "button_label",
-          "type": "String"
-        },
-        {
-          "index": 8,
-          "direction": "in",
-          "name": "error_in",
-          "type": "cluster"
-        },
-        {
-          "index": 9,
-          "direction": "in",
-          "name": "default_name",
-          "type": "String"
-        },
-        {
-          "index": 11,
-          "direction": "in",
-          "name": "start_path",
-          "type": "Path"
-        },
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "error_out",
-          "type": "cluster"
-        },
-        {
-          "index": 1,
-          "direction": "out",
-          "name": "cancelled",
-          "type": "Boolean"
-        },
-        {
-          "index": 2,
-          "direction": "out",
-          "name": "exists",
-          "type": "Boolean"
-        },
-        {
-          "index": 3,
-          "direction": "out",
-          "name": "selected_path",
-          "type": "Path"
-        }
-      ],
-      "python_code": {
-        "selected_path": "in_11",
-        "cancelled": "False",
-        "exists": "__import__('os').path.exists(in_11)",
-        "error_out": "in_8"
-      },
-      "note": "File Dialog -- identified by pane signature (file-pattern + start path -> path + cancelled?/exists?). Express-VI doc page has no backend connector pane, so verify names if refining.",
-      "verified": false
-    },
-    "1082": {
-      "name": "Logical Shift",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/logical-shift.html",
-      "terminals": [
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "n",
-          "type": "NumUInt32"
-        },
-        {
-          "index": 2,
-          "direction": "in",
-          "name": "x",
+          "name": "column N",
           "type": "NumInt32"
-        },
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "x_shifted",
-          "type": "NumUInt32"
         }
       ],
-      "python_code": {
-        "x_shifted": "((in_2 << in_1) if in_1 >= 0 else (in_2 >> -in_1)) & 0xFFFFFFFF"
-      },
-      "note": "Logical Shift -- positive n = shift left, negative = right, zero-fill; masked to source width (U32 here; MD5 builds its circular rotate from this). Input slots run Bottom->Top, so the upper input `x` takes the higher index.",
-      "verified": false
-    },
-    "1188": {
-      "name": "To Upper Case",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/to-upper-case.html",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "all_upper_case_string",
-          "type": "String"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "string",
-          "type": "String"
-        }
-      ],
-      "python_code": {
-        "all_upper_case_string": "in_1.upper() if isinstance(in_1, str) else [s.upper() for s in in_1]"
-      },
-      "inline": true,
-      "verified": true,
-      "guess_reason": "2-terminal unary type-preserving string op (same pane class as 1537 To Lower Case); candidates were to-upper/reverse/rotate-string. Consumer-forced: in GIF.Read.Unpack its output is Equal?-compared to literals 'GIF87A'/'GIF89A' (GIF signatures), so it must PRESERVE letters -> rules out reverse/rotate; UPPER because the compared targets are uppercase (case-insensitive header check). Also fits To Proper Case. Cleanroom: no glyph; resolved from consumer dataflow."
-    },
-    "1072": {
-      "name": "Not Or",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/not-or.html",
-      "terminals": [
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "y",
-          "type": "Boolean"
-        },
-        {
-          "index": 2,
-          "direction": "in",
-          "name": "x",
-          "type": "Boolean"
-        },
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "nor",
-          "type": "Boolean"
-        }
-      ],
-      "python_code": {
-        "nor": "not (in_1 or in_2)"
-      },
-      "inline": true,
-      "verified": true,
-      "note": "Not Or (NOR) -- deduced from a Valid Path idiom: NOT(empty OR not-a-path); only NOR fits that truth table (And/Or/Xor/Not already claimed at 1061-1064). Commutative. Input slots run Bottom->Top, so the upper input `x` takes the higher index."
-    },
-    "1425": {
-      "name": "VI Library",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/vi-library.html",
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "path",
-          "type": "Path"
-        }
-      ],
-      "python_code": {
-        "path": "__import__('os').environ.get('LABVIEW_VI_LIB', 'vi.lib')"
-      },
-      "inline": true,
       "verified": false,
-      "note": "VI Library constant (vi.lib path) -- node XML is byte-identical to the User/Instrument Library variants; identified in 'Is VI-LIB' (output feeds Path To Array Of Strings + Equal? on the path). python_code is a placeholder."
+      "source": "vi-scripting-nodes-lv2025"
     },
-    "1539": {
-      "name": "Spreadsheet String To Array",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/spreadsheet-string-to-array.html",
+    "8507": {
+      "name": "Matrix Size",
       "terminals": [
         {
-          "index": 1,
+          "index": 0,
           "direction": "in",
-          "name": "delimiter",
-          "type": "String"
-        },
-        {
-          "index": 2,
-          "direction": "in",
-          "name": "array_type",
+          "name": "number of rows",
           "type": "Array"
         },
         {
-          "index": 3,
-          "direction": "in",
-          "name": "spreadsheet_string",
-          "type": "String"
-        },
-        {
-          "index": 4,
-          "direction": "in",
-          "name": "format_string",
-          "type": "String"
-        },
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "array",
-          "type": "Array"
-        }
-      ],
-      "python_code": {
-        "array": "[r.split(in_1 or '\\t') for r in in_3.splitlines()]"
-      },
-      "inline": true,
-      "verified": false,
-      "note": "Spreadsheet String To Array -- splits a delimited string into a typed array. python_code covers only the 2-D string case; real dimensionality/element type come from array_type + format_string and need an lvkit runtime helper."
-    },
-    "1075": {
-      "name": "Round Toward -Infinity",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/round-toward-infinity.html",
-      "terminals": [
-        {
           "index": 1,
-          "direction": "in",
-          "name": "x",
-          "type": "polymorphic"
-        },
-        {
-          "index": 0,
           "direction": "out",
-          "name": "floor_x",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "floor_x": "__import__('math').floor(in_1)"
-      },
-      "inline": true,
-      "verified": true,
-      "note": "Round Toward -Infinity (floor) -- forced in 'MasterAquisitionFile_2P' (a scaled index must floor); distinct from 1076 (+Inf), co-occurring in 'GenerateStimulusOutputs_FP'. NB NI slug misleads: unsuffixed round-toward-infinity.html is -Inf."
-    },
-    "1180": {
-      "name": "Number To Decimal String",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/number-to-decimal-string.html",
-      "terminals": [
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "width",
-          "type": "NumInt16"
-        },
-        {
-          "index": 2,
-          "direction": "in",
-          "name": "number",
-          "type": "polymorphic"
-        },
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "decimal_integer_string",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "decimal_integer_string": "str(int(round(in_2))).rjust(in_1)"
-      },
-      "inline": true,
-      "verified": false,
-      "note": "Number To Decimal String -- pane identical to sibling 1181 (Number To Hexadecimal String), adjacent palette slot (Decimal precedes Hex); 2 inputs excludes Engineering/Fractional/Exponential. python_code not execution-verified for width/pad."
-    },
-    "1213": {
-      "name": "Power Of X",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/power-of-x.html",
-      "terminals": [
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "y",
-          "type": "polymorphic"
-        },
-        {
-          "index": 2,
-          "direction": "in",
-          "name": "x",
-          "type": "polymorphic"
-        },
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "x_to_the_y",
-          "type": "NumFloat64"
-        }
-      ],
-      "python_code": {
-        "x_to_the_y": "in_2 ** in_1"
-      },
-      "inline": true,
-      "verified": false,
-      "note": "Power Of X -- algorithm-forced in the PCO camera examples: value * 1000^dTB is the SDK timebase (ns/us/ms) unit conversion; Logarithm Base X excluded (log1000(0) = -inf). Input slots run Bottom->Top, so the upper input `x` takes the higher index."
-    },
-    "1340": {
-      "name": "One Button Dialog",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/one-button-dialog.html",
-      "terminals": [
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "button_name",
-          "type": "String"
-        },
-        {
-          "index": 2,
-          "direction": "in",
-          "name": "message",
-          "type": "String"
-        },
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "true",
-          "type": "Boolean"
-        }
-      ],
-      "python_code": {
-        "true": "True"
-      },
-      "inline": true,
-      "verified": false,
-      "note": "One Button Dialog -- 3-terminal pane; message (idx2) wired 19/19, button name (idx1) never wired (defaults 'OK'). Two Button Dialog excluded (three strings). Side-effecting dialog; python_code does not emit it."
-    },
-    "2408": {
-      "name": "New Data Value Reference",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/new-data-value-reference.html",
-      "terminals": [
-        {
-          "index": 4,
-          "direction": "in",
-          "name": "error_in",
-          "type": "cluster"
-        },
-        {
-          "index": 7,
-          "direction": "in",
-          "name": "data_value",
-          "type": "polymorphic"
-        },
-        {
-          "index": 0,
-          "direction": "out",
-          "name": "error_out",
-          "type": "cluster"
-        },
-        {
-          "index": 3,
-          "direction": "out",
-          "name": "data_value_reference",
-          "type": "Refnum"
-        }
-      ],
-      "python_code": {
-        "data_value_reference": "[in_7]",
-        "error_out": "in_4"
-      },
-      "inline": true,
-      "verified": false,
-      "note": "New Data Value Reference -- identity from ref_type=DataValueRef on the out#3 refnum; every call site is a *_New.vi LVOOP constructor. python_code models the DVR as a 1-element list and is PROVISIONAL (belongs with the lvkit runtime decision)."
-    },
-    "9110": {
-      "name": "Get Queue Status",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/get-queue-status.html",
-      "verified": true,
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "in",
-          "name": "queue",
-          "type": "Refnum"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "return_elements",
-          "type": "Boolean"
-        },
-        {
-          "index": 3,
-          "direction": "in",
-          "name": "error_in",
-          "type": "Cluster"
-        },
-        {
-          "index": 4,
-          "direction": "out",
-          "name": "max_queue_size",
+          "name": "number of columns",
           "type": "NumInt32"
         },
         {
-          "index": 5,
+          "index": 2,
           "direction": "out",
-          "name": "elements",
+          "name": "matrix",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "8508": {
+      "name": "Resize Matrix",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "resized matrix",
           "type": "Array"
         },
         {
-          "index": 6,
-          "direction": "out",
-          "name": "queue_name",
-          "type": "String"
-        },
-        {
-          "index": 7,
-          "direction": "out",
-          "name": "elements_in_queue",
-          "type": "NumInt32"
-        },
-        {
-          "index": 8,
-          "direction": "out",
-          "name": "queue_out",
-          "type": "Refnum"
-        },
-        {
-          "index": 9,
-          "direction": "out",
-          "name": "pending_remove",
-          "type": "NumInt32"
-        },
-        {
-          "index": 10,
-          "direction": "out",
-          "name": "pending_insert",
-          "type": "NumInt32"
-        },
-        {
-          "index": 11,
-          "direction": "out",
-          "name": "error_out",
-          "type": "Cluster"
-        }
-      ],
-      "placeholder": true,
-      "python_code": "pass",
-      "note": "Get Queue Status -- full 11-terminal pane, exact type+count match to the NI Get Queue Status doc; terminals pinned from 'Graphical Test Runner - Main UI - .vi' and 'test Queue Size is Zero.vi' (JKI VI-Tester). 9109 is the corrected Release Queue."
-    },
-    "9114": {
-      "name": "Flush Queue",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/flush-queue.html",
-      "verified": true,
-      "terminals": [
-        {
-          "index": 0,
+          "index": 1,
           "direction": "in",
-          "name": "queue",
-          "type": "Refnum"
+          "name": "number of columns",
+          "type": "NumInt32"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "number of rows",
+          "type": "NumInt32"
         },
         {
           "index": 3,
           "direction": "in",
-          "name": "error_in",
-          "type": "Cluster"
-        },
+          "name": "matrix",
+          "type": "Array"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "8509": {
+      "name": "Transpose Matrix",
+      "terminals": [
         {
-          "index": 8,
+          "index": 0,
           "direction": "out",
-          "name": "queue_out",
-          "type": "Refnum"
-        },
-        {
-          "index": 9,
-          "direction": "out",
-          "name": "remaining_elements",
+          "name": "transposed matrix",
           "type": "Array"
         },
         {
-          "index": 11,
-          "direction": "out",
-          "name": "error_out",
-          "type": "Cluster"
-        }
-      ],
-      "python_code": {
-        "_body": "raise RuntimeError('Flush Queue (9114) should be dispatched to codegen/nodes/queue_ops.py by primResID -- this stub should be unreachable')"
-      },
-      "note": "Flush Queue -- empties a queue, returns the drained elements (NI Flush Queue doc); terminals pinned from 'Graphical Test Runner - Main UI - .vi', 'Measurement UI.vi'. Distinct from Release Queue/9109 and Get Queue Status/9110."
-    },
-    "2073": {
-      "name": "Create User Event",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/create-user-event.html",
-      "verified": true,
-      "placeholder": true,
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "in",
-          "name": "user_event_data_type",
-          "type": "polymorphic"
-        },
-        {
-          "index": 3,
-          "direction": "in",
-          "name": "error_in",
-          "type": "Cluster"
-        },
-        {
-          "index": 8,
-          "direction": "out",
-          "name": "user_event_out",
-          "type": "Refnum"
-        },
-        {
-          "index": 11,
-          "direction": "out",
-          "name": "error_out",
-          "type": "Cluster"
-        }
-      ],
-      "python_code": "pass",
-      "note": "Create User Event (NI Create User Event doc) -- user event data-type -> UserEvent refnum out (ref_type=UserEvent is the identity). Terminals from 'Graphical Test Runner - Main UI - .vi', 'WaveGen.vi'. Placeholder codegen."
-    },
-    "2075": {
-      "name": "Destroy User Event",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/destroy-user-event.html",
-      "verified": true,
-      "placeholder": true,
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "in",
-          "name": "user_event",
-          "type": "Refnum"
-        },
-        {
-          "index": 3,
-          "direction": "in",
-          "name": "error_in",
-          "type": "Cluster"
-        },
-        {
-          "index": 7,
-          "direction": "out",
-          "name": "error_out",
-          "type": "Cluster"
-        }
-      ],
-      "python_code": "pass",
-      "note": "Destroy User Event (NI Destroy User Event doc) -- UserEvent refnum + error in -> error out only (destroying invalidates the ref). Terminals from 'Graphical Test Runner - Main UI - .vi', 'Run Client.vi'. Placeholder codegen."
-    },
-    "2402": {
-      "name": "Merge Event Registrations",
-      "verified": false,
-      "placeholder": true,
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "in",
-          "name": "event_reg_a",
-          "type": "Refnum"
-        },
-        {
           "index": 1,
           "direction": "in",
-          "name": "event_reg_b",
-          "type": "Refnum"
-        },
-        {
-          "index": 2,
-          "direction": "out",
-          "name": "event_reg_out",
-          "type": "Refnum"
+          "name": "matrix",
+          "type": "Array"
         }
       ],
-      "python_code": "pass",
-      "note": "Merge Event Registrations (internal) -- no matching NI doc; deduced compiler-internal glue combining two EventReg refnums into one (like 2401 Merge Errors). Terminals from 'DAQmx AO.vi', 'WaveGen.vi', 'Control.vi'. Placeholder codegen."
-    },
-    "2135": {
-      "name": "Register Event Source For Event Type (internal)",
       "verified": false,
-      "placeholder": true,
-      "terminals": [
-        {
-          "index": 0,
-          "direction": "in",
-          "name": "event_reg_in",
-          "type": "Refnum"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "dynamic",
-          "type": "Boolean"
-        },
-        {
-          "index": 2,
-          "direction": "in",
-          "name": "event_type",
-          "type": "enum"
-        },
-        {
-          "index": 3,
-          "direction": "in",
-          "name": "error_in",
-          "type": "Cluster"
-        },
-        {
-          "index": 4,
-          "direction": "in",
-          "name": "source_id",
-          "type": "NumUInt32"
-        },
-        {
-          "index": 5,
-          "direction": "in",
-          "name": "config",
-          "type": "NumInt32"
-        },
-        {
-          "index": 8,
-          "direction": "out",
-          "name": "event_reg_out",
-          "type": "Refnum"
-        },
-        {
-          "index": 9,
-          "direction": "out",
-          "name": "registration_id",
-          "type": "NumUInt32"
-        },
-        {
-          "index": 11,
-          "direction": "out",
-          "name": "error_out",
-          "type": "Cluster"
-        }
-      ],
-      "python_code": "pass",
-      "note": "Register Event Source For Event Type (internal) -- no matching NI doc; compiler-internal expansion of Register For Events; idx2 enum carries LabVIEW's built-in Event Type list. Terminals from 'DAQmx AO.vi', 'WaveGen.vi'. Placeholder, verified false."
+      "source": "vi-scripting-nodes-lv2025"
     },
     "9000": {
       "name": "Current VI's Menubar",
@@ -5427,6 +19223,108 @@
       ],
       "python_code": "pass",
       "note": "Current VI's Menubar (NI Menu-category doc) -- single output, no inputs; returns the current VI's menu reference (ref_type=Menu). Terminals from 'Graphical Test Runner - Main UI - .vi'. Placeholder codegen (no lvkit Menu runtime)."
+    },
+    "9001": {
+      "name": "Get Menu Selection",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "menu reference",
+          "type": "Refnum",
+          "refnum_type": "menu"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "ms timeout (200)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "block menu (F)",
+          "type": "Boolean"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "timed out",
+          "type": "Boolean"
+        },
+        {
+          "index": 5,
+          "direction": "out",
+          "name": "menu reference out",
+          "type": "Refnum",
+          "refnum_type": "menu"
+        },
+        {
+          "index": 6,
+          "direction": "out",
+          "name": "item tag",
+          "type": "String"
+        },
+        {
+          "index": 7,
+          "direction": "out",
+          "name": "item path",
+          "type": "String"
+        },
+        {
+          "index": 8,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "9002": {
+      "name": "Enable Menu Tracking",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "menu reference out",
+          "type": "Refnum",
+          "refnum_type": "menu"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "enable (T)",
+          "type": "Boolean"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "menu reference",
+          "type": "Refnum",
+          "refnum_type": "menu"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
     },
     "9003": {
       "name": "Insert Menu Items",
@@ -5608,118 +19506,5955 @@
       "python_code": "pass",
       "note": "Get Menu Item Info (NI Get Menu Item Info doc) -- 3 inputs + 7 real outputs (doc's shortcut fields collapse into one cluster); terminals from 'Graphical Test Runner - Main UI - .vi'. idx1/idx4 (enabled?/checked?) unconfirmed. Placeholder codegen."
     },
-    "1156": {
-      "name": "To Unsigned Quad Integer",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/to-unsigned-quad-integer.html",
-      "verified": true,
+    "9006": {
+      "name": "Set Menu Item Info",
       "terminals": [
         {
           "index": 0,
           "direction": "out",
-          "name": "result",
-          "type": "NumUInt64"
+          "name": "error out",
+          "type": "ErrorCluster"
         },
         {
           "index": 1,
-          "direction": "in",
-          "name": "x",
-          "type": "polymorphic"
-        }
-      ],
-      "python_code": {
-        "result": "int(in_1) & 0xFFFFFFFFFFFFFFFF"
-      },
-      "inline": true,
-      "note": "To Unsigned Quad Integer (NI doc) -- completes the To-<T> conversion family (1140-1144), idx0=out/idx1=in. Terminals from 'pco.camera_FloatingMean_Example_IMAQ.vi', 'testNumericU64.vi' (JKI-EasyXML)."
-    },
-    "1341": {
-      "name": "Two Button Dialog",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/two-button-dialog.html",
-      "verified": true,
-      "terminals": [
-        {
-          "index": 0,
           "direction": "out",
-          "name": "t_button_pressed",
-          "type": "Boolean"
-        },
-        {
-          "index": 1,
-          "direction": "in",
-          "name": "t_button_name",
-          "type": "String"
+          "name": "menu reference out",
+          "type": "Refnum",
+          "refnum_type": "menu"
         },
         {
           "index": 2,
           "direction": "in",
-          "name": "f_button_name",
-          "type": "String"
+          "name": "short cut",
+          "type": "Cluster"
         },
         {
           "index": 3,
           "direction": "in",
-          "name": "message",
+          "name": "checked",
+          "type": "Boolean"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "item tag",
           "type": "String"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "enabled",
+          "type": "Boolean"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "item name",
+          "type": "String"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "menu reference",
+          "type": "Refnum",
+          "refnum_type": "menu"
         }
       ],
-      "placeholder": true,
-      "python_code": "pass",
-      "note": "Two Button Dialog (NI Two Button Dialog doc) -> T button?. Terminals from 'Graphical Test Runner - Main UI - .vi', 'Dictionary Example.vi', 'Folder Reuse Warning.vi'. Placeholder: T-vs-F is a real branch, python_code hard-codes True."
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
     },
-    "1184": {
-      "name": "Decimal String To Number",
-      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/decimal-string-to-number.html",
-      "verified": true,
+    "9007": {
+      "name": "Get Menu Short Cut Info",
       "terminals": [
         {
           "index": 0,
           "direction": "out",
-          "name": "number",
-          "type": "polymorphic"
+          "name": "error out",
+          "type": "ErrorCluster"
         },
         {
           "index": 1,
           "direction": "out",
-          "name": "offset_past_number",
+          "name": "item path",
+          "type": "String"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "item tag",
+          "type": "String"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "menu reference out",
+          "type": "Refnum",
+          "refnum_type": "menu"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "short cut",
+          "type": "Cluster"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "menu reference",
+          "type": "Refnum",
+          "refnum_type": "menu"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "9020": {
+      "name": "Script Node",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "9101": {
+      "name": "Obtain Notifier",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/obtain-notifier.html",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "name",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "element_data_type",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "create_if_not_found",
+          "type": "Boolean"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error_in",
+          "type": "cluster"
+        },
+        {
+          "index": 8,
+          "direction": "out",
+          "name": "notifier_out",
+          "type": "Refnum"
+        },
+        {
+          "index": 10,
+          "direction": "out",
+          "name": "created_new",
+          "type": "Boolean"
+        },
+        {
+          "index": 11,
+          "direction": "out",
+          "name": "error_out",
+          "type": "cluster"
+        }
+      ],
+      "placeholder": true,
+      "python_code": "pass",
+      "verified": false,
+      "note": "Obtain Notifier -- Notifier family (ref_type=NotifierRef is the identity); lifecycle 9101 obtain -> 9104 send -> 9105 wait -> 9102 release, confirmed in VI-Tester. Placeholder codegen (no lvkit notifier runtime yet)."
+    },
+    "9102": {
+      "name": "Release Notifier",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/release-notifier.html",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "notifier",
+          "type": "Refnum"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "force_destroy",
+          "type": "Boolean"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error_in",
+          "type": "cluster"
+        },
+        {
+          "index": 8,
+          "direction": "out",
+          "name": "notifier_name",
+          "type": "String"
+        },
+        {
+          "index": 9,
+          "direction": "out",
+          "name": "last_notification",
+          "type": "Boolean"
+        },
+        {
+          "index": 11,
+          "direction": "out",
+          "name": "error_out",
+          "type": "cluster"
+        }
+      ],
+      "placeholder": true,
+      "python_code": "pass",
+      "verified": false,
+      "note": "Release Notifier -- Notifier family (ref_type=NotifierRef is the identity); lifecycle 9101 obtain -> 9104 send -> 9105 wait -> 9102 release, confirmed in VI-Tester. Placeholder codegen (no lvkit notifier runtime yet)."
+    },
+    "9103": {
+      "name": "Get Notifier Status",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "notifier",
+          "type": "Refnum",
+          "refnum_type": "notifier"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "notifier name",
+          "type": "String"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "notifier out",
+          "type": "Refnum",
+          "refnum_type": "notifier"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "current notification",
+          "type": "String"
+        },
+        {
+          "index": 5,
+          "direction": "out",
+          "name": "# waiting",
+          "type": "NumInt32"
+        },
+        {
+          "index": 6,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "9104": {
+      "name": "Send Notification",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/send-notification.html",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "notifier",
+          "type": "Refnum"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "notification",
+          "type": "Boolean"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error_in",
+          "type": "cluster"
+        },
+        {
+          "index": 8,
+          "direction": "out",
+          "name": "notifier_out",
+          "type": "Refnum"
+        },
+        {
+          "index": 11,
+          "direction": "out",
+          "name": "error_out",
+          "type": "cluster"
+        }
+      ],
+      "placeholder": true,
+      "python_code": "pass",
+      "verified": false,
+      "note": "Send Notification -- Notifier family (ref_type=NotifierRef is the identity); lifecycle 9101 obtain -> 9104 send -> 9105 wait -> 9102 release, confirmed in VI-Tester. Placeholder codegen (no lvkit notifier runtime yet)."
+    },
+    "9105": {
+      "name": "Wait on Notification",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/wait-on-notification.html",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "notifier",
+          "type": "Refnum"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "ignore_previous",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "timeout_ms",
+          "type": "NumInt32"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error_in",
+          "type": "cluster"
+        },
+        {
+          "index": 8,
+          "direction": "out",
+          "name": "notifier_out",
+          "type": "Refnum"
+        },
+        {
+          "index": 9,
+          "direction": "out",
+          "name": "notification",
+          "type": "Boolean"
+        },
+        {
+          "index": 10,
+          "direction": "out",
+          "name": "timed_out",
+          "type": "Boolean"
+        },
+        {
+          "index": 11,
+          "direction": "out",
+          "name": "error_out",
+          "type": "cluster"
+        }
+      ],
+      "placeholder": true,
+      "python_code": "pass",
+      "verified": false,
+      "note": "Wait on Notification -- Notifier family (ref_type=NotifierRef is the identity); lifecycle 9101 obtain -> 9104 send -> 9105 wait -> 9102 release, confirmed in VI-Tester. Placeholder codegen (no lvkit notifier runtime yet)."
+    },
+    "9106": {
+      "name": "Wait on Notification from Multiple",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "notifiers",
+          "type": "Array"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "ignore previous (F)",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "timeout in ms (-1)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "notifier out",
+          "type": "Array"
+        },
+        {
+          "index": 5,
+          "direction": "out",
+          "name": "notifiers out",
+          "type": "Array"
+        },
+        {
+          "index": 6,
+          "direction": "out",
+          "name": "timed out?",
+          "type": "Boolean"
+        },
+        {
+          "index": 7,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "9107": {
+      "name": "Cancel Notification",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "notifier",
+          "type": "Refnum",
+          "refnum_type": "notifier"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "notifier out",
+          "type": "Refnum",
+          "refnum_type": "notifier"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "canceled notifcation",
+          "type": "String"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "9108": {
+      "name": "Obtain Queue",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/obtain-queue.html",
+      "verified": true,
+      "terminals": [
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "max_queue_size",
+          "type": "NumInt32"
+        },
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "name",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "element_data_type",
+          "type": "Cluster"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "create_if_not_found",
+          "type": "Boolean"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error_in",
+          "type": "Cluster"
+        },
+        {
+          "index": 8,
+          "direction": "out",
+          "name": "queue_out",
+          "type": "Refnum"
+        },
+        {
+          "index": 10,
+          "direction": "out",
+          "name": "created",
+          "type": "Boolean"
+        },
+        {
+          "index": 11,
+          "direction": "out",
+          "name": "error_out",
+          "type": "Cluster"
+        }
+      ],
+      "python_code": {
+        "_body": "raise RuntimeError('Obtain Queue (9108) should be dispatched to codegen/nodes/queue_ops.py by primResID -- this stub should be unreachable')"
+      },
+      "note": "Queue op (ref_type=Queue on idx8). Handled by codegen/nodes/queue_ops.py (dispatched by primResID, not this template) -- calls lvkit.labview_queue.obtain_queue()."
+    },
+    "9109": {
+      "name": "Release Queue",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/release-queue.html",
+      "verified": true,
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "queue",
+          "type": "Refnum"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "force_destroy",
+          "type": "Boolean"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error_in",
+          "type": "Cluster"
+        },
+        {
+          "index": 8,
+          "direction": "out",
+          "name": "queue_name",
+          "type": "String"
+        },
+        {
+          "index": 9,
+          "direction": "out",
+          "name": "remaining_elements",
+          "type": "Array"
+        },
+        {
+          "index": 11,
+          "direction": "out",
+          "name": "error_out",
+          "type": "Cluster"
+        }
+      ],
+      "placeholder": true,
+      "python_code": "pass",
+      "note": "Release Queue (NI Release Queue doc; corrected from a mislabeled 'Get Queue Status') -- 6-terminal pane with no queue_out output (releasing invalidates the ref), distinct from Get Queue Status/9110."
+    },
+    "9110": {
+      "name": "Get Queue Status",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/get-queue-status.html",
+      "verified": true,
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "queue",
+          "type": "Refnum"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "return_elements",
+          "type": "Boolean"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error_in",
+          "type": "Cluster"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "max_queue_size",
+          "type": "NumInt32"
+        },
+        {
+          "index": 5,
+          "direction": "out",
+          "name": "elements",
+          "type": "Array"
+        },
+        {
+          "index": 6,
+          "direction": "out",
+          "name": "queue_name",
+          "type": "String"
+        },
+        {
+          "index": 7,
+          "direction": "out",
+          "name": "elements_in_queue",
+          "type": "NumInt32"
+        },
+        {
+          "index": 8,
+          "direction": "out",
+          "name": "queue_out",
+          "type": "Refnum"
+        },
+        {
+          "index": 9,
+          "direction": "out",
+          "name": "pending_remove",
+          "type": "NumInt32"
+        },
+        {
+          "index": 10,
+          "direction": "out",
+          "name": "pending_insert",
+          "type": "NumInt32"
+        },
+        {
+          "index": 11,
+          "direction": "out",
+          "name": "error_out",
+          "type": "Cluster"
+        }
+      ],
+      "placeholder": true,
+      "python_code": "pass",
+      "note": "Get Queue Status -- full 11-terminal pane, exact type+count match to the NI Get Queue Status doc; terminals pinned from 'Graphical Test Runner - Main UI - .vi' and 'test Queue Size is Zero.vi' (JKI VI-Tester). 9109 is the corrected Release Queue."
+    },
+    "9111": {
+      "name": "Enqueue Element",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/enqueue-element.html",
+      "verified": true,
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "queue",
+          "type": "Refnum"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "element",
+          "type": "Cluster"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "timeout_ms",
+          "type": "NumInt32"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error_in",
+          "type": "Cluster"
+        },
+        {
+          "index": 8,
+          "direction": "out",
+          "name": "queue_out",
+          "type": "Refnum"
+        },
+        {
+          "index": 10,
+          "direction": "out",
+          "name": "timed_out",
+          "type": "Boolean"
+        },
+        {
+          "index": 11,
+          "direction": "out",
+          "name": "error_out",
+          "type": "Cluster"
+        }
+      ],
+      "python_code": {
+        "_body": "raise RuntimeError('Enqueue Element (9111) should be dispatched to codegen/nodes/queue_ops.py by primResID -- this stub should be unreachable')"
+      },
+      "note": "Queue op. Handled by codegen/nodes/queue_ops.py (dispatched by primResID, not this template) -- calls lvkit.labview_queue.enqueue_element()."
+    },
+    "9112": {
+      "name": "Preview Queue Element",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "queue",
+          "type": "Refnum",
+          "refnum_type": "queue"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "timeout in ms (-1)",
           "type": "NumInt32"
         },
         {
           "index": 2,
           "direction": "in",
-          "name": "default",
-          "type": "polymorphic"
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "queue out",
+          "type": "Refnum",
+          "refnum_type": "queue"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "element",
+          "type": "String"
+        },
+        {
+          "index": 5,
+          "direction": "out",
+          "name": "timed out?",
+          "type": "Boolean"
+        },
+        {
+          "index": 6,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "9113": {
+      "name": "Dequeue Element",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/dequeue-element.html",
+      "verified": true,
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "queue",
+          "type": "Refnum"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "timeout_ms",
+          "type": "NumInt32"
         },
         {
           "index": 3,
           "direction": "in",
-          "name": "offset",
+          "name": "error_in",
+          "type": "Cluster"
+        },
+        {
+          "index": 8,
+          "direction": "out",
+          "name": "queue_out",
+          "type": "Refnum"
+        },
+        {
+          "index": 9,
+          "direction": "out",
+          "name": "element",
+          "type": "Cluster"
+        },
+        {
+          "index": 10,
+          "direction": "out",
+          "name": "timed_out",
+          "type": "Boolean"
+        },
+        {
+          "index": 11,
+          "direction": "out",
+          "name": "error_out",
+          "type": "Cluster"
+        }
+      ],
+      "python_code": {
+        "_body": "raise RuntimeError('Dequeue Element (9113) should be dispatched to codegen/nodes/queue_ops.py by primResID -- this stub should be unreachable')"
+      },
+      "note": "Queue op. Handled by codegen/nodes/queue_ops.py (dispatched by primResID, not this template) -- calls lvkit.labview_queue.dequeue_element()."
+    },
+    "9114": {
+      "name": "Flush Queue",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/flush-queue.html",
+      "verified": true,
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "queue",
+          "type": "Refnum"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error_in",
+          "type": "Cluster"
+        },
+        {
+          "index": 8,
+          "direction": "out",
+          "name": "queue_out",
+          "type": "Refnum"
+        },
+        {
+          "index": 9,
+          "direction": "out",
+          "name": "remaining_elements",
+          "type": "Array"
+        },
+        {
+          "index": 11,
+          "direction": "out",
+          "name": "error_out",
+          "type": "Cluster"
+        }
+      ],
+      "python_code": {
+        "_body": "raise RuntimeError('Flush Queue (9114) should be dispatched to codegen/nodes/queue_ops.py by primResID -- this stub should be unreachable')"
+      },
+      "note": "Flush Queue -- empties a queue, returns the drained elements (NI Flush Queue doc); terminals pinned from 'Graphical Test Runner - Main UI - .vi', 'Measurement UI.vi'. Distinct from Release Queue/9109 and Get Queue Status/9110."
+    },
+    "9129": {
+      "name": "Enqueue Element At Opposite End",
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/enqueue-element-at-opposite-end.html",
+      "verified": true,
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "queue",
+          "type": "Refnum"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "element",
+          "type": "Cluster"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "timeout_ms",
+          "type": "NumInt32"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error_in",
+          "type": "Cluster"
+        },
+        {
+          "index": 8,
+          "direction": "out",
+          "name": "queue_out",
+          "type": "Refnum"
+        },
+        {
+          "index": 10,
+          "direction": "out",
+          "name": "timed_out",
+          "type": "Boolean"
+        },
+        {
+          "index": 11,
+          "direction": "out",
+          "name": "error_out",
+          "type": "Cluster"
+        }
+      ],
+      "python_code": {
+        "_body": "raise RuntimeError('Enqueue Element At Opposite End (9129) should be dispatched to codegen/nodes/queue_ops.py by primResID -- this stub should be unreachable')"
+      },
+      "note": "Queue op (LIFO push for the parser stack). Handled by codegen/nodes/queue_ops.py -> lvkit.labview_queue.enqueue_element_at_opposite_end()."
+    },
+    "9130": {
+      "name": "Lossy Enqueue Element",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "queue",
+          "type": "Refnum",
+          "refnum_type": "queue"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "element",
+          "type": "String"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "queue out",
+          "type": "Refnum",
+          "refnum_type": "queue"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "overflow element",
+          "type": "String"
+        },
+        {
+          "index": 5,
+          "direction": "out",
+          "name": "overflow?",
+          "type": "Boolean"
+        },
+        {
+          "index": 6,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "9131": {
+      "name": "Wait on Notification with Notifier History",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "notifier",
+          "type": "Refnum",
+          "refnum_type": "notifier"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "ignore previous (F)",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "timeout in ms (-1)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "notifier out",
+          "type": "Refnum",
+          "refnum_type": "notifier"
+        },
+        {
+          "index": 5,
+          "direction": "out",
+          "name": "notification",
+          "type": "String"
+        },
+        {
+          "index": 6,
+          "direction": "out",
+          "name": "timed out?",
+          "type": "Boolean"
+        },
+        {
+          "index": 7,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "9132": {
+      "name": "Wait on Notification from Multiple with Notifier History",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "notifiers",
+          "type": "Array"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "ignore previous (F)",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "timeout in ms (-1)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "notifier out",
+          "type": "Array"
+        },
+        {
+          "index": 5,
+          "direction": "out",
+          "name": "notifiers out",
+          "type": "Array"
+        },
+        {
+          "index": 6,
+          "direction": "out",
+          "name": "timed out?",
+          "type": "Boolean"
+        },
+        {
+          "index": 7,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "9140": {
+      "name": "IrDA Create Listener",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "listener ID",
+          "type": "Refnum",
+          "refnum_type": "irda"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "service name",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "9141": {
+      "name": "IrDA Discover",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "device list",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "number of devices",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "9142": {
+      "name": "IrDA Open Connection",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "connection ID",
+          "type": "Refnum",
+          "refnum_type": "irda"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "timeout ms (60000)",
           "type": "NumInt32"
         },
         {
           "index": 4,
           "direction": "in",
-          "name": "string",
+          "name": "remote device id",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "service name",
           "type": "String"
         }
       ],
-      "placeholder": true,
-      "python_code": "pass",
-      "note": "Decimal String To Number (NI doc) -- string, offset, default -> offset past number, number. Terminals from 'Results Status Update Process__core.vi', 'Get LV Mem Usage.vi'. Placeholder codegen: integer-only scan, needs float/exponent handling."
-    },
-    "1350": {
-      "name": "Unknown Boolean-Sink Primitive 1350",
-      "placeholder": true,
       "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "9143": {
+      "name": "IrDA Wait On Listener",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "remote device ID",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "remote LSAP-SEL",
+          "type": "String"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "listener ID out",
+          "type": "Refnum",
+          "refnum_type": "irda"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "connection ID",
+          "type": "Refnum",
+          "refnum_type": "irda"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "timeout ms (wait forever: -1)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "resolve remote address (T)",
+          "type": "Boolean",
+          "hidden": true
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "listener ID in",
+          "type": "Refnum",
+          "refnum_type": "irda"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "9144": {
+      "name": "IrDA Close Connection",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "connection ID out",
+          "type": "Refnum",
+          "refnum_type": "irda"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "abort (F)",
+          "type": "Boolean"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "connection ID",
+          "type": "Refnum",
+          "refnum_type": "irda"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "9145": {
+      "name": "IrDA Read",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "data out",
+          "type": "String"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "connection ID out",
+          "type": "Refnum",
+          "refnum_type": "irda"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "mode (standard)",
+          "type": "Enum16"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "timeout ms (25000)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "bytes to read",
+          "type": "NumInt32"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "connection ID",
+          "type": "Refnum",
+          "refnum_type": "irda"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "9146": {
+      "name": "IrDA Write",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "bytes written",
+          "type": "NumInt32"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "connection ID out",
+          "type": "Refnum",
+          "refnum_type": "irda"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "timeout ms (25000)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "data in",
+          "type": "String"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "connection ID",
+          "type": "Refnum",
+          "refnum_type": "irda"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "9147": {
+      "name": "Bluetooth Wait On Listener",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "remote channel",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "remote address",
+          "type": "String"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "listener ID out",
+          "type": "Refnum",
+          "refnum_type": "bluetooth_net_connection"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "connection ID",
+          "type": "Refnum",
+          "refnum_type": "bluetooth_net_connection"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "timeout ms (wait forever: -1)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "resolve remote address (T)",
+          "type": "Boolean",
+          "hidden": true
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "listener ID in",
+          "type": "Refnum",
+          "refnum_type": "bluetooth_net_connection"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "9148": {
+      "name": "Bluetooth Close Connection",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "connection ID out",
+          "type": "Refnum",
+          "refnum_type": "bluetooth_net_connection"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "abort (F)",
+          "type": "Boolean"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "connection ID",
+          "type": "Refnum",
+          "refnum_type": "bluetooth_net_connection"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "9149": {
+      "name": "Bluetooth Read",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "data out",
+          "type": "String"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "connection ID out",
+          "type": "Refnum",
+          "refnum_type": "bluetooth_net_connection"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "mode (standard)",
+          "type": "Enum16"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "timeout ms (25000)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "bytes to read",
+          "type": "NumInt32"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "connection ID",
+          "type": "Refnum",
+          "refnum_type": "bluetooth_net_connection"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "9150": {
+      "name": "Bluetooth Write",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "bytes written",
+          "type": "NumInt32"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "connection ID out",
+          "type": "Refnum",
+          "refnum_type": "bluetooth_net_connection"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "timeout ms (25000)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "data in",
+          "type": "String"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "connection ID",
+          "type": "Refnum",
+          "refnum_type": "bluetooth_net_connection"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "9151": {
+      "name": "Bluetooth Create Listener",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "channel",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "listener ID",
+          "type": "Refnum",
+          "refnum_type": "bluetooth_net_connection"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "service description",
+          "type": "Cluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "address",
+          "type": "String"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "uuid",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "9152": {
+      "name": "Bluetooth Discover",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "device list",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "number of devices",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "time limit ms (10000)",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "9153": {
+      "name": "Bluetooth Open Connection",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "connection ID",
+          "type": "Refnum",
+          "refnum_type": "bluetooth_net_connection"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "uuid",
+          "type": "String"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "timeout ms (60000)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "channel (0)",
+          "type": "NumUInt16"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "address",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "9154": {
+      "name": "Get Drag Drop Data",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "data",
+          "type": "String"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "type",
+          "type": "String"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "data name",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "9155": {
+      "name": "Lookup Channel Probe",
       "terminals": [
         {
           "index": 0,
           "direction": "in",
-          "name": "value",
+          "name": "refnum to monitor",
+          "type": "Refnum",
+          "refnum_type": "vi_server",
+          "class_id": 2,
+          "class_name": "VI"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "probe type specifier",
+          "type": "Refnum",
+          "refnum_type": "vi_server",
+          "class_id": 2,
+          "class_name": "VI"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "force create?",
+          "type": "Boolean"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "probe VI refnum",
+          "type": "Refnum",
+          "refnum_type": "vi_server",
+          "class_id": 2,
+          "class_name": "VI"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "type mismatched?",
           "type": "Boolean"
         }
       ],
-      "python_code": "pass",
-      "note": "Unknown Boolean-Sink Primitive 1350 -- single Boolean input, no outputs; a terminal branch-sink fed by 'Simple Error Handler.vi' or 1340. Seen in 6 VIs (PCO camera, Moog SmartMotor examples). No NI match; placeholder."
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "11163": {
+      "name": "Unknown",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "input fixed-point number",
+          "type": "FixedPoint"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "Encoding",
+          "type": "Cluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23000": {
+      "name": "Unpackage Matrix",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "matrix",
+          "type": "Cluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "matrix",
+          "type": "Cluster"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "array",
+          "type": "Array"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23001": {
+      "name": "Package Matrix",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "matrix",
+          "type": "Cluster"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "array",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "matrix",
+          "type": "Cluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23050": {
+      "name": "Inverse Cosecant",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "arccsc(x)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23051": {
+      "name": "Inverse Secant",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "arcsec(x)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23052": {
+      "name": "Inverse Cotangent",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "arccot(x)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23053": {
+      "name": "Hyperbolic Cosecant",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "csch(x)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23054": {
+      "name": "Hyperbolic Secant",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "sech(x)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23055": {
+      "name": "Hyperbolic Cotangent",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "coth(x)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23056": {
+      "name": "Inverse Hyperbolic Cosecant",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "arccsch(x)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23057": {
+      "name": "Inverse Hyperbolic Secant",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "arcsech(x)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23058": {
+      "name": "Inverse Hyperbolic Cotangent",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "arccoth(x)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23059": {
+      "name": "Square",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "x^2",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23060": {
+      "name": "Re/Im To Polar",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "theta",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "r",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "y",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23061": {
+      "name": "Polar To Re/Im",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "y",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "x",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "theta",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "r",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23062": {
+      "name": "Y-th Root of X",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "y-th root(x)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "y",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23063": {
+      "name": "Empty Array?",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "empty",
+          "type": "Boolean"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "array",
+          "type": "Array"
+        }
+      ],
+      "python_code": {
+        "empty": "len(in_1) == 0"
+      },
+      "inline": true,
+      "verified": true,
+      "doc_url": "https://www.ni.com/docs/en-US/bundle/labview-api-ref/page/functions/empty-array.html"
+    },
+    "23064": {
+      "name": "Floating Point Equal",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "x ~ y?",
+          "type": "Boolean"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "y",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "tolerance",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "x",
+          "type": "NumFloat64"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23065": {
+      "name": "Sort Array of String",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "sorted array",
+          "type": "Array"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "array",
+          "type": "Array"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23066": {
+      "name": "Text to UTF-8",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "utf-8 text",
+          "type": "String"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "encoding",
+          "type": "NumInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "text",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23067": {
+      "name": "Text to UTF-8",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "text",
+          "type": "String"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "encoding",
+          "type": "NumInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "utf-8 text",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23068": {
+      "name": "Transpose 1D Array",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "transposed array",
+          "type": "Array"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "1D array",
+          "type": "Array"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23778": {
+      "name": "Shared Variable",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "?",
+          "type": "Void"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23779": {
+      "name": "Open Variable Connection",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "shared variable refnum in",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "shared variable refnum out",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "data type",
+          "type": "Void"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "access",
+          "type": "Cluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23781": {
+      "name": "Read Variable",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "shared variable refnum in",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "shared variable refnum out",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "data type",
+          "type": "Void"
+        },
+        {
+          "index": 5,
+          "direction": "out",
+          "name": "data out",
+          "type": "Void"
+        },
+        {
+          "index": 6,
+          "direction": "out",
+          "name": "timestamp",
+          "type": "Timestamp"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23782": {
+      "name": "Write Variable",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "shared variable refnum in",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "shared variable refnum out",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "data in",
+          "type": "Void"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23783": {
+      "name": "Close Variable Connection",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "shared variable refnum in",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23784": {
+      "name": "Scanned Variable Read",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "shared variable refnum in",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "shared variable refnum out",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "data type",
+          "type": "Void"
+        },
+        {
+          "index": 5,
+          "direction": "out",
+          "name": "data out",
+          "type": "Void"
+        },
+        {
+          "index": 6,
+          "direction": "out",
+          "name": "timestamp",
+          "type": "Timestamp"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23785": {
+      "name": "Direct Variable Read",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "shared variable refnum in",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "shared variable refnum out",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "data type",
+          "type": "Void"
+        },
+        {
+          "index": 5,
+          "direction": "out",
+          "name": "data out",
+          "type": "Void"
+        },
+        {
+          "index": 6,
+          "direction": "out",
+          "name": "timestamp",
+          "type": "Timestamp"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23786": {
+      "name": "Read Variable with Timeout",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "shared variable refnum in",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "shared variable refnum out",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "data type",
+          "type": "Void"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "timeout ms",
+          "type": "NumInt32"
+        },
+        {
+          "index": 6,
+          "direction": "out",
+          "name": "timed out?",
+          "type": "Boolean"
+        },
+        {
+          "index": 7,
+          "direction": "out",
+          "name": "data out",
+          "type": "Void"
+        },
+        {
+          "index": 8,
+          "direction": "out",
+          "name": "timestamp",
+          "type": "Timestamp"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23787": {
+      "name": "Scanned Variable Write",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "shared variable refnum in",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "shared variable refnum out",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "data in",
+          "type": "Void"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23788": {
+      "name": "Direct Variable Write",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "shared variable refnum in",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "shared variable refnum out",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "data in",
+          "type": "Void"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23789": {
+      "name": "Write Variable with Timeout",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "shared variable refnum in",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "shared variable refnum out",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "data in",
+          "type": "Void"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "timeout ms",
+          "type": "NumInt32"
+        },
+        {
+          "index": 6,
+          "direction": "out",
+          "name": "timed out?",
+          "type": "Boolean"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23790": {
+      "name": "Open and Verify Variable Connection",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "shared variable refnum in",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "shared variable refnum out",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "data type",
+          "type": "Void"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "access",
+          "type": "Cluster"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "timeout ms",
+          "type": "NumInt32"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "buffer size in elements",
+          "type": "NumUInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23791": {
+      "name": "Open Variable Connection in Background",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "shared variable refnum in",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "shared variable refnum out",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "data type",
+          "type": "Void"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "access",
+          "type": "Cluster"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "buffer size in elements",
+          "type": "NumUInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23793": {
+      "name": "Create Network Stream Endpoint",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "endpoint",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "timeout in ms (-1)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "element allocation mode",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "buffer sizes",
+          "type": "Cluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "data type",
+          "type": "Void"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "remote endpoint url",
+          "type": "String"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "endpoint name",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23794": {
+      "name": "Destroy Stream Endpoint",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "endpoint in",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23795": {
+      "name": "Create Unique Network Stream Endpoint",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "endpoint",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "max connections (-1)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "timeout in ms (-1)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "element allocation mode",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "buffer sizes",
+          "type": "Cluster"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "data type",
+          "type": "Void"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "base endpoint name",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23796": {
+      "name": "Create Stream",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "endpoint in",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "endpoint out",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "data type",
+          "type": "Void"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "access",
+          "type": "Cluster"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "buffer size",
+          "type": "NumUInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23797": {
+      "name": "Read Single Element from Stream",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "endpoint in",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "endpoint out",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "data type",
+          "type": "Void"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "timeout ms (-1)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 6,
+          "direction": "out",
+          "name": "timed out?",
+          "type": "Boolean"
+        },
+        {
+          "index": 7,
+          "direction": "out",
+          "name": "data out",
+          "type": "Void"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23798": {
+      "name": "Write Single Element to Stream",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "endpoint in",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "endpoint out",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "data in",
+          "type": "Void"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "timeout ms (-1)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 6,
+          "direction": "out",
+          "name": "timed out?",
+          "type": "Boolean"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23802": {
+      "name": "Search Variable Container",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "refnum array out",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "container refnum out",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "access type",
+          "type": "Cluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "class",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "data type",
+          "type": "LVVariant"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "regular expression",
+          "type": "String"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "container refnum in",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23803": {
+      "name": "Read Multiple Elements from Stream",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "endpoint in",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "endpoint out",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "data type",
+          "type": "Void"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "timeout ms (-1)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 6,
+          "direction": "out",
+          "name": "timed out?",
+          "type": "Boolean"
+        },
+        {
+          "index": 7,
+          "direction": "out",
+          "name": "data out",
+          "type": "Array"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "# elements (-1)",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23804": {
+      "name": "Write Multiple Elements to Stream",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "endpoint in",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "endpoint out",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "data in",
+          "type": "Void"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "timeout ms (-1)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 6,
+          "direction": "out",
+          "name": "timed out?",
+          "type": "Boolean"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23806": {
+      "name": "Create Unique Network Stream Writer Endpoint",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "writer endpoint",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "max connections (-1)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "timeout in ms (-1)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "element allocation mode",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "writer buffer size",
+          "type": "NumInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "data type",
+          "type": "Void"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "base writer name",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23807": {
+      "name": "Create Unique Network Stream Reader Endpoint",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "reader endpoint",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "max connections (-1)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "timeout in ms (-1)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "element allocation mode",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "reader buffer size",
+          "type": "NumInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "data type",
+          "type": "Void"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "base reader name",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23808": {
+      "name": "Flush Stream",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "timed out?",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "endpoint out",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "timeout in ms (-1)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "wait condition",
+          "type": "NumUInt8"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "endpoint in",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23810": {
+      "name": "Create Network Stream Writer Endpoint",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "writer endpoint",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "timeout in ms (-1)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "element allocation mode",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "writer buffer size",
+          "type": "NumInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "data type",
+          "type": "Void"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "reader url",
+          "type": "String"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "writer name",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "23811": {
+      "name": "Create Network Stream Reader Endpoint",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "reader endpoint",
+          "type": "Refnum",
+          "refnum_type": "user_defined_refnum_tag"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "timeout in ms (-1)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "element allocation mode",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "reader buffer size",
+          "type": "NumInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "data type",
+          "type": "Void"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "writer url",
+          "type": "String"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "reader name",
+          "type": "String"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24000": {
+      "name": "RT FIFO Create",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "name (unnamed)",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "type",
+          "type": "LVVariant"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "create if not found? (T)",
+          "type": "Boolean"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "size (10)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "datapoints in waveform (1)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "elements in array (1)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "r/w modes (polling,polling)",
+          "type": "Cluster"
+        },
+        {
+          "index": 8,
+          "direction": "out",
+          "name": "rt fifo",
+          "type": "Refnum",
+          "refnum_type": "rt_fifo"
+        },
+        {
+          "index": 9,
+          "direction": "out",
+          "name": "created new?",
+          "type": "Boolean"
+        },
+        {
+          "index": 10,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24001": {
+      "name": "RT FIFO Read",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "rt fifo",
+          "type": "Refnum",
+          "refnum_type": "rt_fifo"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "element",
+          "type": "String"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "timeout in ms (0)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "# elements",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 5,
+          "direction": "out",
+          "name": "rt fifo out",
+          "type": "Refnum",
+          "refnum_type": "rt_fifo"
+        },
+        {
+          "index": 6,
+          "direction": "out",
+          "name": "element out",
+          "type": "String"
+        },
+        {
+          "index": 7,
+          "direction": "out",
+          "name": "empty?",
+          "type": "Boolean"
+        },
+        {
+          "index": 8,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24002": {
+      "name": "RT FIFO Write",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "rt fifo",
+          "type": "Refnum",
+          "refnum_type": "rt_fifo"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "element",
+          "type": "String"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "timeout in ms (0)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "overwrite on timeout (T)",
+          "type": "Boolean"
+        },
+        {
+          "index": 5,
+          "direction": "out",
+          "name": "# elements",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 6,
+          "direction": "out",
+          "name": "rt fifo out",
+          "type": "Refnum",
+          "refnum_type": "rt_fifo"
+        },
+        {
+          "index": 7,
+          "direction": "out",
+          "name": "timed out?",
+          "type": "Boolean"
+        },
+        {
+          "index": 8,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24003": {
+      "name": "RT FIFO Delete",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "rt fifo",
+          "type": "Refnum",
+          "refnum_type": "rt_fifo"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "force destroy? (F)",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24110": {
+      "name": "TDMS Write",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "tdms file",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "data layout (0:decimated)",
+          "type": "Enum16"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "tdms file out",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "group name in (Untitled)",
+          "type": "String"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "group name out",
+          "type": "String"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "channel name(s) in (Untitled)",
+          "type": "Array"
+        },
+        {
+          "index": 6,
+          "direction": "out",
+          "name": "channel name(s) out",
+          "type": "Array"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "data",
+          "type": "Array"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 9,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24111": {
+      "name": "TDMS Read",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "tdms file",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "offset (0)",
+          "type": "NumInt64"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "count (-1: all)",
+          "type": "NumInt64"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "tdms file out",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "group name in",
+          "type": "String"
+        },
+        {
+          "index": 5,
+          "direction": "out",
+          "name": "group name out",
+          "type": "String"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "channel name(s) in",
+          "type": "Array"
+        },
+        {
+          "index": 7,
+          "direction": "out",
+          "name": "channel name(s) out",
+          "type": "Array"
+        },
+        {
+          "index": 8,
+          "direction": "out",
+          "name": "data",
+          "type": "Array"
+        },
+        {
+          "index": 9,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 10,
+          "direction": "in",
+          "name": "data type",
+          "type": "Array"
+        },
+        {
+          "index": 11,
+          "direction": "in",
+          "name": "return channels in file order? (F)",
+          "type": "Boolean"
+        },
+        {
+          "index": 12,
+          "direction": "out",
+          "name": "end of file?",
+          "type": "Boolean"
+        },
+        {
+          "index": 13,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24112": {
+      "name": "TDMS Open",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "tdms file out",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "create index file? (T)",
+          "type": "Boolean"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "disable buffering (T)",
+          "type": "Boolean"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "file format version (2.0)",
+          "type": "Enum16"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "byte order (2:little-endian)",
+          "type": "Enum16"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "operation (0:open)",
+          "type": "Enum16"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "file path",
+          "type": "Path"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24113": {
+      "name": "TDMS Close",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "file path out",
+          "type": "Path"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "tdms file",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24114": {
+      "name": "TDMS Set Properties",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "channel name out",
+          "type": "String"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "group name out",
+          "type": "String"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "tdms file out",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "property values",
+          "type": "Array"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "property names",
+          "type": "Array"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "channel name",
+          "type": "String"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "group name",
+          "type": "String"
+        },
+        {
+          "index": 9,
+          "direction": "in",
+          "name": "tdms file",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24115": {
+      "name": "TDMS Get Properties",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "channel name out",
+          "type": "String"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "group name out",
+          "type": "String"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "tdms file out",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "property values",
+          "type": "Array"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "data type",
+          "type": "String"
+        },
+        {
+          "index": 6,
+          "direction": "out",
+          "name": "property names",
+          "type": "Array"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "property name",
+          "type": "String"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 9,
+          "direction": "in",
+          "name": "channel name",
+          "type": "String"
+        },
+        {
+          "index": 10,
+          "direction": "in",
+          "name": "group name",
+          "type": "String"
+        },
+        {
+          "index": 11,
+          "direction": "in",
+          "name": "tdms file",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24116": {
+      "name": "TDMS List Contents",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "group/channel names",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "group names",
+          "type": "Array"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "tdms file out",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "group name",
+          "type": "String"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "tdms file",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24117": {
+      "name": "TDMS Flush",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "tdms file out",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "tdms file",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24118": {
+      "name": "TDMS Write IP",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "tdms file",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "tdms file out",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "group name in",
+          "type": "String"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "group name out",
+          "type": "String"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "channel names in",
+          "type": "Array"
+        },
+        {
+          "index": 5,
+          "direction": "out",
+          "name": "channel names out",
+          "type": "Array"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "data",
+          "type": "Array"
+        },
+        {
+          "index": 7,
+          "direction": "out",
+          "name": "data out",
+          "type": "Array"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 9,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24119": {
+      "name": "TDMS Defragment",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "file path",
+          "type": "Path"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24120": {
+      "name": "TDMS Refnum To File ID",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "object id",
+          "type": "NumUInt64"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "tdms file id",
+          "type": "NumUInt64"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "channel name",
+          "type": "String"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "group name",
+          "type": "String"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "tdms file",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24121": {
+      "name": "TDMS Advanced Open",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "sector size",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "tdms file out",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "enable asynchronous? (T)",
+          "type": "Boolean"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "disable buffering? (T)",
+          "type": "Boolean"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "operation (0:open)",
+          "type": "Enum16"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "file path",
+          "type": "Path"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24122": {
+      "name": "TDMS Set Channel Information",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "tdms file out",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "samples per channel",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "data type",
+          "type": "NumUInt8"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "data layout (0:non-interleaved)",
+          "type": "Enum16"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "channel name(s)",
+          "type": "Array"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "group name (Untitled)",
+          "type": "String"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "tdms file",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24123": {
+      "name": "TDMS Reserve File Size",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "tdms file out",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "data type",
+          "type": "NumUInt8"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "append? (T)",
+          "type": "Boolean"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "reserve size",
+          "type": "NumUInt64"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "tdms file",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24124": {
+      "name": "TDMS Configure Asynchronous Writes",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "tdms file out",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "timeout (5 s)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "max write size",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "data type",
+          "type": "NumUInt8"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "pre-allocate? (F)",
+          "type": "Boolean"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "max asynchronous writes (4)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "tdms file",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24125": {
+      "name": "TDMS Set Next Write Position",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "tdms file out",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "channel name in",
+          "type": "String"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "group name in",
+          "type": "String"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "from (0:start)",
+          "type": "Enum16"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "offset (0)",
+          "type": "NumInt64"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "tdms file",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24126": {
+      "name": "TDMS Advanced Synchronous Write",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "tdms file out",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "data",
+          "type": "Array"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "tdms file",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24127": {
+      "name": "TDMS Configure Asynchronous Reads",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "tdms file out",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "timeout (5 s)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "data type",
+          "type": "NumUInt8"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "buffer size",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "number of buffers (4)",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "tdms file",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24128": {
+      "name": "TDMS Start Asynchronous Reads",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "tdms file out",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "data type",
+          "type": "NumUInt8"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "total count (-1)",
+          "type": "NumInt64"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "tdms file",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24129": {
+      "name": "TDMS Advanced Synchronous Read",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "data",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "tdms file out",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "read process finished?",
+          "type": "Boolean"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "data type",
+          "type": "NumUInt8"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "",
+          "type": "NumInt64"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "tdms file",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24130": {
+      "name": "CPU Information",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "# of logical processors",
+          "type": "NumInt32"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "# of packages",
+          "type": "NumInt32"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "# of cores per package",
+          "type": "NumInt32"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "# of logical processors per core",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24131": {
+      "name": "Current Processor ID",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "current processor ID",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24132": {
+      "name": "Data Cache Size",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "cache level (2)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "total cache size (in bytes)",
+          "type": "NumInt32"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "cache entry size (in bytes)",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24133": {
+      "name": "Number of Cache Levels",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "# of cache levels",
+          "type": "NumInt32"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24135": {
+      "name": "Preallocated Read from Binary File",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "num elements read",
+          "type": "NumInt32"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "data out",
+          "type": "Array"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "refnum out",
+          "type": "Refnum",
+          "refnum_type": "byte_stream"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "byte order (0:big-endian, network order)",
+          "type": "Enum16"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "data in",
+          "type": "Array"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "refnum in",
+          "type": "Refnum",
+          "refnum_type": "byte_stream"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24136": {
+      "name": "TDMS Stop Asynchronous Reads",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "tdms file out",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "tdms file",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24137": {
+      "name": "TDMS Get Asynchronous Write Status",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "number of pending writes",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "tdms file out",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "tdms file",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24138": {
+      "name": "TDMS Advanced Close",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "file path out",
+          "type": "Path"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "timeout (10 s)",
+          "type": "NumFloat64"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "truncate file? (F)",
+          "type": "Boolean"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "tdms file",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24139": {
+      "name": "TDMS Set Next Read Position",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "tdms file out",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "channel name in",
+          "type": "String"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "group name in",
+          "type": "String"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "from (0: start)",
+          "type": "Enum16"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "offset (0)",
+          "type": "NumInt64"
+        },
+        {
+          "index": 7,
+          "direction": "in",
+          "name": "tdms file",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24140": {
+      "name": "TDMS Get Asynchronous Read Status",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "all buffers full?",
+          "type": "Boolean"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "number of buffers available",
+          "type": "NumUInt32"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "tdms file out",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "tdms file",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24141": {
+      "name": "TDMS Advanced Asynchronous Write",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "tdms file out",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "data",
+          "type": "Array"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "tdms file",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24142": {
+      "name": "TDMS Advanced Asynchronous Read",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "data",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "tdms file out",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "read process finished?",
+          "type": "Boolean"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "data type",
+          "type": "NumUInt8"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "tdms file",
+          "type": "Refnum",
+          "refnum_type": "tdms_file"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24201": {
+      "name": "Flatten To JSON",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "anything",
+          "type": "Cluster"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "enable LabVIEW extensions? (T)",
+          "type": "Boolean"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "JSON string",
+          "type": "String"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24202": {
+      "name": "Unflatten From JSON",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "JSON string",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "type and defaults",
+          "type": "Cluster"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "path",
+          "type": "Array"
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "default null elements? (F)",
+          "type": "Boolean"
+        },
+        {
+          "index": 5,
+          "direction": "in",
+          "name": "enable LabVIEW extensions? (T)",
+          "type": "Boolean"
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "strict validation? (F)",
+          "type": "Boolean"
+        },
+        {
+          "index": 7,
+          "direction": "out",
+          "name": "value",
+          "type": "Cluster"
+        },
+        {
+          "index": 8,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24203": {
+      "name": "Set Control Values by Index",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "VI Refnum",
+          "type": "Refnum",
+          "refnum_type": "vi_server",
+          "class_id": 2,
+          "class_name": "VI"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "control indexes",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "data values",
+          "type": "Array"
+        },
+        {
+          "index": 3,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24204": {
+      "name": "Get Control Values by Index",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "VI Refnum",
+          "type": "Refnum",
+          "refnum_type": "vi_server",
+          "class_id": 2,
+          "class_name": "VI"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "control indexes",
+          "type": "Array"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "data values",
+          "type": "Array"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24205": {
+      "name": "Python Node",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "session in",
+          "type": "Refnum",
+          "refnum_type": "python_session"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "session out",
+          "type": "Refnum",
+          "refnum_type": "python_session"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "module in",
+          "type": "Path"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "module out",
+          "type": "Path",
+          "hidden": true
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "module out",
+          "type": "String"
+        },
+        {
+          "index": 5,
+          "direction": "out",
+          "name": "function name in",
+          "type": "String",
+          "hidden": true
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "function name in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 7,
+          "direction": "out",
+          "name": "function name out",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "Void"
+        },
+        {
+          "index": 9,
+          "direction": "out",
+          "name": "error out",
+          "type": "Void"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24206": {
+      "name": "Open Python Session",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "python version",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "python path",
+          "type": "Path"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "session out",
+          "type": "Refnum",
+          "refnum_type": "python_session"
+        },
+        {
+          "index": 4,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24207": {
+      "name": "Close Python Session",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "session in",
+          "type": "Refnum",
+          "refnum_type": "python_session"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24208": {
+      "name": "Open MATLAB Session",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "release name",
+          "type": "String"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "session out",
+          "type": "Refnum",
+          "refnum_type": "matlab_session"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24209": {
+      "name": "Close MATLAB Session",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "session in",
+          "type": "Refnum",
+          "refnum_type": "matlab_session"
+        },
+        {
+          "index": 1,
+          "direction": "in",
+          "name": "error in",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 2,
+          "direction": "out",
+          "name": "error out",
+          "type": "ErrorCluster"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
+    },
+    "24210": {
+      "name": "Call MATLAB Function",
+      "terminals": [
+        {
+          "index": 0,
+          "direction": "in",
+          "name": "session in",
+          "type": "Refnum",
+          "refnum_type": "matlab_session"
+        },
+        {
+          "index": 1,
+          "direction": "out",
+          "name": "session out",
+          "type": "Refnum",
+          "refnum_type": "matlab_session"
+        },
+        {
+          "index": 2,
+          "direction": "in",
+          "name": "source file path",
+          "type": "Path"
+        },
+        {
+          "index": 3,
+          "direction": "out",
+          "name": "function name",
+          "type": "Path",
+          "hidden": true
+        },
+        {
+          "index": 4,
+          "direction": "in",
+          "name": "error in (no error)",
+          "type": "String",
+          "hidden": true
+        },
+        {
+          "index": 5,
+          "direction": "out",
+          "name": "error out",
+          "type": "String",
+          "hidden": true
+        },
+        {
+          "index": 6,
+          "direction": "in",
+          "name": "function name",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 7,
+          "direction": "out",
+          "name": "error in (no error)",
+          "type": "ErrorCluster"
+        },
+        {
+          "index": 8,
+          "direction": "in",
+          "name": "error out",
+          "type": "Void"
+        },
+        {
+          "index": 9,
+          "direction": "out",
+          "name": "return type",
+          "type": "Void"
+        }
+      ],
+      "verified": false,
+      "source": "vi-scripting-nodes-lv2025"
     }
   },
   "node_types": {

--- a/src/lvkit/parser/node_types.py
+++ b/src/lvkit/parser/node_types.py
@@ -1260,10 +1260,13 @@ _HANDLERS: list[NodeTypeHandler] = [
     _BuiltinPrimitiveHandler("aIndx", "Index Array", None),
     _BuiltinPrimitiveHandler("subset", "Array Subset", None),
     # mergeErrors/oHExt have NO node_types entry, so their primResID IS the
-    # resolution path (and is not counter-indicated: 2401 really is Merge Errors;
-    # 8069 has no competing prim-class entry). Keep them until/unless they get a
-    # node_types entry.
-    _BuiltinPrimitiveHandler("mergeErrors", "Merge Errors", 2401),
+    # resolution path (and is not counter-indicated: 2147 really is Merge
+    # Errors -- confirmed by nodes.json's VI-Scripting export, whose pane for
+    # 2147 is error_cluster out x1 / error_cluster in x2, matching the
+    # expandable Merge Errors doc; 2401 is a different primitive, Swap Values
+    # (#59). 8069 has no competing prim-class entry). Keep them until/unless
+    # they get a node_types entry.
+    _BuiltinPrimitiveHandler("mergeErrors", "Merge Errors", 2147),
     _BuiltinPrimitiveHandler("oHExt", "Obtain/Release Semaphore", 8069),
     # Class-resolved primitives — no numeric primResID. These resolve via the
     # node_types section of primitives.json by XML class. Do NOT borrow a numeric

--- a/tests/test_condition_builder.py
+++ b/tests/test_condition_builder.py
@@ -123,12 +123,12 @@ class TestComparisonPrimitives:
             {"src_x": "value", "src_y": "threshold"},
         )
 
-        # Less? primitive (1107)
+        # Less? primitive (1111)
         cmp_op = PrimitiveOperation(
             id="cmp1",
             name="Less?",
             kind="primitive",
-            primResID=1107,
+            primResID=1111,
             terminals=[
                 Terminal(id="cmp_in1", index=0, direction="input"),
                 Terminal(id="cmp_in2", index=1, direction="input"),
@@ -153,12 +153,12 @@ class TestBooleanPrimitives:
             {"src_a": "flag_a", "src_b": "flag_b"},
         )
 
-        # And primitive (1100)
+        # And primitive (1061)
         and_op = PrimitiveOperation(
             id="and1",
             name="And",
             kind="primitive",
-            primResID=1100,
+            primResID=1061,
             terminals=[
                 Terminal(id="and_in1", index=0, direction="input"),
                 Terminal(id="and_in2", index=1, direction="input"),
@@ -179,12 +179,12 @@ class TestBooleanPrimitives:
             {"src_a": "done", "src_b": "timeout"},
         )
 
-        # Or primitive (1101)
+        # Or primitive (1062)
         or_op = PrimitiveOperation(
             id="or1",
             name="Or",
             kind="primitive",
-            primResID=1101,
+            primResID=1062,
             terminals=[
                 Terminal(id="or_in1", index=0, direction="input"),
                 Terminal(id="or_in2", index=1, direction="input"),
@@ -209,12 +209,12 @@ class TestNotPrimitive:
             {"src_x": "running"},
         )
 
-        # Not primitive (1109)
+        # Not primitive (1064)
         not_op = PrimitiveOperation(
             id="not1",
             name="Not",
             kind="primitive",
-            primResID=1109,
+            primResID=1064,
             terminals=[
                 Terminal(id="not_in", index=0, direction="input"),
                 Terminal(id="not_out", index=1, direction="output"),
@@ -277,12 +277,12 @@ class TestNestedExpressions:
             ],
         )
 
-        # Or (1101)
+        # Or (1062)
         or_op = PrimitiveOperation(
             id="or1",
             name="Or",
             kind="primitive",
-            primResID=1101,
+            primResID=1062,
             terminals=[
                 Terminal(id="or_in1", index=0, direction="input"),
                 Terminal(id="or_in2", index=1, direction="input"),
@@ -310,12 +310,12 @@ class TestNestedExpressions:
             {"src_x": "value", "src_y": "limit"},
         )
 
-        # Less? (1107)
+        # Less? (1111)
         cmp_op = PrimitiveOperation(
             id="cmp1",
             name="Less?",
             kind="primitive",
-            primResID=1107,
+            primResID=1111,
             terminals=[
                 Terminal(id="cmp_in1", index=0, direction="input"),
                 Terminal(id="cmp_in2", index=1, direction="input"),
@@ -323,12 +323,12 @@ class TestNestedExpressions:
             ],
         )
 
-        # Not (1109)
+        # Not (1064)
         not_op = PrimitiveOperation(
             id="not1",
             name="Not",
             kind="primitive",
-            primResID=1109,
+            primResID=1064,
             terminals=[
                 Terminal(id="not_in", index=0, direction="input"),
                 Terminal(id="not_out", index=1, direction="output"),
@@ -473,16 +473,16 @@ class TestPrimitiveMappings:
         """Verify comparison primitive IDs map to correct AST operators."""
         assert COMPARISON_PRIMITIVES[1102] == ast.Eq
         assert COMPARISON_PRIMITIVES[1103] == ast.GtE
+        assert COMPARISON_PRIMITIVES[1104] == ast.LtE
         assert COMPARISON_PRIMITIVES[1105] == ast.NotEq
-        assert COMPARISON_PRIMITIVES[1107] == ast.Lt
-        assert COMPARISON_PRIMITIVES[1108] == ast.LtE
         assert COMPARISON_PRIMITIVES[1110] == ast.Gt
+        assert COMPARISON_PRIMITIVES[1111] == ast.Lt
 
     def test_boolean_primitives_mapping(self):
         """Verify boolean primitive IDs map to correct AST operators."""
-        assert BOOLEAN_PRIMITIVES[1100] == ast.And
-        assert BOOLEAN_PRIMITIVES[1101] == ast.Or
+        assert BOOLEAN_PRIMITIVES[1061] == ast.And
+        assert BOOLEAN_PRIMITIVES[1062] == ast.Or
 
     def test_not_primitives_set(self):
         """Verify NOT primitive ID is in the set."""
-        assert 1109 in NOT_PRIMITIVES
+        assert 1064 in NOT_PRIMITIVES

--- a/tests/test_error_codegen.py
+++ b/tests/test_error_codegen.py
@@ -2,7 +2,7 @@
 
 Covers:
 - ErrorHandlingPattern classification
-- Merge Errors (prim 2401) produces empty fragment
+- Merge Errors (prim 2147) produces empty fragment
 - needs_error_handling() graph-driven detection
 - future.result() wrapping with held-error model
 - No wrapping when no error handling nodes present
@@ -94,8 +94,8 @@ def _make_terminal(
 class TestClassifyErrorNode:
     """classify_error_node identifies error handling patterns."""
 
-    def test_merge_errors_prim_2401(self):
-        op = _make_op("m", prim_res_id=2401, kind="primitive")
+    def test_merge_errors_prim_2147(self):
+        op = _make_op("m", prim_res_id=2147, kind="primitive")
         assert classify_error_node(op) == ErrorHandlingPattern.MERGE
 
     def test_clear_errors_subvi(self):
@@ -141,7 +141,7 @@ class TestNeedsErrorHandling:
     def test_merge_errors_returns_true(self):
         ops = [
             _make_op("a"),
-            _make_op("m", prim_res_id=2401, kind="primitive"),
+            _make_op("m", prim_res_id=2147, kind="primitive"),
         ]
         assert needs_error_handling(ops) is True
 
@@ -152,7 +152,7 @@ class TestNeedsErrorHandling:
 
     def test_merge_errors_in_case_frame(self):
         """Merge Errors nested in a case frame is detected."""
-        inner_op = _make_op("m", prim_res_id=2401, kind="primitive")
+        inner_op = _make_op("m", prim_res_id=2147, kind="primitive")
         frame = CaseFrame(
             selector_value="default",
             is_default=True,
@@ -163,7 +163,7 @@ class TestNeedsErrorHandling:
 
     def test_merge_errors_in_inner_nodes(self):
         """Merge Errors in inner_nodes is detected."""
-        inner_op = _make_op("m", prim_res_id=2401, kind="primitive")
+        inner_op = _make_op("m", prim_res_id=2147, kind="primitive")
         outer = _make_op("loop", inner_nodes=[inner_op])
         assert needs_error_handling([outer]) is True
 
@@ -174,13 +174,13 @@ class TestNeedsErrorHandling:
 
 
 class TestMergeErrorsNoOp:
-    """Merge Errors (prim 2401) produces no code."""
+    """Merge Errors (prim 2147) produces no code."""
 
     def test_merge_errors_empty_fragment(self):
         merge_op = _make_op(
             "m",
             name="Merge Errors",
-            prim_res_id=2401,
+            prim_res_id=2147,
             kind="primitive",
             node_type="prim",
         )
@@ -211,7 +211,7 @@ class TestFutureResultWrapping:
         ]
 
         if include_merge:
-            ops.append(_make_op("M", prim_res_id=2401, kind="primitive"))
+            ops.append(_make_op("M", prim_res_id=2147, kind="primitive"))
 
         return VIContext(
             name="test_vi",
@@ -243,7 +243,7 @@ class TestFutureResultWrapping:
         ops = [
             _make_op("A", name="op_a", terminals=[a_out]),
             _make_op("B", name="op_b", terminals=[b_out]),
-            _make_op("M", prim_res_id=2401, kind="primitive"),
+            _make_op("M", prim_res_id=2147, kind="primitive"),
         ]
 
         vi_ctx = VIContext(

--- a/tests/test_primitive_name_uniqueness.py
+++ b/tests/test_primitive_name_uniqueness.py
@@ -6,12 +6,16 @@ skill calls duplicate names a red flag. In practice a batch of resolutions lande
 six such duplicates with nothing to catch them, because the only safeguard was
 "remember to check", which is the wrong place for an invariant.
 
-LabVIEW *does* legitimately give one function two resIDs (Absolute Value
-1054/1057; Split 1D Array 1056/1908 — identical panes, one returning SubArray
-views). So duplicates are not banned outright: they must be **explicitly
-reviewed**. Anything not listed below fails, which makes an accidental duplicate
+LabVIEW *does* legitimately give one function two resIDs on occasion (identical
+panes, e.g. one variant returning a view onto the other's result). So
+duplicates are not banned outright: they must be **explicitly reviewed**.
+Anything not listed below fails, which makes an accidental duplicate
 impossible to land silently while a proven twin is a one-line, evidence-carrying
-addition.
+addition. (REVIEWED_DUPLICATES is currently empty — its last two entries,
+Absolute Value 1054/1057 and Split 1D Array 1056/1908, turned out not to be
+twins after all: nodes.json's VI-Scripting export (#59) proved 1057 is really
+Increment and 1056 is really Quotient & Remainder, each a different function
+from 1054/1908, not a shared-pane variant.)
 
 To add an entry here you must have compared the two panes AS OBSERVED in the
 corpus (scripts/audit_primitive_consistency.py + the duplicate pane dump) — not
@@ -43,13 +47,24 @@ PRIMS = Path(__file__).resolve().parents[1] / "src/lvkit/data/primitives.json"
 # NEEDS-ADJUDICATION = panes materially DIFFER, so one of the pair is mislabeled;
 # tracked as debt, must not grow.
 REVIEWED_DUPLICATES: dict[str, set[str]] = {
-    # --- confirmed twins (observed panes identical) ---
-    "Logical Shift": {"1081", "1082"},  # same (data, shift)->data pane
-    "Split 1D Array": {"1056", "1908"},  # same pane; 1908 yields SubArray
     # --- pre-existing, inherited (predate the audit; not yet pane-compared) ---
-    "Absolute Value": {"1054", "1057"},
-    "Flatten To String": {"1165", "1189", "1608"},
-    "Get Type Information": {"1164", "8203"},
+    # NOTE (#59, VI-Scripting nodes-export import): 1082, 1056, 1165/1189/1608,
+    # and 1164/8203 were renamed away from these shared labels once the export
+    # supplied their real style_name ("Rotate", "Quotient & Remainder",
+    # "Unflatten From String"/"To Lower Case"/"String To Byte Array", and
+    # "Flatten To String"/"Variant To Flattened String" respectively) — so
+    # "Logical Shift", "Split 1D Array" (this pair), "Flatten To String" (this
+    # pair) and "Get Type Information" are no longer duplicated.
+    #
+    # "Absolute Value" {1054, 1057} was the one pair the import initially held
+    # back (import_nodes_primitives.py's HOLD_IDS), because 1057's nodes.json
+    # claim ("Increment") contradicted a verified:true corpus dataflow chain.
+    # The maintainer reviewed the conflict and confirmed nodes.json is correct
+    # (1057's own output terminal is literally named "x+1", not an
+    # absolute-value expression) — 1057 was corrected to "Increment", which
+    # dissolves this duplicate too, so it is no longer listed here either.
+    # REVIEWED_DUPLICATES is currently empty; kept as the mechanism for a
+    # FUTURE pane-compared twin.
 }
 # RESOLVED, no longer duplicated (kept as a record of what the gate caught):
 #   Close File / Open/Create/Replace File — 8011/8010 were never file I/O; they are
@@ -64,6 +79,48 @@ REVIEWED_DUPLICATES: dict[str, set[str]] = {
 #     (2D-in/2D-out across 8 element types in the corpus; 1900 is the real 1D
 #     reverse). Also Format Value (1540) was Array To Spreadsheet String (every
 #     instance takes a 1D array + single %s + delimiter; inverse of 1539).
+
+# --- ground-truth IMPORT collisions (#59), NOT pane-compared ---
+# The VI-Scripting nodes export (695 primResID -> real style_name) was bulk
+# merge-imported (scripts/import_nodes_primitives.py) as UNVERIFIED baseline
+# data (see project_080_primitives_baseline). Every pid below that carries
+# `"source": "vi-scripting-nodes-lv2025"` makes no verified-identity claim at
+# all — its name is the primitive's REAL name (confirmed straight from
+# LabVIEW's own VI-Scripting API, not guessed), so two such entries sharing a
+# name is expected LabVIEW reality (the same palette label legitimately
+# covers multiple resIDs — polymorphic/legacy/type-family variants), not a
+# guessing error the pane-comparison rule exists to catch. Listed here so the
+# gate doesn't block a legitimate provisional import; NOT a claim that any
+# pair's panes were compared. Re-verify (and fold into REVIEWED_DUPLICATES
+# proper once confirmed) via the normal lvkit-resolve-primitive workflow.
+IMPORT_UNVERIFIED_DUPLICATES: dict[str, set[str]] = {
+    "Add": {"1050", "3915"},
+    "Close File": {"1405", "8052"},
+    "Copy": {"1416", "8053"},
+    "Delete": {"1417", "8056"},
+    "Divide": {"1053", "3918"},
+    "File Dialog": {"1429", "8058", "8081"},
+    "File/Directory Info": {"1413", "8082"},
+    "Flatten To String": {"1160", "1164"},
+    "Flatten To XML": {"8400", "8402"},
+    "Flush File": {"1406", "8059"},
+    "List Folder": {"1418", "8083"},
+    # NOTE (#59, resolved 2026-08-27): "Merge Errors" {2147, 2401} and
+    # "Quotient & Remainder" {1056, 1108} were both listed here as HOLD_IDS
+    # corroborating evidence -- 2401/1108 each had a prior identity (Merge
+    # Errors / Quotient & Remainder respectively) that collided with the
+    # nodes.json-sourced 2147/1056. The maintainer confirmed nodes.json is
+    # correct for both (2401 is really Swap Values; 1108 is really Max & Min,
+    # each proven by their own terminal EXPRESSION text, not just style_name),
+    # so 2401 and 1108 were corrected away from these labels and both
+    # collisions are dissolved -- removed from this dict.
+    "Move": {"1415", "8068"},
+    "Multiply": {"1052", "3917"},
+    "Subtract": {"1051", "3916"},
+    "Text to UTF-8": {"23066", "23067"},
+    "Unflatten From String": {"1161", "1165"},
+    "Unknown": {"2372", "11163"},
+}
 
 
 def _duplicate_groups() -> dict[str, set[str]]:
@@ -81,7 +138,9 @@ def test_no_unreviewed_duplicate_primitive_names() -> None:
     groups = _duplicate_groups()
     problems = []
     for name, pids in sorted(groups.items()):
-        reviewed = REVIEWED_DUPLICATES.get(name)
+        reviewed = REVIEWED_DUPLICATES.get(name) or IMPORT_UNVERIFIED_DUPLICATES.get(
+            name
+        )
         if reviewed is None:
             problems.append(
                 f"NEW duplicate name {name!r} -> {sorted(pids, key=int)}. "
@@ -101,8 +160,12 @@ def test_no_unreviewed_duplicate_primitive_names() -> None:
 def test_reviewed_duplicates_still_exist() -> None:
     """Keep the review list honest — drop entries once a mislabel is fixed."""
     groups = _duplicate_groups()
-    stale = [n for n in REVIEWED_DUPLICATES if n not in groups]
+    stale = [
+        n
+        for n in {**REVIEWED_DUPLICATES, **IMPORT_UNVERIFIED_DUPLICATES}
+        if n not in groups
+    ]
     assert not stale, (
-        "REVIEWED_DUPLICATES lists names that are no longer duplicated "
-        f"(remove them): {stale}"
+        "REVIEWED_DUPLICATES/IMPORT_UNVERIFIED_DUPLICATES lists names that are "
+        f"no longer duplicated (remove them): {stale}"
     )

--- a/tests/test_primitive_positional_order.py
+++ b/tests/test_primitive_positional_order.py
@@ -1,18 +1,33 @@
 """Gate: a positionally-named input pair must sit on the slots its names imply.
 
 Why this exists: ``connector_geometry``'s index space runs Right->Left,
-Bottom->Top (idx0 = bottom-right), so on a two-input primitive the UPPER
-terminal carries the HIGHER index. NI documents the upper input of the dyadic
-arithmetic, comparison and logic primitives as ``x`` and the lower as ``y``
-(``n`` for the shift/scale pair). So ``x`` must always hold the higher index.
+Bottom->Top (idx0 = bottom-right), so on a two-input primitive with `x`/`y`
+(or `x`/`n`) inputs, one of them sits physically ABOVE the other and so must
+carry the HIGHER index -- WHICH terminal that is depends on the primitive
+FAMILY, and is measured from nodes.json's terminal geometry (#59, VI-Scripting
+nodes export), not assumed from NI-doc reading order:
 
-Nineteen entries had it backwards, because the names were filled in from
-NI-doc LISTING order (x first) against ASCENDING index -- which is bottom-up,
-so ``x`` landed on the lower slot. That is the same bug class as the
-Clear-Errors fix in 2f71ff2 (doc listing order mistaken for pane geometry),
-in the one variant ``connector_geometry_profile.audit_primitive`` explicitly
-cannot catch: both terminals share a type family, so a per-index direction/
-type diff sees nothing wrong either way round.
+- The dyadic ARITHMETIC/comparison/logic family (Add, Subtract, Divide,
+  Equal?, And, Or, ...): `x` sits ABOVE `y`/`n` -> `x` must hold the HIGHER
+  index. NI documents `x` as the upper input for this family.
+- The SHIFT/POWER family (X_LOWER_PRIMS below): `x` sits BELOW `y`/`n` --
+  confirmed by nodes.json's own output-terminal EXPRESSION text, which spells
+  the physical layout out directly: 1081/1082 output `x << y` (x first,
+  low/right slot in a left-shift idiom), 1074 outputs `x*2^n`, 1213/1224/1228/
+  23062 output `x^y`/`logx(y)`/`atan2(y,x)`/`y-th root(x)` -- in every one of
+  these, `y`/`n` is the exponent/shift-count/angle operand that NI's pane
+  puts on TOP, with `x` (the base/value operand) on the bottom. So for this
+  family `x` must hold the LOWER index -- the OPPOSITE rule from the
+  arithmetic family, not a violation of the same rule.
+
+Nineteen entries in the arithmetic/comparison/logic family had it backwards,
+because the names were filled in from NI-doc LISTING order (x first) against
+ASCENDING index -- which is bottom-up, so `x` landed on the lower slot. That
+is the same bug class as the Clear-Errors fix in 2f71ff2 (doc listing order
+mistaken for pane geometry), in the one variant
+``connector_geometry_profile.audit_primitive`` explicitly cannot catch: both
+terminals share a type family, so a per-index direction/type diff sees
+nothing wrong either way round.
 
 For this family the doc-image half of the auditor is not needed, because the
 NAMES themselves encode the geometry. That makes the invariant checkable as
@@ -27,6 +42,20 @@ Not Equal?) show no symptom, which is why this survived.
 SCOPE -- the SHIPPED catalog only, matching test_primitive_name_uniqueness.py.
 A project-local ``.lvkit/primitives.json`` override is the designed escape
 hatch and must never be scanned here.
+
+UNVERIFIED-IMPORT CAVEAT (#59): entries carrying ``"source":
+"vi-scripting-nodes-lv2025"`` (the bulk VI-Scripting nodes-export merge,
+scripts/import_nodes_primitives.py) that are still ``verified: false`` get
+their terminal ``index`` verbatim from the export's own per-terminal
+``index`` field -- which the SHIFT/POWER-family discovery above shows is NOT
+uniformly the arithmetic-family convention; a given entry needs its own
+geometry confirmation (lvkit-resolve-primitive Step 6, or the family
+membership check above) before this gate can judge it. No python_code ships
+for an unconfirmed entry, so there is no operand-binding consequence today.
+Excluded below; once a vi-scripting-sourced entry is confirmed and verified
+(as 1074/1081/1213 -- and 1057/1058, single-input so exempt from this gate
+entirely -- now are, #59), it drops out of the exemption and this gate covers
+it like everything else.
 """
 
 from __future__ import annotations
@@ -37,11 +66,19 @@ from pathlib import Path
 PRIMS = Path(__file__).resolve().parents[1] / "src/lvkit/data/primitives.json"
 
 # Input-name sets whose ordering is fixed by NI's documented pane layout.
-# First element is the DOCUMENTED UPPER terminal -> must hold the higher index.
+# First element is the DOCUMENTED UPPER terminal for the ARITHMETIC family
+# (X_LOWER_PRIMS below is the opposite convention -- see module docstring).
 POSITIONAL_PAIRS: tuple[tuple[str, str], ...] = (
     ("x", "y"),
     ("x", "n"),
 )
+
+# The shift/power family: `x` sits on the LOWER slot (geometry-confirmed from
+# nodes.json's own output-terminal expression text -- see module docstring),
+# the opposite of the arithmetic/comparison/logic family's convention. Every
+# member is non-commutative in x/y, so getting this backwards is exactly the
+# same silent-inversion risk the arithmetic family's rule guards against.
+X_LOWER_PRIMS: set[int] = {1074, 1081, 1082, 1213, 1224, 1228, 23062}
 
 
 def _entries() -> dict[str, dict]:
@@ -49,15 +86,29 @@ def _entries() -> dict[str, dict]:
 
 
 def _positional_two_input_entries():
-    """Yield (prim_id, entry, upper_name, lower_name) for each pair entry."""
+    """Yield (prim_id, entry, upper_name, lower_name) for each pair entry.
+
+    ``upper_name``/``lower_name`` are the LOGICAL roles (must-hold-higher-index
+    / must-hold-lower-index) after accounting for family: for the default
+    (arithmetic/comparison/logic) family ``x`` is upper; for X_LOWER_PRIMS
+    (shift/power family) the roles are swapped -- ``x`` is lower.
+    """
     for prim_id, entry in _entries().items():
+        if (
+            entry.get("verified") is False
+            and entry.get("source") == "vi-scripting-nodes-lv2025"
+        ):
+            continue  # see the UNVERIFIED-IMPORT CAVEAT in the module docstring
         ins = [t for t in entry.get("terminals", []) if t.get("direction") == "in"]
         if len(ins) != 2:
             continue
         names = {t.get("name") for t in ins}
-        for upper, lower in POSITIONAL_PAIRS:
-            if names == {upper, lower}:
-                yield prim_id, entry, upper, lower
+        for x_name, other_name in POSITIONAL_PAIRS:
+            if names == {x_name, other_name}:
+                if int(prim_id) in X_LOWER_PRIMS:
+                    yield prim_id, entry, other_name, x_name
+                else:
+                    yield prim_id, entry, x_name, other_name
                 break
 
 
@@ -68,7 +119,13 @@ def _input_indices(entry: dict) -> dict[str, int]:
 
 
 def test_positional_upper_input_has_higher_index() -> None:
-    """``x`` sits above ``y``/``n``, so it must carry the higher slot index."""
+    """The logical upper-slot input must carry the higher index.
+
+    For the default (arithmetic/comparison/logic) family that's ``x``; for
+    X_LOWER_PRIMS (shift/power family) the roles are swapped and it's
+    ``y``/``n`` -- ``_positional_two_input_entries`` already resolves which
+    name plays which role, so this check itself is family-agnostic.
+    """
     offenders = []
     for prim_id, entry, upper, lower in _positional_two_input_entries():
         idx = _input_indices(entry)
@@ -87,5 +144,6 @@ def test_gate_is_actually_covering_something() -> None:
     """Guard against the gate silently matching zero entries."""
     found = list(_positional_two_input_entries())
     assert len(found) >= 15, (
-        f"expected the dyadic arithmetic/comparison/logic family, got {len(found)}"
+        f"expected the dyadic arithmetic/comparison/logic + shift/power "
+        f"families, got {len(found)}"
     )

--- a/tests/test_primitive_resolutions.py
+++ b/tests/test_primitive_resolutions.py
@@ -9,19 +9,37 @@ Build Array routing. No user IP: only resID → function-identity facts.
 Four of these (1057, 1809, 1903, 1904) were ALL mislabeled "Array Size"; only
 1809 is really Array Size. The collision guard below stops a future edit from
 re-merging them.
+
+UPDATE (#59, 2026-08-27): 1057's onward identification as "Absolute Value"
+(pinned below as of this docstring's original writing) has since been
+corrected to "Increment" -- nodes.json's VI-Scripting export gives 1057's real
+output terminal as literally "x+1", proving the earlier context-based
+resolution had the right ALGORITHM (abs-value feeding an increment for a
+pixel-span computation) attached to the wrong primResID. The real
+Absolute-Value primitive in that calibration VI's pane is not yet
+re-identified. 1057's python_code was dropped pending that, then restored
+once corpus-confirmed (pylabview terminal_info) as its own real function --
+`in_1 + 1`, the genuine Increment semantics -- not the old Absolute-Value
+code, and not a stand-in for the calibration VI's still-unidentified abs-value
+step.
 """
 
 from __future__ import annotations
+
+import json
+from pathlib import Path
 
 import pytest
 
 from lvkit.primitive_resolver import get_resolver
 
+PRIMS = Path(__file__).resolve().parents[1] / "src/lvkit/data/primitives.json"
+
 EXPECTED_NAMES = {
     1809: "Array Size",
     1903: "Add Array Elements",
     1904: "Multiply Array Elements",
-    1057: "Absolute Value",
+    1057: "Increment",  # was "Absolute Value" -- corrected per nodes.json, #59
     1049: "Sign",
     1140: "To Byte Integer",
     # The 2-input arithmetic block: 1050 Add, 1051 Subtract, 1052 Multiply,
@@ -58,7 +76,10 @@ def test_key_python_code_semantics():
     assert "len(in_1)" in str(res.resolve(prim_id=1809).python_code)
     assert "sum(in_1)" in str(res.resolve(prim_id=1903).python_code)
     assert "prod(in_1)" in str(res.resolve(prim_id=1904).python_code)
-    assert "abs(in_1)" in str(res.resolve(prim_id=1057).python_code)
+    # 1057 no longer carries "abs(in_1)" -- it was corrected from the
+    # mislabeled "Absolute Value" to its real identity "Increment" (#59), and
+    # its own python_code ("in_1 + 1") was restored once corpus-confirmed.
+    assert "in_1 + 1" in str(res.resolve(prim_id=1057).python_code)
     # Sign -> +/-1, To Byte Integer -> saturating I8
     assert "(in_1 > 0) - (in_1 < 0)" in str(res.resolve(prim_id=1049).python_code)
     assert "127" in str(res.resolve(prim_id=1140).python_code)
@@ -126,16 +147,28 @@ def test_comparison_to_zero_block_verified_members():
     assert len(in_terms) == 1
 
 
-def test_1116_is_not_a_comparison_and_unresolved():
-    """1116 was mislabeled 'Call Chain' / a to-0 compare, but its corpus feeders
-    are boolean/cluster (not numeric). Kept only as a flagged placeholder (used
-    by TestCase.lvclass) — must never claim to be Call Chain or a comparison."""
+def test_1116_is_not_equal_to_zero():
+    """1116 was previously mislabeled 'Call Chain' / kept as a flagged
+    placeholder because its corpus feeders looked boolean/cluster, not
+    numeric. That finding was itself wrong: nodes.json's VI-Scripting export
+    (#59) gives 1116's real pane -- output terminal literally named 'x != 0?'
+    (Boolean) over a scalar double_float input 'x' -- confirming it as Not
+    Equal To 0?, one of the comparison-to-0 family alongside 1113/1114/1118
+    (see test_comparison_to_zero_block_verified_members). It was corrected
+    from the nodes.json ground truth, dropping the old placeholder along with
+    its now-superseded python_code -- codegen re-derivation is a separate
+    follow-on, so it resolves unverified with no python_code yet."""
     res = get_resolver()
     r = res.resolve(prim_id=1116)
     assert r is not None
-    assert r.name == "Unresolved primitive 1116"
-    assert r.name != "Call Chain"
-    assert "Equal" not in r.name and "Greater" not in r.name and "Less" not in r.name
+    assert r.name == "Not Equal To 0?"
+    assert r.confidence != "placeholder"
+    assert not r.python_code
+
+    entry = json.loads(PRIMS.read_text())["primitives"]["1116"]
+    assert entry.get("verified") is False
+    assert "python_code" not in entry
+    assert "placeholder" not in entry
 
 
 def test_1901_search_vs_delete_collision():


### PR DESCRIPTION
Closes #59.

Imports the public LabVIEW VI-Scripting node export as the ground-truth source for primitive identities, corrects a cluster of wrong/placeholder names, and fixes the operand-order and ID-mapping bugs that came with them.

## What changed

**Data (`feat(primitives)`)**
- New `builtin_types.json` — one unified terminal-type vocabulary aliasing the VI-Scripting names and the existing flat vocab.
- `primitives.json` 165 → 680 entries: 515 unverified baseline imports (name + terminals, no codegen), **31 identity corrections** verified against LabVIEW's own terminal-geometry (e.g. the 8016/8017/8018 class-cast rotation, Type Cast ← mislabeled String Subset, Increment/Decrement, Max & Min, Not Equal To 0?, Swap Values), and **5 fixed-arity operand-order inversions** whose codegen bound operands backwards (Logical Shift, Power Of X, Scale By Power Of 2, Join Numbers, In Range and Coerce). Increment/Decrement codegen restored.
- Deterministic, re-runnable importer; matches identity case-insensitively (a capitalization-only difference keeps its codegen); fails with the offending `style_id` named on an unknown type.
- `test_primitive_positional_order` gains a shift/power-family carve-out (`x` sits on the **lower** connector slot there — confirmed from nodes.json geometry and pylabview parmIndex in the corpus, opposite the arithmetic family).

**Codegen (`fix(codegen)`)**
- The while-loop condition builder keyed comparisons off phantom primResIDs no VI emits (1100/1101/1107/1108/1109); repointed to the real IDs (Less? 1111, Less Or Equal? 1104, And 1061, Or 1062, Not 1064).
- Merge Errors was keyed to 2401, which is actually **Swap Values**; repointed the class-string stamp and the error-cluster no-code handler to the real Merge Errors ID **2147**.

## Not included (deliberate follow-ons)
- Python codegen for the 515 baseline + corrected-identity primitives.
- Option B: class→id stamping + `node_types` retirement (only the 2147 Merge Errors piece landed here).
- Phase 2: palette split into `data/primitives/<category>.json`.

## Testing
Full suite green (ruff + pyright + pytest via the pre-commit hook on both commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
