### PR TITLE
fix(loading): stage + render SubVIs on the web — recorded-path resolution, inheritance, progressive staging

### DIFF
--- a/editors/vscode/build/check-web-parity.sh
+++ b/editors/vscode/build/check-web-parity.sh
@@ -22,6 +22,22 @@ FIXTURES=(
   tests/corpus/issues/39/zorder-not-respected.vi
 )
 
+# LOCAL-ONLY class coverage: the committed fixtures above exercise no class,
+# inheritance, or cross-class dispatch — the path a caller takes to stage a
+# SubVI it calls by INHERITANCE (a parent class's dispatch method). That lives
+# in the icon-editor sample, a gitignored corpus CI runners don't pull. Append
+# it ONLY when it's on disk (mirrors tests' `needs_samples`): a local run gates
+# the class path byte-for-byte, CI renders the same 5 and never sees these.
+ICON_DIR=".lvkit/cache/samples/ni-labview-icon-editor/vi.lib/LabVIEW Icon API/lv_icon/Classes"
+if [ -d "$ICON_DIR" ]; then
+  FIXTURES+=(
+    "$ICON_DIR/Icon Framework/Apply Body Text.vi" # inherited Layer dispatch + 6 SubVIs
+    "$ICON_DIR/Layer/GET_LayerData.vi"            # cross-class dispatch target
+    "$ICON_DIR/Icon/GET_IconTextClass.vi"         # Icon class method
+    "$ICON_DIR/Icon Framework/CreateBodyText.vi"  # own-class static call
+  )
+fi
+
 OUT="$(mktemp -d)"
 # Case-INSENSITIVE char class: the id embeds the source PATH slug, which
 # preserves case (JKI-VI-Tester, Test LVKit). Must stay identical to

--- a/editors/vscode/build/web-parity.cjs
+++ b/editors/vscode/build/web-parity.cjs
@@ -36,16 +36,58 @@ os.environ["LVKIT_CACHE_DIR"] = "/tmp/lvkit-parity-cache"
 from pathlib import Path
 from lvkit.render import render_vi_file_titled
 def _r(p):
-    # Bare render, default theme — must match \`lvkit render --format svg
-    # --theme light\` on the native side.
-    svg, _ = render_vi_file_titled(Path(p))
+    # Render from the STAGED /proj tree with /proj as the search root, exactly
+    # as the shipped web extension does — must match \`lvkit render --format svg
+    # --theme light\` on the native side (which reads the same files off disk).
+    svg, _ = render_vi_file_titled(Path(p), search_paths=[Path("/proj")])
     return svg or ""
 _r`);
 
+  // Report the MINIMAL dependency closure of a staged VI (the /proj paths the
+  // loader resolved) so we can stage its callees, one layer at a time.
+  const depsOf = pyodide.runPython(`
+import json
+from pathlib import Path
+from lvkit.graph import InMemoryVIGraph
+from lvkit.load_mode import LoadMode
+def _deps(p):
+    g = InMemoryVIGraph()
+    n = g.load_vi(Path(p), LoadMode.MINIMAL, search_paths=[Path("/proj")])
+    return json.dumps([str(x) for x in g.get_dependency_paths(n)])
+_deps`);
+
+  // Mirror a VI's whole dependency closure into the Pyodide FS under /proj,
+  // preserving each file's native absolute path (so recorded RELATIVE paths —
+  // e.g. a parent class at ../../Layer/Layer.lvclass — resolve), staging one
+  // layer per pass until the set stops growing. This is the SAME progressive
+  // MINIMAL-load → get_dependency_paths → fetch loop the web extension runs.
+  function stageClosure(viNative) {
+    const abs = path.resolve(viNative);
+    const staged = new Set();
+    const put = (nativePath) => {
+      const proj = "/proj" + nativePath;
+      if (staged.has(proj) || !fs.existsSync(nativePath)) return false;
+      pyodide.FS.mkdirTree(path.posix.dirname(proj));
+      pyodide.FS.writeFile(proj, fs.readFileSync(nativePath));
+      staged.add(proj);
+      return true;
+    };
+    put(abs);
+    const entryProj = "/proj" + abs;
+    for (let round = 0; round < 20; round++) {
+      const deps = JSON.parse(depsOf(entryProj));
+      let added = 0;
+      for (const dp of deps) {
+        if (dp.startsWith("/proj/") && put(dp.slice("/proj".length))) added++;
+      }
+      if (added === 0) break;
+    }
+    return entryProj;
+  }
+
   for (const vi of FIXTURES) {
-    const dst = `/vi/${slug(vi)}.vi`;
-    pyodide.FS.writeFile(dst, fs.readFileSync(vi));
-    const svg = render(dst);
+    const entry = stageClosure(vi);
+    const svg = render(entry);
     fs.writeFileSync(path.join(OUT, `${slug(vi)}.wasm.svg`), svg);
     console.log(`  wasm rendered ${vi} (${svg.length} bytes)`);
   }

--- a/src/lvkit/graph/loading.py
+++ b/src/lvkit/graph/loading.py
@@ -606,20 +606,25 @@ class LoadingMixin:
         # node so inheritance walks follow it by IDENTITY (a name can hit
         # duplicates; a path can't). None when the parent isn't on disk.
         parent = cls.parent_class
-        parent_file = None
+        parent_file = None  # the parent's file when it's actually present
+        parent_intended: Path | None = None  # its recorded path, present or not
         if parent and parent != "LabVIEW Object":
             if cls.parent_url:
                 # LabVIEW ``.lvclass`` URLs are relative to the class FILE treated
                 # as a directory (members read ``../X.vi``), so resolve against
                 # ``lvclass_path`` itself — that absorbs the leading ``..``.
-                cand = (lvclass_path / cls.parent_url).resolve()
-                if cand.exists():
-                    parent_file = cand
-            if parent_file is None:
+                parent_intended = (lvclass_path / cls.parent_url).resolve()
+                if parent_intended.exists():
+                    parent_file = parent_intended
+            if parent_file is None and parent_intended is None:
                 parent_file = self._walk_up_find(
                     lvclass_path.parent, parent + ".lvclass"
                 )
-        parent_key = str(parent_file.resolve()) if parent_file is not None else None
+        # The parent's KEY is its recorded path whether or not the file is staged
+        # yet — so progressive (web) staging can NAME + fetch a not-yet-present
+        # parent (an ``.exists()`` gate would drop the whole inherited surface).
+        parent_ref = parent_file or parent_intended
+        parent_key = str(parent_ref.resolve()) if parent_ref is not None else None
         # The class's member VIs as a ``method-leaf -> resolved .vi path`` map,
         # keyed by the ``.vi`` filename (e.g. ``"GET_LayerData.vi"``) so a caller's
         # dynamic-dispatch call resolves to its file by member-list membership —
@@ -627,11 +632,21 @@ class LoadingMixin:
         # Recorded even under a MINIMAL field-load (it's just names + paths, no
         # bodies), so the class can supply a called method's path without loading
         # all 27 members. See ``_load_subvi_method_deps``.
+        # Record the member's path even when the file is NOT present yet: the
+        # ``.lvclass`` URL (``../X.vi``, the class-as-directory quirk) gives its
+        # INTENDED path, which is what progressive (web) staging needs to NAME +
+        # fetch a not-yet-staged member. An ``.exists()``-gated resolve would name
+        # nothing until the file is already staged — chicken-and-egg — so the web
+        # closure would converge WITHOUT the SubVIs (they'd never be fetched).
         method_paths: dict[str, str] = {}
         for method in cls.methods:
             vp = self._resolve_class_vi_path(lvclass_path.parent, method.vi_path)
-            if vp is not None:
-                method_paths[Path(method.vi_path).name] = str(vp.resolve())
+            if vp is None:
+                rel = method.vi_path
+                while rel.startswith("../"):
+                    rel = rel[3:]
+                vp = cls_path_r.parent / rel
+            method_paths[Path(method.vi_path).name] = str(vp)
         self._dep_graph.add_node(
             cls_key,
             node_type="class",
@@ -651,12 +666,31 @@ class LoadingMixin:
             # PATH key. Edge class -> parent so the parent (and thus the render's
             # inherited surface) is reachable in the dep graph and gets staged.
             if parent_file is not None:
-                if not self._dep_graph.has_node(parent_key):
+                assert parent_key is not None  # parent_file present => key set
+                # Load when absent OR when a prior round left it a STUB (present
+                # now — upgrade it so its method_paths populate; the has_node
+                # guard alone would leave the stub un-upgraded and its inherited
+                # methods forever unresolvable).
+                if (
+                    not self._dep_graph.has_node(parent_key)
+                    or parent_key in self._stubs
+                ):
                     self.load_lvclass(
                         parent_file,
                         LoadMode.MINIMAL,
                         search_paths=search_paths,
                     )
+                    self._stubs.discard(parent_key)
+                self._dep_graph.add_edge(cls_key, parent_key)
+            elif parent_key is not None:
+                # Parent recorded but not staged yet (web round 1): stub it by its
+                # intended path so the closure NAMES it and staging fetches it; a
+                # later round loads it for real and its methods become resolvable.
+                if not self._dep_graph.has_node(parent_key):
+                    self._dep_graph.add_node(
+                        parent_key, node_type="class", fields_only=True
+                    )
+                    self._stubs.add(parent_key)
                 self._dep_graph.add_edge(cls_key, parent_key)
             return cls_key
 
@@ -1466,12 +1500,17 @@ class LoadingMixin:
                     self._cache_vilib_terminal_layout(loaded_name, dep_ref)
             return loaded_name
         except (RuntimeError, OSError):
+            # The file isn't present (e.g. web round 1: it hasn't been staged
+            # yet). Stub it BY PATH and EDGE it to the caller, so the recorded
+            # path surfaces in get_dependency_paths — otherwise the extension has
+            # nothing to stage and the SubVI never appears. A later round finds
+            # the file and this upgrades to a real leaf-load.
+            stub_key = str(resolved.resolve())
             self._stub_subvi(
-                qualified_name,
-                caller_qname or "",
-                dep_ref=dep_ref,
-                key=str(resolved.resolve()),
+                qualified_name, caller_qname or "", dep_ref=dep_ref, key=stub_key
             )
+            if caller_qname:
+                self._dep_graph.add_edge(caller_qname, stub_key)
             return None
 
     def _load_subvi_method_deps(

--- a/src/lvkit/graph/loading.py
+++ b/src/lvkit/graph/loading.py
@@ -7,6 +7,7 @@ _resolve_class_vi_path, _resolve_through_llb.
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 import xml.etree.ElementTree as ET
@@ -32,6 +33,7 @@ from ..parser import (
 )
 from ..parser.type_mapping import parse_type_map_rich
 from ..structure import (
+    LVClass,
     get_project_classes,
     get_project_libraries,
     get_project_vis,
@@ -91,6 +93,28 @@ def _case_insensitive_match(directory: Path, filename: str) -> Path | None:
     except OSError:
         return None
     return None
+
+
+def _redirect_member_beside_container(cand: Path, leaf: str) -> Path:
+    """Redirect a resolved dependency path from its OWNING container to the
+    member's actual on-disk sibling.
+
+    A class/library MEMBER's LinkSavePathRef tokens describe the owning
+    container (e.g. ``['', 'TestCase.lvclass']``); the member's own filename
+    is carried separately as ``leaf``, NOT in the tokens. So resolving those
+    tokens yields the ``.lvclass``/``.lvlib`` file itself — dispatching that
+    as the member's own file fails (e.g. a ``.vi`` member fails
+    ``extract_vi_xml``, a ``NotADirectoryError`` joining a ``.ctl`` member
+    INTO the class file). Member files are stored BESIDE their container, so
+    when ``cand`` resolved to a ``.lvclass``/``.lvlib`` that isn't ``leaf``
+    itself, redirect to the sibling ``container_dir/leaf``. Returns ``cand``
+    unchanged otherwise. Pure path math — does not check existence; callers
+    that need an existence gate (only a resolved sibling counts) apply it
+    themselves.
+    """
+    if cand.suffix.lower() in (".lvclass", ".lvlib") and leaf != cand.name:
+        return cand.with_name(leaf)
+    return cand
 
 
 def _build_vi_properties(poly_metadata: dict[str, Any]) -> VIProperties:
@@ -399,6 +423,43 @@ class LoadingMixin:
             node["qname"] = qname
             node["name"] = name
 
+    def _add_stub(
+        self,
+        key: str,
+        node_type: str,
+        name: str,
+        qname: str | None,
+        path_tokens: list[str] | None,
+        caller: str | None,
+        rel: str | None = None,
+    ) -> None:
+        """Add one path-keyed STUB node for a dependency whose file is absent
+        (or unresolved) -- the single shape shared by every stub-creation site
+        in this module: the dep is still NAMED by its recorded/intended path
+        (``key``) so a progressive (web) load can see + fetch it, and a later
+        real load upgrades it in place (paired with a ``self._stubs.discard``
+        at the matching real-load site -- see e.g. ``load_lvclass``,
+        ``load_typedef``, ``_load_vi_recursive``).
+
+        Never overwrites an already-loaded (non-stub) node: guarded by
+        ``has_node``, so a stub call that races a real load is a no-op on the
+        node/``_stubs`` side. ``caller`` is optional -- when given, edges
+        ``caller -> key`` (with ``rel`` when one is passed, e.g. ``"owns"``
+        for a class/library member; no ``rel`` attribute for a plain SubVI/
+        type reference); when None, no edge is added (a caller with no
+        dep_graph node of its own, e.g. a ``.lvproj`` member, cannot be
+        edged from).
+        """
+        if not self._dep_graph.has_node(key):
+            self._dep_graph.add_node(key, node_type=node_type, path_tokens=path_tokens)
+            self._stubs.add(key)
+        self._register_dep_name(key, name, qname if qname is not None else name)
+        if caller:
+            if rel:
+                self._dep_graph.add_edge(caller, key, rel=rel)
+            else:
+                self._dep_graph.add_edge(caller, key)
+
     def load_lvlib(
         self,
         lvlib_path: Path | str,
@@ -428,6 +489,7 @@ class LoadingMixin:
         lib_key = str(lib_path_r)
         self._dep_graph.add_node(lib_key, node_type="library")
         self._register_dep_node(lib_key, lib_path_r, lib_name, lib_qname)
+        self._stubs.discard(lib_key)
 
         for member in lib.members:
             if member.member_type == "VI":
@@ -454,12 +516,17 @@ class LoadingMixin:
                         # (computable without the file), so it stages/upgrades by
                         # identity. Index the qname so refs resolve here.
                         ctl_key = str(ctl_path.resolve())
-                        if not self._dep_graph.has_node(ctl_key):
-                            self._dep_graph.add_node(ctl_key, node_type="typedef")
-                            self._stubs.add(ctl_key)
-                        self._register_dep_name(ctl_key, member_name, typedef_qname)
-                        self._dep_graph.add_edge(lib_key, ctl_key, rel="owns")
+                        self._add_stub(
+                            ctl_key,
+                            "typedef",
+                            member_name,
+                            typedef_qname,
+                            path_tokens=None,
+                            caller=lib_key,
+                            rel="owns",
+                        )
                 else:
+                    member_qname = lib_qname + ":" + member_name
                     vi_path = lvlib_path.parent / member.url
                     if not vi_path.exists():
                         # Relative path doesn't resolve — search by filename
@@ -473,10 +540,25 @@ class LoadingMixin:
                         # Ownership edge — to the member's RETURN key (its path).
                         if member_key and member_key in self._dep_graph:
                             self._dep_graph.add_edge(lib_key, member_key, rel="owns")
+                    else:
+                        # Absent .vi member: key the stub by its INTENDED
+                        # resolved path (computable without the file), so it
+                        # stages/upgrades by identity. Mirrors the absent-.ctl
+                        # branch above.
+                        vi_key = str((lvlib_path.parent / member.url).resolve())
+                        self._add_stub(
+                            vi_key,
+                            "vi",
+                            member_name,
+                            member_qname,
+                            path_tokens=None,
+                            caller=lib_key,
+                            rel="owns",
+                        )
             elif member.member_type == "LVClass":
+                class_name = Path(member.url).name
                 class_path = lvlib_path.parent / member.url
                 if not class_path.exists():
-                    class_name = Path(member.url).name
                     found = self._find_file(
                         class_name,
                         search_paths,
@@ -497,16 +579,31 @@ class LoadingMixin:
                     # load_lvclass) to land on the real VI node. Dropping
                     # owner_chain here silently loses that ownership
                     # attribution instead of fixing anything.
-                    self.load_lvclass(
+                    member_key = self.load_lvclass(
                         class_path,
                         mode,
                         search_paths,
                         owner_chain=chain + [lib.name + ".lvlib"],
                     )
+                    if member_key:
+                        self._dep_graph.add_edge(lib_key, member_key, rel="owns")
+                else:
+                    # Absent .lvclass member: same path-keyed stub treatment.
+                    class_key = str((lvlib_path.parent / member.url).resolve())
+                    class_qname = lib_qname + ":" + class_name
+                    self._add_stub(
+                        class_key,
+                        "class",
+                        class_name,
+                        class_qname,
+                        path_tokens=None,
+                        caller=lib_key,
+                        rel="owns",
+                    )
             elif member.member_type == "Library":
+                lib_name_file = Path(member.url).name
                 nested_path = lvlib_path.parent / member.url
                 if not nested_path.exists():
-                    lib_name_file = Path(member.url).name
                     found = self._find_file(
                         lib_name_file,
                         search_paths,
@@ -515,11 +612,27 @@ class LoadingMixin:
                     if found:
                         nested_path = found
                 if nested_path.exists():
-                    self.load_lvlib(
+                    nested_key = self.load_lvlib(
                         nested_path,
                         mode,
                         search_paths,
                         owner_chain=chain + [lib.name + ".lvlib"],
+                    )
+                    if nested_key:
+                        self._dep_graph.add_edge(lib_key, nested_key, rel="owns")
+                else:
+                    # Absent nested .lvlib member: same path-keyed stub
+                    # treatment.
+                    nested_key = str((lvlib_path.parent / member.url).resolve())
+                    nested_qname = lib_qname + ":" + lib_name_file
+                    self._add_stub(
+                        nested_key,
+                        "library",
+                        lib_name_file,
+                        nested_qname,
+                        path_tokens=None,
+                        caller=lib_key,
+                        rel="owns",
                     )
 
         return lib_key
@@ -559,67 +672,18 @@ class LoadingMixin:
         cls_name = cls.name + ".lvclass"
         cls_qname = ":".join(chain + [cls_name]) if chain else cls_name
 
-        # Add class node to dep_graph with field info. The LVPrivateDataField
-        # -> ClusterField conversion (incl. nested sub-field typing) is
-        # shared with the render resolver's VI-own-inline-copy fallback —
-        # see structure.py::private_data_field_to_cluster_field.
-        fields = [
-            private_data_field_to_cluster_field(f) for f in cls.private_data_fields
-        ]
-        if not fields:
-            # No inline "class private data" cluster found in a method VI's VCTP
-            # (structure.py::_parse_private_data_fields) — this class stores its
-            # private data as a control (.ctl) typedef instead. Read the fields
-            # straight from that control (same .ctl extraction as load_typedef);
-            # its file may differ from the class's recorded logical name.
-            ctl = self._find_private_data_ctl(lvclass_path.parent, cls.private_data_ctl)
-            if ctl is not None:
-                ctl_fields, _ = self._ctl_root_fields(ctl)
-                if ctl_fields:
-                    fields = ctl_fields
-        if not fields:
-            # Source-only .lvclass: neither a method VI's VCTP nor a .ctl file
-            # on disk carries the cluster (e.g. the pre-refactor layout where
-            # the private data is embedded ONLY as the flattened
-            # NI.LVClass.FlattenedPrivateDataCTL property in the class XML).
-            # Recover the field layout straight from that property. Best-effort:
-            # a malformed/older embedded control must never break class loading.
-            try:
-                pd_fields = private_data_from_lvclass_xml(lvclass_path)
-            except Exception:
-                logger.debug(
-                    "flattened private-data recovery failed for %s",
-                    lvclass_path,
-                    exc_info=True,
-                )
-                pd_fields = []
-            fields = [private_data_field_to_cluster_field(f) for f in pd_fields]
+        # Add class node to dep_graph with field info.
+        fields = self._class_private_data_fields(cls, lvclass_path)
         # PATH is the class's identity (finishes #26): key the node by the
         # resolved .lvclass path and index its qname/bare-name so a type
         # reference resolves to this key. The qname stays the DISPLAY name.
         cls_path_r = lvclass_path.resolve()
         cls_key = str(cls_path_r)
-        # The parent class's PATH (its key). PREFER the parent's own recorded URL
-        # (a DIRECT relative path — the parent commonly lives in a sibling subtree
-        # an up-tree walk can't reach, e.g. ``../../Layer/Layer.lvclass``); fall
-        # back to a walk-up by name only when no URL was recorded. Kept on the
-        # node so inheritance walks follow it by IDENTITY (a name can hit
-        # duplicates; a path can't). None when the parent isn't on disk.
+        # The parent class's PATH (its key). Kept on the node so inheritance
+        # walks follow it by IDENTITY (a name can hit duplicates; a path
+        # can't). None when the parent isn't on disk.
         parent = cls.parent_class
-        parent_file = None  # the parent's file when it's actually present
-        parent_intended: Path | None = None  # its recorded path, present or not
-        if parent and parent != "LabVIEW Object":
-            if cls.parent_url:
-                # LabVIEW ``.lvclass`` URLs are relative to the class FILE treated
-                # as a directory (members read ``../X.vi``), so resolve against
-                # ``lvclass_path`` itself — that absorbs the leading ``..``.
-                parent_intended = (lvclass_path / cls.parent_url).resolve()
-                if parent_intended.exists():
-                    parent_file = parent_intended
-            if parent_file is None and parent_intended is None:
-                parent_file = self._walk_up_find(
-                    lvclass_path.parent, parent + ".lvclass"
-                )
+        parent_file, parent_intended = self._resolve_parent(cls, lvclass_path)
         # The parent's KEY is its recorded path whether or not the file is staged
         # yet — so progressive (web) staging can NAME + fetch a not-yet-present
         # parent (an ``.exists()`` gate would drop the whole inherited surface).
@@ -642,10 +706,7 @@ class LoadingMixin:
         for method in cls.methods:
             vp = self._resolve_class_vi_path(lvclass_path.parent, method.vi_path)
             if vp is None:
-                rel = method.vi_path
-                while rel.startswith("../"):
-                    rel = rel[3:]
-                vp = cls_path_r.parent / rel
+                vp = self._intended_class_vi_path(lvclass_path.parent, method.vi_path)
             method_paths[Path(method.vi_path).name] = str(vp)
         self._dep_graph.add_node(
             cls_key,
@@ -659,39 +720,51 @@ class LoadingMixin:
             method_paths=method_paths,
         )
         self._register_dep_node(cls_key, cls_path_r, cls_name, cls_qname)
+        self._stubs.discard(cls_key)
+
+        # Field-load the parent chain (no methods) so inherited nMux field
+        # indices AND inherited-method calls resolve; dedup on the parent's
+        # PATH key. Edge class -> parent so the parent (and thus the render's
+        # inherited surface) is reachable in the dep graph and gets staged.
+        # Runs for BOTH a fields_only (MINIMAL) and a FULL class load — a FULL
+        # load's method-loading loop below still needs the inheritance edge
+        # (and the parent's method_paths) for dispatch resolution, so the
+        # parent is never skipped just because this load went deeper.
+        if parent_file is not None:
+            assert parent_key is not None  # parent_file present => key set
+            # Load when absent OR when a prior round left it a STUB (present
+            # now — upgrade it so its method_paths populate; the has_node
+            # guard alone would leave the stub un-upgraded and its inherited
+            # methods forever unresolvable).
+            if not self._dep_graph.has_node(parent_key) or parent_key in self._stubs:
+                self.load_lvclass(
+                    parent_file,
+                    LoadMode.MINIMAL,
+                    search_paths=search_paths,
+                )
+                self._stubs.discard(parent_key)
+            self._dep_graph.add_edge(cls_key, parent_key)
+        elif parent_key is not None:
+            # Parent recorded but not staged yet (web round 1): stub it by its
+            # intended path so the closure NAMES it and staging fetches it; a
+            # later round loads it for real and its methods become resolvable.
+            # Not routed through _add_stub: this stub carries a ``fields_only``
+            # node attribute the shared helper doesn't set, so it stays manual
+            # (kept shape-consistent with the other stub sites: an explicit
+            # ``path_tokens=None`` and the same register/edge order).
+            assert parent is not None  # parent_key set => parent name is known
+            if not self._dep_graph.has_node(parent_key):
+                self._dep_graph.add_node(
+                    parent_key,
+                    node_type="class",
+                    fields_only=True,
+                    path_tokens=None,
+                )
+                self._stubs.add(parent_key)
+                self._register_dep_name(parent_key, parent + ".lvclass", parent)
+            self._dep_graph.add_edge(cls_key, parent_key)
 
         if fields_only:
-            # Field-load the parent chain (no methods) so inherited nMux field
-            # indices AND inherited-method calls resolve; dedup on the parent's
-            # PATH key. Edge class -> parent so the parent (and thus the render's
-            # inherited surface) is reachable in the dep graph and gets staged.
-            if parent_file is not None:
-                assert parent_key is not None  # parent_file present => key set
-                # Load when absent OR when a prior round left it a STUB (present
-                # now — upgrade it so its method_paths populate; the has_node
-                # guard alone would leave the stub un-upgraded and its inherited
-                # methods forever unresolvable).
-                if (
-                    not self._dep_graph.has_node(parent_key)
-                    or parent_key in self._stubs
-                ):
-                    self.load_lvclass(
-                        parent_file,
-                        LoadMode.MINIMAL,
-                        search_paths=search_paths,
-                    )
-                    self._stubs.discard(parent_key)
-                self._dep_graph.add_edge(cls_key, parent_key)
-            elif parent_key is not None:
-                # Parent recorded but not staged yet (web round 1): stub it by its
-                # intended path so the closure NAMES it and staging fetches it; a
-                # later round loads it for real and its methods become resolvable.
-                if not self._dep_graph.has_node(parent_key):
-                    self._dep_graph.add_node(
-                        parent_key, node_type="class", fields_only=True
-                    )
-                    self._stubs.add(parent_key)
-                self._dep_graph.add_edge(cls_key, parent_key)
             return cls_key
 
         for method in cls.methods:
@@ -719,6 +792,81 @@ class LoadingMixin:
 
         return cls_key
 
+    def _class_private_data_fields(
+        self, cls: LVClass, lvclass_path: Path
+    ) -> list[ClusterField]:
+        """The class's private-data fields, tried in fallback order.
+
+        The LVPrivateDataField -> ClusterField conversion (incl. nested
+        sub-field typing) is shared with the render resolver's
+        VI-own-inline-copy fallback — see
+        structure.py::private_data_field_to_cluster_field. Three sources, in
+        order:
+
+        1. An inline "class private data" cluster found in a method VI's VCTP
+           (structure.py::_parse_private_data_fields).
+        2. A separate control (.ctl) typedef this class stores its private
+           data as instead (same .ctl extraction as load_typedef); its file
+           may differ from the class's recorded logical name.
+        3. A source-only .lvclass: neither of the above carries the cluster
+           (e.g. the pre-refactor layout where the private data is embedded
+           ONLY as the flattened NI.LVClass.FlattenedPrivateDataCTL property
+           in the class XML) — recovered straight from that property.
+           Best-effort: a malformed/older embedded control must never break
+           class loading.
+        """
+        fields = [
+            private_data_field_to_cluster_field(f) for f in cls.private_data_fields
+        ]
+        if not fields:
+            ctl = self._find_private_data_ctl(lvclass_path.parent, cls.private_data_ctl)
+            if ctl is not None:
+                ctl_fields, _ = self._ctl_root_fields(ctl)
+                if ctl_fields:
+                    fields = ctl_fields
+        if not fields:
+            try:
+                pd_fields = private_data_from_lvclass_xml(lvclass_path)
+            except Exception:
+                logger.debug(
+                    "flattened private-data recovery failed for %s",
+                    lvclass_path,
+                    exc_info=True,
+                )
+                pd_fields = []
+            fields = [private_data_field_to_cluster_field(f) for f in pd_fields]
+        return fields
+
+    def _resolve_parent(
+        self, cls: LVClass, lvclass_path: Path
+    ) -> tuple[Path | None, Path | None]:
+        """The parent class's file (when present) and its INTENDED path
+        (present or not) -> ``(parent_file, parent_intended)``.
+
+        PREFERS the parent's own recorded URL (a DIRECT relative path — the
+        parent commonly lives in a sibling subtree an up-tree walk can't
+        reach, e.g. ``../../Layer/Layer.lvclass``); falls back to a walk-up
+        by name only when no URL was recorded. Both None when the class has
+        no parent (or its parent is the root ``LabVIEW Object``).
+        """
+        parent = cls.parent_class
+        parent_file: Path | None = None
+        parent_intended: Path | None = None
+        if parent and parent != "LabVIEW Object":
+            if cls.parent_url:
+                # LabVIEW ``.lvclass`` URLs are relative to the class FILE
+                # treated as a directory (members read ``../X.vi``), so
+                # resolve against ``lvclass_path`` itself — that absorbs the
+                # leading ``..``.
+                parent_intended = (lvclass_path / cls.parent_url).resolve()
+                if parent_intended.exists():
+                    parent_file = parent_intended
+            if parent_file is None and parent_intended is None:
+                parent_file = self._walk_up_find(
+                    lvclass_path.parent, parent + ".lvclass"
+                )
+        return parent_file, parent_intended
+
     def _walk_up_find(
         self,
         start_dir: Path,
@@ -744,20 +892,32 @@ class LoadingMixin:
             d = d.parent
         return None
 
+    def _intended_class_vi_path(self, cls_dir: Path, relative_path: str) -> Path:
+        """The resolved INTENDED path of a class-method VI from its recorded
+        ``.lvclass`` relative URL — WITHOUT requiring the file to exist, so an
+        ABSENT member's stub key and a later PRESENT load's key are the SAME
+        resolved string. A ``.lvclass`` treats its OWN file as a directory, so a
+        member URL ``../Member.vi`` actually lives IN the class dir (the leading
+        ``..`` is that quirk, not a real level-up): strip it and resolve against
+        ``cls_dir``. This is the form ``_resolve_class_vi_path`` returns for a
+        PRESENT member, so absent stubs upgrade in place. Shared by the
+        absent-member branch of ``load_lvclass``'s ``method_paths`` loop."""
+        rel = relative_path
+        while rel.startswith("../"):
+            rel = rel[3:]
+        return (cls_dir / rel).resolve()
+
     def _resolve_class_vi_path(self, cls_dir: Path, relative_path: str) -> Path | None:
-        """Resolve VI path from lvclass relative URL."""
-        direct = cls_dir / relative_path
-        if direct.exists():
-            return direct.resolve()
-
-        stripped = relative_path
-        while stripped.startswith("../"):
-            stripped = stripped[3:]
-        if stripped != relative_path:
-            from_cls = cls_dir / stripped
-            if from_cls.exists():
-                return from_cls.resolve()
-
+        """Resolve a class member VI from its ``.lvclass`` relative URL. Prefers
+        the INTENDED (class-as-directory) path — the same key the absent-member
+        stub uses, so they never diverge — then the literal ``..``-preserving
+        path as a fallback for the rare member that truly lives one level up."""
+        intended = self._intended_class_vi_path(cls_dir, relative_path)
+        if intended.exists():
+            return intended
+        direct = (cls_dir / relative_path).resolve()
+        if direct != intended and direct.exists():
+            return direct
         return None
 
     def load_lvproj(
@@ -774,17 +934,44 @@ class LoadingMixin:
         if search_paths is None:
             search_paths = [proj_dir]
 
+        # Absent project members are stubbed by their INTENDED resolved path
+        # (mirroring load_lvlib's absent-member branches) so they're still
+        # NAMED — get_dependency_paths / is_stub_vi / progressive staging can
+        # see them and upgrade by identity when the file appears. UNLIKE
+        # load_lvlib's members, there is no ownership edge: a ``.lvproj`` is a
+        # build/reference manifest, not itself a dep_graph node — load_lvproj
+        # creates no project node to edge these members FROM.
         for lib_name, lib_path in get_project_libraries(proj):
             if lib_path.exists():
                 self.load_lvlib(lib_path, mode, search_paths)
+            else:
+                key = str(lib_path.resolve())
+                self._add_stub(
+                    key, "library", lib_name, lib_name, path_tokens=None, caller=None
+                )
 
         for class_name, class_path in get_project_classes(proj):
             if class_path.exists():
                 self.load_lvclass(class_path, mode, search_paths)
+            else:
+                key = str(class_path.resolve())
+                self._add_stub(
+                    key,
+                    "class",
+                    class_name,
+                    class_name,
+                    path_tokens=None,
+                    caller=None,
+                )
 
         for vi_name, vi_path in get_project_vis(proj):
             if vi_path.exists():
                 self.load_vi(vi_path, mode, search_paths)
+            else:
+                key = str(vi_path.resolve())
+                self._add_stub(
+                    key, "vi", vi_name, vi_name, path_tokens=None, caller=None
+                )
 
     def load_directory(
         self,
@@ -879,6 +1066,33 @@ class LoadingMixin:
                 member_path = cache_dir / Path(*parts[i + 1 :])
                 return member_path if member_path.exists() else None
         return None
+
+    def _pick_link_ref(
+        self,
+        candidates: list[ParsedDependencyRef] | None,
+        caller_file: Path,
+    ) -> ParsedDependencyRef | None:
+        """Pick the best link-table ref for a leaf-filename lookup out of
+        several candidates that share the leaf.
+
+        ``parse_link_path_refs`` dedups on ``(leaf, *path_tokens)`` and
+        deliberately keeps distinct same-leaf refs — different link records
+        can name the same on-disk leaf via DIFFERENT recorded paths. Prefer
+        the one whose recorded path actually resolves to an EXISTING file
+        against ``caller_file``; otherwise fall back to the first candidate
+        (list order — deterministic, unlike a set)."""
+        if not candidates:
+            return None
+        for ref in candidates:
+            resolved = ref.resolve_against(
+                caller_file,
+                vilib_root=self._vilib_root,
+                userlib_root=self._userlib_root,
+                instrlib_root=self._instrlib_root,
+            )
+            if resolved is not None and resolved.exists():
+                return ref
+        return candidates[0]
 
     def _load_vi_recursive(
         self,
@@ -1015,6 +1229,7 @@ class LoadingMixin:
         # recursing forever. Recording it after the walk would reintroduce the
         # infinite recursion the old unconditional _loaded_vis check prevented.
         self._loaded_vis.add(vi_key)
+        self._stubs.discard(vi_key)
         self._dep_load_mode[vi_key] = mode
 
         # Build dep_ref_map from recorded LinkSavePathRef data.
@@ -1055,15 +1270,21 @@ class LoadingMixin:
             # instead of a name-search (path-driven closure, web == desktop). It
             # only ENRICHES deps already in all_dep_qnames — never adds one — so a
             # library-prefixed dep's bare leaf can't shadow it into a duplicate.
-            link_index = {r.name: r for r in metadata.link_path_refs}
+            # List-valued: parse_link_path_refs dedups on (leaf, *path_tokens),
+            # so several refs can legitimately share a leaf via DISTINCT recorded
+            # paths — grouping (not last-wins) keeps every one available to
+            # _pick_link_ref below.
+            link_index: dict[str, list[ParsedDependencyRef]] = {}
+            for r in metadata.link_path_refs:
+                link_index.setdefault(r.name, []).append(r)
 
             # Sorted: dependency load ORDER decides which same-named candidate
             # file claims a name first, so a hash-ordered set here made the
             # loaded VI SET non-deterministic across runs (146 vs 109 on the
             # JKI Programmatic API tree). Deterministic order → reproducible docs.
             for qname in sorted(all_dep_qnames):
-                dep_ref = dep_ref_map.get(qname) or link_index.get(
-                    qname.rsplit(":", 1)[-1]
+                dep_ref = dep_ref_map.get(qname) or self._pick_link_ref(
+                    link_index.get(qname.rsplit(":", 1)[-1]), caller_file
                 )
                 self._load_dependency(
                     qname,
@@ -1171,11 +1392,15 @@ class LoadingMixin:
         # and lets the stub upgrade by identity when the file appears.
         ctl_path_r = ctl_path.resolve()
         ctl_key = str(ctl_path_r)
-        if self._dep_graph.has_node(ctl_key):
+        if self._dep_graph.has_node(ctl_key) and ctl_key not in self._stubs:
             return ctl_key
 
         if not ctl_path.exists():
-            self._dep_graph.add_node(ctl_key, node_type="typedef")
+            # Not routed through _add_stub: load_typedef returns the key and
+            # is edged by its CALLER, not internally (unlike a caller-edging
+            # stub site) — kept shape-consistent (explicit path_tokens) with
+            # the other stub sites regardless.
+            self._dep_graph.add_node(ctl_key, node_type="typedef", path_tokens=None)
             self._stubs.add(ctl_key)
             self._register_dep_name(ctl_key, ctl_path.name, qname)
             return ctl_key
@@ -1184,6 +1409,7 @@ class LoadingMixin:
         if type_map:
             self._dep_graph.add_node(ctl_key, node_type="typedef", fields=fields)
             self._register_dep_node(ctl_key, ctl_path_r, ctl_path.name, qname)
+            self._stubs.discard(ctl_key)
 
             # Recurse: load any class/typedef deps referenced in this ctl's
             # type_map (e.g. a cluster field whose type is an lvclass or ctl).
@@ -1206,7 +1432,7 @@ class LoadingMixin:
                     )
         else:
             # XML not produced — stub with what we know
-            self._dep_graph.add_node(ctl_key, node_type="typedef")
+            self._dep_graph.add_node(ctl_key, node_type="typedef", path_tokens=None)
             self._stubs.add(ctl_key)
             self._register_dep_name(ctl_key, ctl_path.name, qname)
         return ctl_key
@@ -1249,28 +1475,16 @@ class LoadingMixin:
                     if llb_resolved is not None:
                         resolved = llb_resolved
 
-        # A class/library MEMBER VI's LinkSavePathRef tokens describe the OWNING
-        # container (e.g. ['', 'TestCase.lvclass']); the member's own filename is
-        # carried in ``dep_ref.name`` (== ``leaf``), NOT in the tokens. So
-        # ``resolve_against`` yields the ``.lvclass``/``.lvlib`` file itself, and
-        # dispatching that as a ``.vi`` fails ``extract_vi_xml`` → the SubVI gets
-        # stubbed with no connector pane, so its call terminals lose their real
-        # names (render falls back to "terminal N"). Member VIs are stored beside
-        # their container file — redirect to the actual sibling ``.vi`` so it
-        # leaf-loads and its param names resolve. If the sibling isn't there,
-        # drop to None and let the name-based search below find it.
-        # Applies to ANY member leaf — a .vi member AND a .ctl typedef owned by
-        # a class (its ref also names the .lvclass container) — not just .vi, so
-        # a member .ctl doesn't get joined INTO the class file (the
-        # Class.lvclass/Class.ctl NotADirectoryError). The redirect fires only
-        # when the resolved container isn't the leaf itself.
-        if (
-            resolved is not None
-            and resolved.suffix.lower() in (".lvclass", ".lvlib")
-            and leaf != resolved.name
-        ):
-            member = resolved.with_name(leaf)
-            resolved = member if member.exists() else None
+        # Member VIs (and .ctl typedefs) are stored beside their owning class/
+        # library container, not inside it (see
+        # _redirect_member_beside_container) — redirect so a resolved
+        # container path becomes the actual sibling file. If the sibling
+        # isn't there, drop to None and let the name-based search below find
+        # it.
+        if resolved is not None:
+            redirected = _redirect_member_beside_container(resolved, leaf)
+            if redirected != resolved:
+                resolved = redirected if redirected.exists() else None
 
         if resolved is None:
             if leaf.endswith(".vi"):
@@ -1306,8 +1520,7 @@ class LoadingMixin:
         if cand is None:
             return None
         leaf = qualified_name.rsplit(":", 1)[-1]
-        if cand.suffix.lower() in (".lvclass", ".lvlib") and leaf != cand.name:
-            cand = cand.with_name(leaf)
+        cand = _redirect_member_beside_container(cand, leaf)
         return cand.resolve()
 
     def _load_dependency(
@@ -1389,16 +1602,14 @@ class LoadingMixin:
             path_tokens = (
                 list(dep_ref.path_tokens) if dep_ref and dep_ref.path_tokens else None
             )
-            if not self._dep_graph.has_node(stub_key):
-                self._dep_graph.add_node(
-                    stub_key,
-                    node_type=node_type,
-                    path_tokens=path_tokens,
-                )
-                self._stubs.add(stub_key)
-                self._register_dep_name(stub_key, leaf, qualified_name)
-            if caller_qname:
-                self._dep_graph.add_edge(caller_qname, stub_key)
+            self._add_stub(
+                stub_key,
+                node_type,
+                leaf,
+                qualified_name,
+                path_tokens=path_tokens,
+                caller=caller_qname,
+            )
             return
 
         # Dispatch by extension to the matching public loader.
@@ -1447,16 +1658,14 @@ class LoadingMixin:
             path_tokens = (
                 list(dep_ref.path_tokens) if dep_ref and dep_ref.path_tokens else None
             )
-            if not self._dep_graph.has_node(unknown_key):
-                self._dep_graph.add_node(
-                    unknown_key,
-                    node_type="unknown",
-                    path_tokens=path_tokens,
-                )
-                self._stubs.add(unknown_key)
-                self._register_dep_name(unknown_key, leaf, qualified_name)
-            if caller_qname:
-                self._dep_graph.add_edge(caller_qname, unknown_key)
+            self._add_stub(
+                unknown_key,
+                "unknown",
+                leaf,
+                qualified_name,
+                path_tokens=path_tokens,
+                caller=caller_qname,
+            )
 
     def _leaf_load_vi(
         self,
@@ -1506,9 +1715,7 @@ class LoadingMixin:
             # nothing to stage and the SubVI never appears. A later round finds
             # the file and this upgrades to a real leaf-load.
             stub_key = str(resolved.resolve())
-            self._stub_subvi(
-                qualified_name, caller_qname or "", dep_ref=dep_ref, key=stub_key
-            )
+            self._stub_subvi(qualified_name, dep_ref=dep_ref, key=stub_key)
             if caller_qname:
                 self._dep_graph.add_edge(caller_qname, stub_key)
             return None
@@ -1534,7 +1741,7 @@ class LoadingMixin:
         carries no static path, only the wire's class resolves it), so the render
         draws a named box and a later click loads it as its own root.
         """
-        called: set[str] = {ref.name for ref in metadata.subvi_method_refs}
+        called: set[str] = set(metadata.subvi_method_names)
         for qname in metadata.iuse_to_qualified_name.values():
             called.add(qname.rsplit(":", 1)[-1])
         if not called:
@@ -1592,30 +1799,29 @@ class LoadingMixin:
     def _stub_subvi(
         self,
         name: str,
-        _parent_vi: str,
+        key: str,
         dep_ref: ParsedDependencyRef | None = None,
-        key: str | None = None,
     ) -> None:
         """Record a SubVI reference that could not be resolved as a stub.
 
         Carries path_tokens from the parser's LinkSavePathRef when
-        available — diagnostics-only, never gates code generation. When the
-        file exists but failed to parse, ``key`` is its resolved path so the
-        stub is PATH-keyed (upgrades by identity) and the qname/name index to
-        it; otherwise the qname is the key (a truly unresolvable ref).
+        available — diagnostics-only, never gates code generation. ``key`` is
+        the SubVI's resolved (intended) path, so the stub is PATH-keyed
+        (upgrades by identity) and the qname/name index to it. Edging to the
+        caller is the caller's job (``_leaf_load_vi``'s except branch), not
+        this method's — so ``caller`` is None here.
         """
-        node_key = key or name
-        self._stubs.add(node_key)
         path_tokens = (
             list(dep_ref.path_tokens) if dep_ref and dep_ref.path_tokens else None
         )
-        self._dep_graph.add_node(
-            node_key,
-            node_type="vi",
+        self._add_stub(
+            key,
+            "vi",
+            name.rsplit(":", 1)[-1],
+            name,
             path_tokens=path_tokens,
+            caller=None,
         )
-        if key is not None:
-            self._register_dep_name(node_key, name.rsplit(":", 1)[-1], name)
 
     def _cache_vilib_terminal_layout(
         self,
@@ -1629,8 +1835,6 @@ class LoadingMixin:
         Skips VIs already in the bundled JSON with complete terminals.
         Safe to call repeatedly — overwrites stale entries.
         """
-        import json as _json
-
         from ..project_store import find_project_store
         from ..vilib_resolver import get_resolver as get_vilib_resolver
 
@@ -1696,8 +1900,8 @@ class LoadingMixin:
         category_file = vilib_dir / f"{category}.json"
         if category_file.exists():
             try:
-                existing_data = _json.loads(category_file.read_text(encoding="utf-8"))
-            except (_json.JSONDecodeError, OSError):
+                existing_data = json.loads(category_file.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
                 existing_data = {"entries": []}
         else:
             existing_data = {"entries": []}
@@ -1715,15 +1919,15 @@ class LoadingMixin:
             entries.append(entry)
 
         category_file.write_text(
-            _json.dumps({"entries": entries}, indent=2), encoding="utf-8"
+            json.dumps({"entries": entries}, indent=2), encoding="utf-8"
         )
 
         # Update _index.json
         index_file = vilib_dir / "_index.json"
         if index_file.exists():
             try:
-                index_data = _json.loads(index_file.read_text(encoding="utf-8"))
-            except (_json.JSONDecodeError, OSError):
+                index_data = json.loads(index_file.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
                 index_data = {"categories": {}}
         else:
             index_data = {"categories": {}}
@@ -1731,7 +1935,7 @@ class LoadingMixin:
         categories: dict[str, str] = index_data.get("categories", {})
         categories[category] = f"{category}.json"
         index_data["categories"] = categories
-        index_file.write_text(_json.dumps(index_data, indent=2), encoding="utf-8")
+        index_file.write_text(json.dumps(index_data, indent=2), encoding="utf-8")
 
     def _find_file(
         self,

--- a/src/lvkit/graph/loading.py
+++ b/src/lvkit/graph/loading.py
@@ -25,6 +25,7 @@ from ..parser import (
     ParsedDependencyRef,
     ParsedFrontPanel,
     ParsedVI,
+    ParsedVIMetadata,
     parse_connector_pane_types,
     parse_vi,
     parse_vi_metadata,
@@ -598,17 +599,39 @@ class LoadingMixin:
         # reference resolves to this key. The qname stays the DISPLAY name.
         cls_path_r = lvclass_path.resolve()
         cls_key = str(cls_path_r)
-        # The parent class's PATH (its key) — found by walk-up from this class's
-        # own dir. Recorded on the node so inheritance walks follow it by
-        # IDENTITY (a name lookup can hit duplicates; a path can't). None when
-        # the parent isn't on disk (best-effort name fallback then).
+        # The parent class's PATH (its key). PREFER the parent's own recorded URL
+        # (a DIRECT relative path — the parent commonly lives in a sibling subtree
+        # an up-tree walk can't reach, e.g. ``../../Layer/Layer.lvclass``); fall
+        # back to a walk-up by name only when no URL was recorded. Kept on the
+        # node so inheritance walks follow it by IDENTITY (a name can hit
+        # duplicates; a path can't). None when the parent isn't on disk.
         parent = cls.parent_class
-        parent_file = (
-            self._walk_up_find(lvclass_path.parent, parent + ".lvclass")
-            if parent and parent != "LabVIEW Object"
-            else None
-        )
+        parent_file = None
+        if parent and parent != "LabVIEW Object":
+            if cls.parent_url:
+                # LabVIEW ``.lvclass`` URLs are relative to the class FILE treated
+                # as a directory (members read ``../X.vi``), so resolve against
+                # ``lvclass_path`` itself — that absorbs the leading ``..``.
+                cand = (lvclass_path / cls.parent_url).resolve()
+                if cand.exists():
+                    parent_file = cand
+            if parent_file is None:
+                parent_file = self._walk_up_find(
+                    lvclass_path.parent, parent + ".lvclass"
+                )
         parent_key = str(parent_file.resolve()) if parent_file is not None else None
+        # The class's member VIs as a ``method-leaf -> resolved .vi path`` map,
+        # keyed by the ``.vi`` filename (e.g. ``"GET_LayerData.vi"``) so a caller's
+        # dynamic-dispatch call resolves to its file by member-list membership —
+        # the authoritative owner (the VIPI/VCTP name only the CALL-SITE class).
+        # Recorded even under a MINIMAL field-load (it's just names + paths, no
+        # bodies), so the class can supply a called method's path without loading
+        # all 27 members. See ``_load_subvi_method_deps``.
+        method_paths: dict[str, str] = {}
+        for method in cls.methods:
+            vp = self._resolve_class_vi_path(lvclass_path.parent, method.vi_path)
+            if vp is not None:
+                method_paths[Path(method.vi_path).name] = str(vp.resolve())
         self._dep_graph.add_node(
             cls_key,
             node_type="class",
@@ -618,20 +641,23 @@ class LoadingMixin:
             fields_only=fields_only,
             version=cls.version,
             ancestors=cls.ancestors,
+            method_paths=method_paths,
         )
         self._register_dep_node(cls_key, cls_path_r, cls_name, cls_qname)
 
         if fields_only:
             # Field-load the parent chain (no methods) so inherited nMux field
-            # indices resolve; dedup on the parent's PATH key.
-            if parent_file is not None and not self._dep_graph.has_node(
-                str(parent_file.resolve())
-            ):
-                self.load_lvclass(
-                    parent_file,
-                    LoadMode.MINIMAL,
-                    search_paths=search_paths,
-                )
+            # indices AND inherited-method calls resolve; dedup on the parent's
+            # PATH key. Edge class -> parent so the parent (and thus the render's
+            # inherited surface) is reachable in the dep graph and gets staged.
+            if parent_file is not None:
+                if not self._dep_graph.has_node(parent_key):
+                    self.load_lvclass(
+                        parent_file,
+                        LoadMode.MINIMAL,
+                        search_paths=search_paths,
+                    )
+                self._dep_graph.add_edge(cls_key, parent_key)
             return cls_key
 
         for method in cls.methods:
@@ -989,19 +1015,35 @@ class LoadingMixin:
             # better). Guards test_issue_corpus.py::…issue29….
             all_dep_qnames.update(dep_ref_map)
 
+            # A leaf-filename -> recorded-path index from LabVIEW's link tables:
+            # supplies a recorded PATH for a type-derived class/typedef dep that
+            # carries no LinkSavePathRef of its own, so it resolves by path
+            # instead of a name-search (path-driven closure, web == desktop). It
+            # only ENRICHES deps already in all_dep_qnames — never adds one — so a
+            # library-prefixed dep's bare leaf can't shadow it into a duplicate.
+            link_index = {r.name: r for r in metadata.link_path_refs}
+
             # Sorted: dependency load ORDER decides which same-named candidate
             # file claims a name first, so a hash-ordered set here made the
             # loaded VI SET non-deterministic across runs (146 vs 109 on the
             # JKI Programmatic API tree). Deterministic order → reproducible docs.
             for qname in sorted(all_dep_qnames):
+                dep_ref = dep_ref_map.get(qname) or link_index.get(
+                    qname.rsplit(":", 1)[-1]
+                )
                 self._load_dependency(
                     qname,
-                    dep_ref_map.get(qname),
+                    dep_ref,
                     caller_file,
                     search_paths,
                     caller_qname=vi_key,
                     mode=mode,
                 )
+
+            # Resolve SubVI CALLEES (incl. dynamic-dispatch methods absent from
+            # _LIbd.bin) to their files via the now-loaded class member lists —
+            # AFTER the class deps above are in the graph. See the method.
+            self._load_subvi_method_deps(vi_key, metadata, search_paths, mode)
 
         # Build map of iUse uid → fully qualified on-disk path for diagnostics.
         iuse_to_qpath: dict[str, str] = {}
@@ -1327,40 +1369,9 @@ class LoadingMixin:
 
         # Dispatch by extension to the matching public loader.
         if leaf.endswith(".vi"):
-            try:
-                bd_xml, fp_xml, main_xml = extract_vi_xml(resolved)
-                # MINIMAL leaf-loads a SubVI: its own connector pane (for the
-                # caller's param-name hovers) but NOT its own SubVIs (child NONE)
-                # — so the transitive tree is never walked. FULL recurses fully.
-                child_mode = LoadMode.FULL if mode is LoadMode.FULL else LoadMode.NONE
-                loaded_name = self._load_vi_recursive(
-                    bd_xml,
-                    fp_xml,
-                    main_xml,
-                    search_paths=search_paths,
-                    visited=set(),
-                    source_dir=resolved.parent,
-                    mode=child_mode,
-                )
-                if loaded_name:
-                    if caller_qname:
-                        self._dep_graph.add_edge(caller_qname, loaded_name)
-                    if qualified_name != loaded_name:
-                        self._qualified_aliases[qualified_name] = loaded_name
-                    # Auto-cache terminal layout for vilib VIs loaded from disk
-                    if (
-                        dep_ref is not None
-                        and dep_ref.path_tokens
-                        and dep_ref.path_tokens[0] == "<vilib>"
-                    ):
-                        self._cache_vilib_terminal_layout(loaded_name, dep_ref)
-            except (RuntimeError, OSError):
-                self._stub_subvi(
-                    qualified_name,
-                    caller_qname or "",
-                    dep_ref=dep_ref,
-                    key=str(resolved.resolve()),
-                )
+            self._leaf_load_vi(
+                resolved, qualified_name, caller_qname, dep_ref, search_paths, mode
+            )
         elif leaf.endswith(".lvclass"):
             parts = qualified_name.split(":")
             owner_chain = parts[:-1] if len(parts) > 1 else None
@@ -1412,6 +1423,132 @@ class LoadingMixin:
                 self._register_dep_name(unknown_key, leaf, qualified_name)
             if caller_qname:
                 self._dep_graph.add_edge(caller_qname, unknown_key)
+
+    def _leaf_load_vi(
+        self,
+        resolved: Path,
+        qualified_name: str,
+        caller_qname: str | None,
+        dep_ref: ParsedDependencyRef | None,
+        search_paths: list[Path],
+        mode: LoadMode,
+    ) -> str | None:
+        """Leaf-load one SubVI file and edge it to its caller — the shared body of
+        ``_load_dependency``'s ``.vi`` branch and the class-method resolver.
+
+        MINIMAL leaf-loads: the SubVI's own connector pane (for the caller's
+        param-name hovers + icon) but NOT its own SubVIs (child NONE), so the
+        transitive tree is never walked; FULL recurses fully. On a parse failure
+        the SubVI is stubbed PATH-keyed so it upgrades by identity later.
+        """
+        try:
+            bd_xml, fp_xml, main_xml = extract_vi_xml(resolved)
+            child_mode = LoadMode.FULL if mode is LoadMode.FULL else LoadMode.NONE
+            loaded_name = self._load_vi_recursive(
+                bd_xml,
+                fp_xml,
+                main_xml,
+                search_paths=search_paths,
+                visited=set(),
+                source_dir=resolved.parent,
+                mode=child_mode,
+            )
+            if loaded_name:
+                if caller_qname:
+                    self._dep_graph.add_edge(caller_qname, loaded_name)
+                if qualified_name != loaded_name:
+                    self._qualified_aliases[qualified_name] = loaded_name
+                if (
+                    dep_ref is not None
+                    and dep_ref.path_tokens
+                    and dep_ref.path_tokens[0] == "<vilib>"
+                ):
+                    self._cache_vilib_terminal_layout(loaded_name, dep_ref)
+            return loaded_name
+        except (RuntimeError, OSError):
+            self._stub_subvi(
+                qualified_name,
+                caller_qname or "",
+                dep_ref=dep_ref,
+                key=str(resolved.resolve()),
+            )
+            return None
+
+    def _load_subvi_method_deps(
+        self,
+        vi_key: str,
+        metadata: ParsedVIMetadata,
+        search_paths: list[Path],
+        mode: LoadMode,
+    ) -> None:
+        """Resolve the VI's class-method SubVI CALLEES — including the dispatch
+        methods the ``_LIbd.bin`` IUVI table omits — to their files by MEMBER-LIST
+        membership over the classes this VI already depends on, and edge each to
+        the caller so the render draws its icon + interface.
+
+        A callee name (from the ``_LIvi.bin`` VIPI table + the IUVI map) resolves
+        against the ``method_paths`` of the VI's class deps: the owner is the class
+        whose member list HAS the method. A CROSS-CLASS dynamic-dispatch call —
+        a method whose owner is a class this VI does NOT path-record (its object
+        was derived mid-diagram, so nothing stores that class's path) — is left
+        UNRESOLVED on purpose: MINIMAL does not follow into it (its ``dynLink``
+        carries no static path, only the wire's class resolves it), so the render
+        draws a named box and a later click loads it as its own root.
+        """
+        called: set[str] = {ref.name for ref in metadata.subvi_method_refs}
+        for qname in metadata.iuse_to_qualified_name.values():
+            called.add(qname.rsplit(":", 1)[-1])
+        if not called:
+            return
+
+        # Most-derived class first, then by path: when a method is OVERRIDDEN
+        # (declared in a child and its parent, both loaded), the child's copy is
+        # the icon that would actually run, and the tie-break is deterministic.
+        class_keys = sorted(
+            (
+                s
+                for s in self._dep_graph.successors(vi_key)
+                if self._dep_graph.nodes[s].get("node_type") == "class"
+            ),
+            key=lambda s: (-len(self._dep_graph.nodes[s].get("ancestors", [])), s),
+        )
+        for name in sorted(called):
+            if self._resolve_method_in_hierarchy(
+                name, class_keys, vi_key, search_paths, mode
+            ):
+                continue
+
+    def _resolve_method_in_hierarchy(
+        self,
+        name: str,
+        class_keys: list[str],
+        vi_key: str,
+        search_paths: list[Path],
+        mode: LoadMode,
+    ) -> bool:
+        """Resolve one callee against each class dep AND its ANCESTOR chain (a
+        dispatch method not declared on the wire's class is INHERITED from a
+        parent — that owner's file is the icon to show), then leaf-load + edge it.
+        The ancestor hop follows the parent's recorded ``parent_key`` — a direct
+        path link, never a name-search. Returns whether it resolved."""
+        for cls_key in class_keys:
+            k: str | None = cls_key
+            seen: set[str] = set()
+            while k is not None and k not in seen and self._dep_graph.has_node(k):
+                seen.add(k)
+                path_str = self._dep_graph.nodes[k].get("method_paths", {}).get(name)
+                if path_str is not None:
+                    self._leaf_load_vi(
+                        Path(path_str),
+                        f"{Path(k).name}:{name}",
+                        vi_key,
+                        None,
+                        search_paths,
+                        mode,
+                    )
+                    return True
+                k = self._dep_graph.nodes[k].get("parent_key")
+        return False
 
     def _stub_subvi(
         self,

--- a/src/lvkit/graph/queries.py
+++ b/src/lvkit/graph/queries.py
@@ -20,6 +20,7 @@ from ..parser.models import ParsedDependencyRef
 from ..vilib_resolver import get_resolver as get_vilib_resolver
 from .core import _OPERATION_KINDS, _graph_node_to_op_kind, _node_order_key
 from .interface_order import ordered_interface
+from .loading import _redirect_member_beside_container
 from .models import (
     AnyGraphNode,
     ClassFieldEntry,
@@ -418,9 +419,9 @@ class QueryMixin:
             if cand is None:
                 continue
             # A class/library MEMBER (.vi OR .ctl) names its OWNING container;
-            # the member's own file sits beside it (see _resolve_dependency_path).
-            if cand.suffix.lower() in (".lvclass", ".lvlib") and leaf != cand.name:
-                cand = cand.with_name(leaf)
+            # the member's own file sits beside it (see
+            # _redirect_member_beside_container).
+            cand = _redirect_member_beside_container(cand, leaf)
             return _real_member_path(cand)
         return None
 

--- a/src/lvkit/parser/__init__.py
+++ b/src/lvkit/parser/__init__.py
@@ -13,7 +13,6 @@ from .front_panel import (
 )
 from .metadata import (
     parse_polymorphic_info,
-    parse_subvi_paths,
     parse_vi_metadata,
 )
 from .models import (
@@ -29,7 +28,6 @@ from .models import (
     ParsedLoopStructure,
     ParsedNode,
     ParsedResolvedTypeDefValue,
-    ParsedSubVIPathRef,  # backward-compat alias for ParsedDependencyRef
     ParsedTerminalInfo,
     ParsedTypeDefRef,
     ParsedVI,
@@ -69,7 +67,6 @@ __all__ = [
     "ParsedNode",
     "ParsedResolvedTypeDefValue",
     "ParsedDependencyRef",
-    "ParsedSubVIPathRef",  # backward-compat alias
     "ParsedTerminalInfo",
     "Tunnel",
     "TunnelMapping",  # Backward compat alias for Tunnel
@@ -82,7 +79,6 @@ __all__ = [
     "parse_connector_pane_types",
     # Metadata
     "parse_polymorphic_info",
-    "parse_subvi_paths",
     "parse_vi_metadata",
     # Types
     "load_enum_reference",

--- a/src/lvkit/parser/metadata.py
+++ b/src/lvkit/parser/metadata.py
@@ -431,74 +431,6 @@ def parse_polymorphic_info(root: ET.Element) -> dict[str, Any]:
     return result
 
 
-def parse_subvi_paths(xml_path: Path | str) -> list[ParsedDependencyRef]:
-    """Parse dependency path references from the main VI XML (VIVI only).
-
-    .. deprecated::
-        This function only walks VIVI elements and is retained for test
-        introspection.  Production code should use ``parse_vi()`` which
-        calls ``_extract_subvi_info`` and returns the full
-        ``ParsedVIMetadata.dependency_refs`` list (covering all LIvi link
-        element types: VIVI, VIPI, VILB, FPPI, DDPI, VICC, etc.).
-
-    Args:
-        xml_path: Path to the main .xml file (not BDHb)
-
-    Returns:
-        List of ParsedDependencyRef with path hints for each VIVI dependency
-    """
-    tree = ET.parse(xml_path)
-    root = tree.getroot()
-
-    refs: list[ParsedDependencyRef] = []
-    seen: set[tuple[str, tuple[str, ...]]] = set()
-
-    for vivi in root.findall(".//LIvi//VIVI"):
-        # Extract qualified name from all strings in LinkSaveQualName
-        qual_name_strings = vivi.findall("LinkSaveQualName/String")
-        if not qual_name_strings:
-            continue
-
-        # Strip each component: a LinkSaveQualName String can carry a spurious
-        # leading/trailing whitespace char from the binary (a real corpus case:
-        # a class-member name decoded as ``"\nToTable.vi"``), which a legitimate
-        # VI/class name never has -- left in, it corrupts the ``class:member``
-        # qualified identity and, downstream, splits a lvnet ``uses :`` line.
-        qual_parts = [
-            s.text.strip() for s in qual_name_strings if s.text and s.text.strip()
-        ]
-        if not qual_parts:
-            continue
-        qualified_name = ":".join(qual_parts)
-        name = qual_parts[-1]
-
-        path_ref = vivi.find("LinkSavePathRef")
-        if path_ref is None:
-            continue
-
-        # Preserve empty strings — they are the '..' navigation markers.
-        path_tokens = [
-            s.text if s.text is not None else "" for s in path_ref.findall("String")
-        ]
-        if not path_tokens:
-            continue
-
-        key: tuple[str, tuple[str, ...]] = (qualified_name, tuple(path_tokens))
-        if key in seen:
-            continue
-        seen.add(key)
-
-        refs.append(
-            ParsedDependencyRef(
-                name=name,
-                path_tokens=path_tokens,
-                qualified_name=qualified_name,
-            )
-        )
-
-    return refs
-
-
 def parse_iuse_from_libd(libd_path: Path) -> dict[str, str]:
     """Parse iUse UID → qualified VI name from a _LIbd.bin binary.
 
@@ -573,6 +505,46 @@ def parse_iuse_from_libd(libd_path: Path) -> dict[str, str]:
     return result
 
 
+def _decode_pth0_components(
+    data: bytes, pth0_offset: int, end: int
+) -> tuple[list[str], int]:
+    """Decode one ``PTH0`` record's pascal-string path components ->
+    ``(tokens, next_idx)``.
+
+    ``pth0_offset`` is the byte offset of the ``b"PTH0"`` tag within ``data``;
+    ``end`` bounds how far the decode may read (exclusive) -- either
+    ``len(data)`` for a whole-file scan or a caller-defined record boundary.
+    Reads the component count at ``pth0_offset+10:+12`` (guarded to
+    ``0 < ncomp <= 64`` -- a sanity bound against a garbage length), then
+    decodes each component as a pascal string (1-byte length prefix + native
+    text). Returns ``([], pth0_offset)`` if the record is truncated (would read
+    past ``end``) or the count is out of range -- a partial token list is never
+    returned, so a truncated record reads as "no components" to every caller.
+    ``next_idx`` is the byte offset just past the last decoded component --
+    the single source of both the decoded tokens AND the consumed-byte count,
+    shared by every caller that needs to keep reading past this record (e.g.
+    ``vi.py``'s ``_walk_path``, which uses it to stay aligned with a
+    following cluster field).
+    """
+    if pth0_offset + 12 > end:
+        return [], pth0_offset
+    ncomp = int.from_bytes(data[pth0_offset + 10 : pth0_offset + 12], "big")
+    if not (0 < ncomp <= 64):
+        return [], pth0_offset
+    idx = pth0_offset + 12
+    tokens: list[str] = []
+    for _ in range(ncomp):
+        if idx >= end:
+            return [], pth0_offset
+        ln = data[idx]
+        idx += 1
+        if idx + ln > end:
+            return [], pth0_offset
+        tokens.append(decode_labview_text(data[idx : idx + ln]))
+        idx += ln
+    return tokens, idx
+
+
 def parse_link_path_refs(link_bin: Path) -> list[ParsedDependencyRef]:
     """A recorded PATH for EVERY file a link binary references, from its ``PTH0``
     path records. LabVIEW stores a ``PTH0`` for each dependency it tracks (it is
@@ -595,24 +567,8 @@ def parse_link_path_refs(link_bin: Path) -> list[ParsedDependencyRef]:
     refs: list[ParsedDependencyRef] = []
     seen: set[tuple[str, ...]] = set()
     for m in re.finditer(b"PTH0", data):
-        p = m.start()
-        if p + 12 > len(data):
-            continue
-        ncomp = int.from_bytes(data[p + 10 : p + 12], "big")
-        if ncomp == 0 or ncomp > 64:  # guard against reading a garbage length
-            continue
-        idx = p + 12
-        tokens: list[str] = []
-        for _ in range(ncomp):
-            if idx >= len(data):
-                break
-            ln = data[idx]
-            idx += 1
-            if idx + ln > len(data):
-                break
-            tokens.append(decode_labview_text(data[idx : idx + ln]))
-            idx += ln
-        if len(tokens) != ncomp or not tokens:
+        tokens, _next_idx = _decode_pth0_components(data, m.start(), len(data))
+        if not tokens:
             continue
         leaf = tokens[-1]
         if not leaf.endswith((".vi", ".lvclass", ".ctl", ".lvlib")):
@@ -627,8 +583,9 @@ def parse_link_path_refs(link_bin: Path) -> list[ParsedDependencyRef]:
     return refs
 
 
-def parse_vipi_from_livi(livi_path: Path) -> list[ParsedDependencyRef]:
-    """Parse subVI callee records from a ``_LIvi.bin`` (VI-level link identity).
+def parse_vipi_from_livi(livi_path: Path) -> list[str]:
+    """Parse subVI callee METHOD NAMES from a ``_LIvi.bin`` (VI-level link
+    identity).
 
     ``_LIvi.bin`` is LabVIEW's VI-LEVEL link table — distinct from the
     ``_LIbd.bin`` block-diagram table read by ``parse_iuse_from_libd``. It
@@ -645,19 +602,20 @@ def parse_vipi_from_livi(livi_path: Path) -> list[ParsedDependencyRef]:
     plain ``[len][text]`` (its text never starts with ``0x01``, so the wrapper
     is detected by the first byte).
 
-    The ``PTH0`` locates the class the call is ROOTED on (the static type at the
-    call site), which for a cross-class dynamic dispatch is NOT where the method
-    file lives — so it is a hint, not a guaranteed file path. Returns one
-    ``ParsedDependencyRef`` per callee: ``name`` = the ``.vi`` leaf,
-    ``path_tokens`` = the ``PTH0`` components, ``qualified_name`` =
-    ``"<Class>.lvclass:<vi>"`` when a class name is present in the record.
+    The record's ``PTH0`` locates the class the call is ROOTED ON (the static
+    type at the call site) — for a cross-class dynamic dispatch that is NOT
+    where the method file lives, so it is an unreliable hint, not a guaranteed
+    owner. It is not decoded here: the caller resolves each returned method
+    name's owning file against the classes the VI already depends on (see
+    ``graph.loading._load_subvi_method_deps``), never from this record's own
+    class hint. Returns the ``.vi`` leaf name of each callee.
     """
     try:
         data = livi_path.read_bytes()
     except OSError:
         return []
 
-    refs: list[ParsedDependencyRef] = []
+    names_out: list[str] = []
     starts = [m.start() for m in re.finditer(b"VIPI", data)]
     starts.append(len(data))
 
@@ -691,30 +649,7 @@ def parse_vipi_from_livi(livi_path: Path) -> list[ParsedDependencyRef]:
             names.append(text.strip())
 
         method = next((n for n in names if n.endswith(".vi")), None)
-        if not method:
-            continue
-        class_name = next((n for n in names if n.endswith(".lvclass")), None)
+        if method:
+            names_out.append(method)
 
-        # PTH0 path hint follows the name strings (class the call is rooted on).
-        path_tokens: list[str] = []
-        pth0 = data.find(b"PTH0", p, rec_end)
-        if pth0 != -1:
-            ncomp = int.from_bytes(data[pth0 + 10 : pth0 + 12], "big")
-            q = pth0 + 12
-            for _ in range(ncomp):
-                if q >= rec_end:
-                    break
-                ln = data[q]
-                q += 1
-                path_tokens.append(decode_labview_text(data[q : q + ln]))
-                q += ln
-
-        refs.append(
-            ParsedDependencyRef(
-                name=method,
-                path_tokens=path_tokens,
-                qualified_name=f"{class_name}:{method}" if class_name else None,
-            )
-        )
-
-    return refs
+    return names_out

--- a/src/lvkit/parser/metadata.py
+++ b/src/lvkit/parser/metadata.py
@@ -571,3 +571,150 @@ def parse_iuse_from_libd(libd_path: Path) -> dict[str, str]:
             result[str(uid)] = qualified
 
     return result
+
+
+def parse_link_path_refs(link_bin: Path) -> list[ParsedDependencyRef]:
+    """A recorded PATH for EVERY file a link binary references, from its ``PTH0``
+    path records. LabVIEW stores a ``PTH0`` for each dependency it tracks (it is
+    what LabVIEW uses to relink / to prompt "find <this file>" when one is
+    missing) across ``_LIvi.bin`` (VI-level), ``_LIbd.bin`` (block diagram) and
+    ``_LIfp.bin`` (front panel). Each ``PTH0``'s components ARE the path
+    (caller-relative; a leading empty pops one level, per
+    ``ParsedDependencyRef.resolve_against``) and its LAST component is the
+    referenced file's leaf (``*.vi`` / ``*.lvclass`` / ``*.ctl`` / ``*.lvlib``).
+
+    Recovering these gives the loader a recorded path for the referenced CLASSES
+    and TYPEDEFS too — not just SubVIs — so the whole dependency closure resolves
+    by PATH with no name-search, identically on web and desktop.
+    """
+    try:
+        data = link_bin.read_bytes()
+    except OSError:
+        return []
+
+    refs: list[ParsedDependencyRef] = []
+    seen: set[tuple[str, ...]] = set()
+    for m in re.finditer(b"PTH0", data):
+        p = m.start()
+        if p + 12 > len(data):
+            continue
+        ncomp = int.from_bytes(data[p + 10 : p + 12], "big")
+        if ncomp == 0 or ncomp > 64:  # guard against reading a garbage length
+            continue
+        idx = p + 12
+        tokens: list[str] = []
+        for _ in range(ncomp):
+            if idx >= len(data):
+                break
+            ln = data[idx]
+            idx += 1
+            if idx + ln > len(data):
+                break
+            tokens.append(decode_labview_text(data[idx : idx + ln]))
+            idx += ln
+        if len(tokens) != ncomp or not tokens:
+            continue
+        leaf = tokens[-1]
+        if not leaf.endswith((".vi", ".lvclass", ".ctl", ".lvlib")):
+            continue
+        key = (leaf, *tokens)
+        if key in seen:
+            continue
+        seen.add(key)
+        refs.append(
+            ParsedDependencyRef(name=leaf, path_tokens=tokens, qualified_name=leaf)
+        )
+    return refs
+
+
+def parse_vipi_from_livi(livi_path: Path) -> list[ParsedDependencyRef]:
+    """Parse subVI callee records from a ``_LIvi.bin`` (VI-level link identity).
+
+    ``_LIvi.bin`` is LabVIEW's VI-LEVEL link table — distinct from the
+    ``_LIbd.bin`` block-diagram table read by ``parse_iuse_from_libd``. It
+    carries a ``VIPI`` record for EVERY subVI the diagram calls, including the
+    dynamic-dispatch (``dynIUse``) calls that leave NO ``IUVI`` in ``_LIbd.bin``
+    — so it is the only record that names those callees. Each record:
+
+        VIPI [uint32 count] [count name strings] [PTH0 path hint] [trailer]
+
+    ``count`` name strings: 0 = the VI's own class-context record (no callee,
+    skipped); 1 = a bare method name whose class is the ``PTH0``'s own class;
+    2 = an explicit ``"<Class>.lvclass"`` + method pair. A method name is a
+    wrapped pascal string ``[len][0x01][inner_len][text]``; a class name is a
+    plain ``[len][text]`` (its text never starts with ``0x01``, so the wrapper
+    is detected by the first byte).
+
+    The ``PTH0`` locates the class the call is ROOTED on (the static type at the
+    call site), which for a cross-class dynamic dispatch is NOT where the method
+    file lives — so it is a hint, not a guaranteed file path. Returns one
+    ``ParsedDependencyRef`` per callee: ``name`` = the ``.vi`` leaf,
+    ``path_tokens`` = the ``PTH0`` components, ``qualified_name`` =
+    ``"<Class>.lvclass:<vi>"`` when a class name is present in the record.
+    """
+    try:
+        data = livi_path.read_bytes()
+    except OSError:
+        return []
+
+    refs: list[ParsedDependencyRef] = []
+    starts = [m.start() for m in re.finditer(b"VIPI", data)]
+    starts.append(len(data))
+
+    for i in range(len(starts) - 1):
+        rec_start, rec_end = starts[i], starts[i + 1]
+        p = rec_start + 4  # past the 'VIPI' tag
+        if p + 4 > rec_end:
+            continue
+        count = struct.unpack(">I", data[p : p + 4])[0]
+        p += 4
+        if count == 0 or count > 4:  # 0 = own-context record; >4 = misparse
+            continue
+
+        names: list[str] = []
+        for _ in range(count):
+            if p >= rec_end:
+                break
+            slen = data[p]
+            p += 1
+            if slen == 0 or p + slen > rec_end:
+                break
+            raw = data[p : p + slen]
+            p += slen
+            # A method name is wrapped [0x01][inner_len][text]; a class name is
+            # a plain pascal string (never starts with 0x01).
+            if raw[0] == 0x01 and slen >= 2:
+                inner = raw[1]
+                text = decode_labview_text(raw[2 : 2 + inner])
+            else:
+                text = decode_labview_text(raw)
+            names.append(text.strip())
+
+        method = next((n for n in names if n.endswith(".vi")), None)
+        if not method:
+            continue
+        class_name = next((n for n in names if n.endswith(".lvclass")), None)
+
+        # PTH0 path hint follows the name strings (class the call is rooted on).
+        path_tokens: list[str] = []
+        pth0 = data.find(b"PTH0", p, rec_end)
+        if pth0 != -1:
+            ncomp = int.from_bytes(data[pth0 + 10 : pth0 + 12], "big")
+            q = pth0 + 12
+            for _ in range(ncomp):
+                if q >= rec_end:
+                    break
+                ln = data[q]
+                q += 1
+                path_tokens.append(decode_labview_text(data[q : q + ln]))
+                q += ln
+
+        refs.append(
+            ParsedDependencyRef(
+                name=method,
+                path_tokens=path_tokens,
+                qualified_name=f"{class_name}:{method}" if class_name else None,
+            )
+        )
+
+    return refs

--- a/src/lvkit/parser/models.py
+++ b/src/lvkit/parser/models.py
@@ -448,10 +448,6 @@ class ParsedDependencyRef:
         return (base / Path(*rest)).resolve()
 
 
-# Backward compatibility alias — all new code uses ParsedDependencyRef
-ParsedSubVIPathRef = ParsedDependencyRef
-
-
 @dataclass
 class ParsedFPDCOType:
     """Type info for a front panel DCO (data container object)."""
@@ -526,13 +522,14 @@ class ParsedVIMetadata:
     dependency_refs: list[ParsedDependencyRef] = field(
         default_factory=list,
     )  # Dependency path refs from LIvi LinkSavePathRef (all file types)
-    # SubVI callee records recovered from the ``_LIvi.bin`` VIPI table — the ONLY
-    # record of the dynamic-dispatch (``dynIUse``) methods the diagram calls (they
-    # leave no IUVI in ``_LIbd.bin``). ``name`` is the method leaf (e.g.
-    # ``"GET_LayerData.vi"``); its concrete file is resolved against the owning
-    # class's member list at load time (the VIPI's own PTH0 names the call-site
-    # class, not where a cross-class method lives). See ``parse_vipi_from_livi``.
-    subvi_method_refs: list[ParsedDependencyRef] = field(default_factory=list)
+    # SubVI callee METHOD NAMES recovered from the ``_LIvi.bin`` VIPI table —
+    # the ONLY record of the dynamic-dispatch (``dynIUse``) methods the diagram
+    # calls (they leave no IUVI in ``_LIbd.bin``). Each entry is a method leaf
+    # (e.g. ``"GET_LayerData.vi"``); its concrete file is resolved against the
+    # owning class's member list at load time (the VIPI's own PTH0 class hint
+    # is unreliable for a cross-class dynamic dispatch, so it is never used).
+    # See ``parse_vipi_from_livi``.
+    subvi_method_names: list[str] = field(default_factory=list)
     # A leaf-filename -> recorded-path INDEX for every file the VI's link tables
     # (_LIvi/_LIbd/_LIfp PTH0 records) reference — classes, typedefs, VIs. The
     # loader consults it to give a type-derived class/typedef dep a recorded path

--- a/src/lvkit/parser/models.py
+++ b/src/lvkit/parser/models.py
@@ -526,6 +526,19 @@ class ParsedVIMetadata:
     dependency_refs: list[ParsedDependencyRef] = field(
         default_factory=list,
     )  # Dependency path refs from LIvi LinkSavePathRef (all file types)
+    # SubVI callee records recovered from the ``_LIvi.bin`` VIPI table — the ONLY
+    # record of the dynamic-dispatch (``dynIUse``) methods the diagram calls (they
+    # leave no IUVI in ``_LIbd.bin``). ``name`` is the method leaf (e.g.
+    # ``"GET_LayerData.vi"``); its concrete file is resolved against the owning
+    # class's member list at load time (the VIPI's own PTH0 names the call-site
+    # class, not where a cross-class method lives). See ``parse_vipi_from_livi``.
+    subvi_method_refs: list[ParsedDependencyRef] = field(default_factory=list)
+    # A leaf-filename -> recorded-path INDEX for every file the VI's link tables
+    # (_LIvi/_LIbd/_LIfp PTH0 records) reference — classes, typedefs, VIs. The
+    # loader consults it to give a type-derived class/typedef dep a recorded path
+    # instead of a name-search (path-driven closure, web == desktop). SEPARATE
+    # from ``dependency_refs`` so it never adds a dep, only supplies a path.
+    link_path_refs: list[ParsedDependencyRef] = field(default_factory=list)
 
 
 @dataclass

--- a/src/lvkit/parser/vi.py
+++ b/src/lvkit/parser/vi.py
@@ -42,6 +42,7 @@ from .front_panel import (
 )
 from .layout import Layout, _icon_for_heap, build_layout_from_root
 from .metadata import (
+    _decode_pth0_components,
     parse_iuse_from_libd,
     parse_link_path_refs,
     parse_vipi_from_livi,
@@ -303,7 +304,7 @@ def _parse_metadata(
     # that leave no IUVI in _LIbd.bin — so it is the only place those callees are
     # named. Their concrete files are resolved against the owning class at load.
     livi_bin = main_xml.with_name(main_xml.stem + "_LIvi.bin")
-    subvi_method_refs = parse_vipi_from_livi(livi_bin) if livi_bin.exists() else []
+    subvi_method_names = parse_vipi_from_livi(livi_bin) if livi_bin.exists() else []
 
     # Recover a recorded PATH for EVERY referenced file (classes + typedefs + VIs)
     # from LabVIEW's link tables (_LIvi/_LIbd/_LIfp PTH0 records) — a leaf -> path
@@ -334,7 +335,7 @@ def _parse_metadata(
         subvi_qualified_names=subvi_qualified_names,
         iuse_to_qualified_name=iuse_to_qualified_name,
         dependency_refs=dependency_refs,
-        subvi_method_refs=subvi_method_refs,
+        subvi_method_names=subvi_method_names,
         link_path_refs=link_path_refs,
     )
 
@@ -1407,25 +1408,16 @@ def _decode_default_data(
 def _walk_path(data: bytes) -> tuple[str | None, int]:
     """Walk a ``PTH0`` path DefaultData blob ONCE -> ``(value, bytes_consumed)``.
 
-    The single source for both the path string AND the byte count, so a path
-    field inside a cluster stays aligned with the following field (previously the
-    value and the consumed count were walked by two divergent loops). Returns
-    ``(None, 0)`` when ``data`` is not a ``PTH0`` blob.
+    Delegates the pascal-string component decode to
+    ``metadata._decode_pth0_components`` (the single source of the ``PTH0``
+    component walk, shared with the link-table ``PTH0`` scan), keeping only
+    the ``Path("…")`` string formatting local -- so a path field inside a
+    cluster stays aligned with the following field. Returns ``(None, 0)``
+    when ``data`` is not a ``PTH0`` blob.
     """
     if not data.startswith(b"PTH0"):
         return None, 0
-    idx = 12  # PTH0 header
-    parts: list[str] = []
-    try:
-        while idx < len(data):
-            str_len = data[idx]
-            idx += 1
-            if str_len == 0 or idx + str_len > len(data):
-                break
-            parts.append(decode_labview_text(data[idx : idx + str_len]))
-            idx += str_len
-    except (IndexError, ValueError):
-        pass
+    parts, idx = _decode_pth0_components(data, 0, len(data))
     return (f'Path("{"/".join(parts)}")' if parts else None), idx
 
 

--- a/src/lvkit/parser/vi.py
+++ b/src/lvkit/parser/vi.py
@@ -41,7 +41,11 @@ from .front_panel import (
     parse_connector_pane_labels,
 )
 from .layout import Layout, _icon_for_heap, build_layout_from_root
-from .metadata import parse_iuse_from_libd
+from .metadata import (
+    parse_iuse_from_libd,
+    parse_link_path_refs,
+    parse_vipi_from_livi,
+)
 from .models import (
     ParsedBlockDiagram,
     ParsedConnectorPane,
@@ -294,6 +298,31 @@ def _parse_metadata(
         if libd_bin.exists():
             iuse_to_qualified_name = parse_iuse_from_libd(libd_bin)
 
+    # Recover the FULL subVI callee list from the VI-level _LIvi.bin link table.
+    # It records EVERY callee — including the dynamic-dispatch (dynIUse) methods
+    # that leave no IUVI in _LIbd.bin — so it is the only place those callees are
+    # named. Their concrete files are resolved against the owning class at load.
+    livi_bin = main_xml.with_name(main_xml.stem + "_LIvi.bin")
+    subvi_method_refs = parse_vipi_from_livi(livi_bin) if livi_bin.exists() else []
+
+    # Recover a recorded PATH for EVERY referenced file (classes + typedefs + VIs)
+    # from LabVIEW's link tables (_LIvi/_LIbd/_LIfp PTH0 records) — a leaf -> path
+    # INDEX the loader consults to give the type-derived class/typedef deps a
+    # recorded path instead of a name-search, making the closure path-driven and
+    # identical on web and desktop. Kept SEPARATE from dependency_refs (never
+    # unioned as new deps) so a library-prefixed dep's leaf can't shadow it.
+    link_path_refs: list[ParsedDependencyRef] = []
+    seen_refs: set[tuple[str, ...]] = set()
+    for suffix in ("_LIvi.bin", "_LIbd.bin", "_LIfp.bin"):
+        link_bin = main_xml.with_name(main_xml.stem + suffix)
+        if not link_bin.exists():
+            continue
+        for ref in parse_link_path_refs(link_bin):
+            key = (ref.name, *ref.path_tokens)
+            if key not in seen_refs:
+                seen_refs.add(key)
+                link_path_refs.append(ref)
+
     # Parse type map
     type_map = parse_type_map_rich(main_xml)
 
@@ -305,6 +334,8 @@ def _parse_metadata(
         subvi_qualified_names=subvi_qualified_names,
         iuse_to_qualified_name=iuse_to_qualified_name,
         dependency_refs=dependency_refs,
+        subvi_method_refs=subvi_method_refs,
+        link_path_refs=link_path_refs,
     )
 
 

--- a/src/lvkit/structure.py
+++ b/src/lvkit/structure.py
@@ -52,6 +52,12 @@ class LVClass:
     name: str
     path: Path
     parent_class: str | None = None
+    # The parent's recorded relative URL from the class's ``Parent`` Item
+    # (e.g. ``"../../Layer/Layer.lvclass"``) when declared that way — a DIRECT
+    # path to the parent file, so the loader follows it without any name-search
+    # (the parent often sits in a sibling subtree, not up-tree). None when the
+    # parent came only from the binary ``ParentClassLinkInfo`` (no URL there).
+    parent_url: str | None = None
     is_vilib_parent: bool = False
     private_data_ctl: str | None = None
     methods: list[LVMethod] = field(default_factory=list)
@@ -560,19 +566,27 @@ def parse_lvclass(lvclass_path: Path | str) -> LVClass:
     private_data_ctl = None
     methods: list[LVMethod] = []
 
-    # Authoritative parent: decoded from NI.LVClass.ParentClassLinkInfo (see
-    # _parent_from_link_info). Absence of the property means this class is a
-    # root (no parent) -- confirmed against the full JKI-VI-Tester corpus
-    # (32/32 classes: every non-root class carries this property, every root
-    # class lacks it).
-    link_info = _parent_from_link_info(root)
-    parent_class = link_info[0] if link_info is not None else None
-    is_vilib_parent = link_info[1] if link_info is not None else False
+    # Parent class. Two on-disk shapes carry it, and NOT every non-root class
+    # has both: the plain-XML ``Parent`` Item carries the name AND a relative
+    # URL to the parent file (preferred — a DIRECT path the loader follows with
+    # no search); the binary ``NI.LVClass.ParentClassLinkInfo`` property carries
+    # only the name (older/other saves). A class with the Item but no property
+    # (e.g. the LabVIEW-Icon-Editor classes) would otherwise be mis-read as a
+    # root, dropping its whole inherited-method surface.
+    parent_url: str | None = None
+    item_parent = _parent_from_item(root)
+    if item_parent is not None:
+        parent_class, parent_url = item_parent
+        is_vilib_parent = "<vilib>" in (parent_url or "")
+    else:
+        link_info = _parent_from_link_info(root)
+        parent_class = link_info[0] if link_info is not None else None
+        is_vilib_parent = link_info[1] if link_info is not None else False
 
     # Full ancestor chain, nearest-first -- best-effort on-disk resolution of
     # each ancestor's own .lvclass file (see _build_ancestor_chain). Never
     # decodes NI.LVClass.Geneology (opaque, leaks siblings).
-    ancestors = _build_ancestor_chain(lvclass_path, parent_class)
+    ancestors = _build_ancestor_chain(lvclass_path, parent_class, parent_url)
 
     # NI.Lib.Version -- verbatim dotted-quad string, same convention as
     # parse_lvlib's version property below.
@@ -597,6 +611,7 @@ def parse_lvclass(lvclass_path: Path | str) -> LVClass:
         name=class_name,
         path=lvclass_path,
         parent_class=parent_class,
+        parent_url=parent_url,
         is_vilib_parent=is_vilib_parent,
         private_data_ctl=private_data_ctl,
         methods=methods,
@@ -699,6 +714,26 @@ def _lv_base64_decode(text: str) -> bytes:
 
 _PRINTABLE_RUN_RE = re.compile(rb"[ -~]{4,}")
 _LVCLASS_TOKEN_RE = re.compile(r"([^\\/<>]+\.lvclass)$")
+
+
+def _parent_from_item(root: ET.Element) -> tuple[str, str | None] | None:
+    """The parent class from the plain-XML ``Parent`` Item, if declared there.
+
+    A ``.lvclass`` records inheritance as
+    ``<Item Name="X.lvclass" Type="Parent" URL="../../X/X.lvclass"/>`` (inside a
+    ``Parent Libraries`` group). This is the richest source — it carries the
+    parent's name AND a relative URL straight to the parent file — so the loader
+    follows the URL with no name-search (the parent commonly lives in a sibling
+    subtree, unreachable by an up-tree walk). Returns
+    ``(parent_name_without_suffix, url_or_None)`` or ``None`` when absent.
+    """
+    for item in root.findall(".//Item"):
+        if item.get("Type") != "Parent":
+            continue
+        name = item.get("Name", "")
+        if name.endswith(".lvclass"):
+            return name[: -len(".lvclass")], item.get("URL")
+    return None
 
 
 def _parent_from_link_info(root: ET.Element) -> tuple[str, bool] | None:
@@ -820,24 +855,28 @@ def _resolve_ancestor_lvclass(
 def _build_ancestor_chain(
     lvclass_path: Path,
     parent_class: str | None,
+    parent_url: str | None = None,
 ) -> list[str]:
-    """The FULL ancestor chain, nearest-first, by recursively following
-    ``NI.LVClass.ParentClassLinkInfo`` (via ``_parent_from_link_info``) up
-    from ``lvclass_path``.
+    """The FULL ancestor chain, nearest-first, by following each class's own
+    recorded parent up from ``lvclass_path``.
+
+    Prefers the parent's DIRECT recorded URL (relative to the class file, which
+    LabVIEW treats as a directory): a hit parses that ancestor and continues via
+    ITS url; a URL whose file is absent stops the chain at the bare name and does
+    NOT fall back to a filesystem search — the URL is authoritative, so a
+    missing file just means the ancestor isn't vendored here. Only a class with
+    NO url (older binary-only ``ParentClassLinkInfo`` saves) uses the climb-and-
+    ``rglob`` ``_resolve_ancestor_lvclass`` fallback — which must never run for a
+    class in a throwaway/tmp tree (it would rglob a giant unrelated root).
 
     Deliberately does NOT decode ``NI.LVClass.Geneology`` (an opaque base64
-    type-descriptor that also leaks sibling classes) -- this walks the SAME
-    authoritative per-class link a child already resolves its own immediate
-    parent from, just repeated up the tree. Each ancestor's ``.lvclass`` file
-    is located with ``_resolve_ancestor_lvclass``; when that lookup misses (the
-    ancestor's file isn't present in this checkout), the chain stops there --
-    tolerated, not an error, since the caller only has ``parent_class``'s bare
-    name to go on for that ancestor and cannot keep walking without its file.
+    type-descriptor that also leaks sibling classes).
     """
     ancestors: list[str] = []
     seen = {lvclass_path.stem}
-    current_dir = lvclass_path.parent
+    current_path = lvclass_path
     current_parent = parent_class
+    current_url = parent_url
     while (
         current_parent
         and current_parent != "LabVIEW Object"
@@ -845,16 +884,27 @@ def _build_ancestor_chain(
     ):
         ancestors.append(current_parent)
         seen.add(current_parent)
-        parent_file = _resolve_ancestor_lvclass(current_dir, current_parent)
+        if current_url:
+            cand = (current_path / current_url).resolve()
+            if not cand.exists():
+                break  # URL authoritative; ancestor simply not vendored here
+            parent_file: Path | None = cand
+        else:
+            parent_file = _resolve_ancestor_lvclass(current_path.parent, current_parent)
         if parent_file is None:
             break
         try:
             parent_root = ET.parse(parent_file).getroot()
         except ET.ParseError:
             break
-        link = _parent_from_link_info(parent_root)
-        current_parent = link[0] if link is not None else None
-        current_dir = parent_file.parent
+        item = _parent_from_item(parent_root)
+        if item is not None:
+            current_parent, current_url = item
+        else:
+            link = _parent_from_link_info(parent_root)
+            current_parent = link[0] if link is not None else None
+            current_url = None
+        current_path = parent_file
     return ancestors
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -7,6 +7,7 @@ with a proper graph (required since bind/resolve store var_names on the graph).
 from __future__ import annotations
 
 import re
+import shutil
 from pathlib import Path
 from typing import Any
 
@@ -35,6 +36,57 @@ def transitive_closure(
     if include_entry:
         closure.add(entry)
     return closure
+
+
+def progressive_closure(entry: Path, root: Path, proj: Path) -> set[Path]:
+    """The dependency closure reached by REPLAYING the web extension's
+    progressive staging loop against an initially-empty ``/proj`` — the ACTUAL
+    absent-then-fetch path, not a single load over the full on-disk tree.
+
+    Desktop/native tests load with every file already present, so they never
+    exercise the loader's ABSENT branches (a dep must be NAMED by its recorded
+    path AND EDGED to its caller while its file is missing, and its stub key must
+    match the key a later present load produces). Those branches are what the web
+    depends on and what silently regresses. This mirrors ``stageDependencyClosure``:
+    stage only ``entry`` into ``proj``, MINIMAL-load it with ``search_paths=[proj]``,
+    fetch every newly-named dependency from ``root`` into ``proj`` preserving
+    layout, and repeat until the set stops growing.
+
+    Returns the staged deps as their ORIGINAL ``root`` resolved paths (same shape
+    as ``transitive_closure`` for direct comparison) — a converged progressive
+    run MUST equal the single-pass closure, or the absent-path logic is broken.
+    """
+    entry, root = entry.resolve(), root.resolve()
+    rel_entry = entry.relative_to(root)
+    staged: set[Path] = set()
+
+    def fetch(rel: Path) -> bool:
+        src = root / rel
+        dst = proj / rel
+        if rel in staged or not src.exists():
+            return False
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dst)
+        staged.add(rel)
+        return True
+
+    fetch(rel_entry)
+    entry_in_proj = proj / rel_entry
+    for _ in range(20):  # bounded; real closures converge in a handful of passes
+        graph = InMemoryVIGraph()
+        name = graph.load_vi(entry_in_proj, LoadMode.MINIMAL, search_paths=[proj])
+        added = 0
+        for dep in graph.get_dependency_paths(name or str(entry_in_proj)):
+            try:
+                rel = dep.resolve().relative_to(proj.resolve())
+            except ValueError:
+                continue  # a dep that didn't resolve under /proj — skip
+            if fetch(rel):
+                added += 1
+        if added == 0:
+            break
+
+    return {(root / rel).resolve() for rel in staged if rel != rel_entry}
 
 
 _RENDER_ID_RE = re.compile(r"lv-[a-z0-9-]*-vi", re.IGNORECASE)

--- a/tests/test_livi_vipi.py
+++ b/tests/test_livi_vipi.py
@@ -43,8 +43,8 @@ def _vipi(count: int, names: bytes, pth0: bytes) -> bytes:
 
 def test_parse_vipi_static_and_dynamic_callees(tmp_path: Path) -> None:
     """A count=0 own-context record is skipped; a count=1 record yields a bare
-    method (class only via its PTH0); a count=2 record yields a class-qualified
-    method."""
+    method name; a count=2 record yields the method name too (the class hint
+    is not decoded — see the function docstring on why it's unreliable)."""
     own_ctx = _vipi(0, b"", _pth0(["", "Icon Framework.lvclass"]))
     rec1 = _vipi(
         1,
@@ -59,16 +59,8 @@ def test_parse_vipi_static_and_dynamic_callees(tmp_path: Path) -> None:
     path = tmp_path / "sample_LIvi.bin"
     path.write_bytes(own_ctx + rec1 + rec2)
 
-    refs = {r.name: r for r in parse_vipi_from_livi(path)}
-    assert set(refs) == {"GET_IconTextClass.vi", "SET_BodyText.vi"}
-
-    got = refs["GET_IconTextClass.vi"]
-    assert got.path_tokens == ["", "", "Icon", "Icon.lvclass"]
-    assert got.qualified_name is None  # class known only via the PTH0 hint
-
-    body = refs["SET_BodyText.vi"]
-    assert body.qualified_name == "Icon Framework.lvclass:SET_BodyText.vi"
-    assert body.path_tokens == ["", "Icon Framework.lvclass"]
+    names = set(parse_vipi_from_livi(path))
+    assert names == {"GET_IconTextClass.vi", "SET_BodyText.vi"}
 
 
 def test_parse_vipi_missing_file_returns_empty(tmp_path: Path) -> None:
@@ -96,7 +88,7 @@ def test_parse_vipi_real_apply_body_text() -> None:
     if not livi.exists():
         pytest.skip("no _LIvi.bin extracted for this VI")
 
-    names = {r.name for r in parse_vipi_from_livi(livi)}
+    names = set(parse_vipi_from_livi(livi))
     assert {
         "GET_IconTextClass.vi",
         "SET_IconTextClass.vi",

--- a/tests/test_livi_vipi.py
+++ b/tests/test_livi_vipi.py
@@ -1,0 +1,174 @@
+"""Tests for ``parse_vipi_from_livi`` — the ``_LIvi.bin`` (VI-level link
+identity) parser that recovers EVERY subVI callee, including the
+dynamic-dispatch calls that leave no ``IUVI`` in ``_LIbd.bin``."""
+
+from __future__ import annotations
+
+import struct
+from pathlib import Path
+
+import pytest
+
+from lvkit.parser.metadata import parse_vipi_from_livi
+
+SAMPLES_ROOT = Path(__file__).resolve().parent.parent / ".lvkit" / "cache" / "samples"
+
+
+def _plain(name: str) -> bytes:
+    """A plain pascal string ``[len][text]`` — how a class name is stored."""
+    b = name.encode("ascii")
+    return bytes([len(b)]) + b
+
+
+def _wrapped_method(name: str) -> bytes:
+    """A method name pascal string ``[outer_len][0x01][inner_len][text]``."""
+    b = name.encode("ascii")
+    return bytes([2 + len(b), 0x01, len(b)]) + b
+
+
+def _pth0(tokens: list[str]) -> bytes:
+    comp = b"".join(bytes([len(t)]) + t.encode("ascii") for t in tokens)
+    return (
+        b"PTH0"
+        + struct.pack(">I", len(comp) + 4)  # total (ignored by the parser)
+        + struct.pack(">H", 1)  # path type
+        + struct.pack(">H", len(tokens))  # ncomp
+        + comp
+    )
+
+
+def _vipi(count: int, names: bytes, pth0: bytes) -> bytes:
+    return b"VIPI" + struct.pack(">I", count) + names + pth0
+
+
+def test_parse_vipi_static_and_dynamic_callees(tmp_path: Path) -> None:
+    """A count=0 own-context record is skipped; a count=1 record yields a bare
+    method (class only via its PTH0); a count=2 record yields a class-qualified
+    method."""
+    own_ctx = _vipi(0, b"", _pth0(["", "Icon Framework.lvclass"]))
+    rec1 = _vipi(
+        1,
+        _wrapped_method("GET_IconTextClass.vi"),
+        _pth0(["", "", "Icon", "Icon.lvclass"]),
+    )
+    rec2 = _vipi(
+        2,
+        _plain("Icon Framework.lvclass") + _wrapped_method("SET_BodyText.vi"),
+        _pth0(["", "Icon Framework.lvclass"]),
+    )
+    path = tmp_path / "sample_LIvi.bin"
+    path.write_bytes(own_ctx + rec1 + rec2)
+
+    refs = {r.name: r for r in parse_vipi_from_livi(path)}
+    assert set(refs) == {"GET_IconTextClass.vi", "SET_BodyText.vi"}
+
+    got = refs["GET_IconTextClass.vi"]
+    assert got.path_tokens == ["", "", "Icon", "Icon.lvclass"]
+    assert got.qualified_name is None  # class known only via the PTH0 hint
+
+    body = refs["SET_BodyText.vi"]
+    assert body.qualified_name == "Icon Framework.lvclass:SET_BodyText.vi"
+    assert body.path_tokens == ["", "Icon Framework.lvclass"]
+
+
+def test_parse_vipi_missing_file_returns_empty(tmp_path: Path) -> None:
+    assert parse_vipi_from_livi(tmp_path / "nope_LIvi.bin") == []
+
+
+@pytest.mark.needs_samples
+def test_parse_vipi_real_apply_body_text() -> None:
+    """The real ``Apply Body Text.vi`` calls 5 class methods via dynamic
+    dispatch — NONE of which appear in ``_LIbd.bin``. They are all in
+    ``_LIvi.bin``, which is exactly what we recover here."""
+    from lvkit.extractor import extract_vi_xml
+
+    vi = (
+        SAMPLES_ROOT
+        / "ni-labview-icon-editor/vi.lib/LabVIEW Icon API/lv_icon/Classes"
+        / "Icon Framework/Apply Body Text.vi"
+    )
+    if not vi.exists():
+        pytest.skip(f"sample VI absent: {vi}")
+
+    _, _, main_xml = extract_vi_xml(vi)
+    assert main_xml is not None
+    livi = main_xml.with_name(main_xml.stem + "_LIvi.bin")
+    if not livi.exists():
+        pytest.skip("no _LIvi.bin extracted for this VI")
+
+    names = {r.name for r in parse_vipi_from_livi(livi)}
+    assert {
+        "GET_IconTextClass.vi",
+        "SET_IconTextClass.vi",
+        "SET_BodyText.vi",
+        "GET_LayerData.vi",
+        "SET_Layer_Data.vi",
+    } <= names
+
+
+@pytest.mark.needs_samples
+def test_minimal_staging_resolves_class_method_subvis() -> None:
+    """The MINIMAL dependency closure the web extension stages
+    (``get_dependency_paths`` — mirrored by ``tests.helpers.transitive_closure``)
+    must include EVERY class-method SubVI the diagram calls, so their icons +
+    interfaces render instead of bare boxes. Before this work it returned only
+    the 8 class/typedef deps and ZERO SubVIs.
+
+    ``Apply Body Text`` calls 6 class methods. Four are declared on classes it
+    path-records (``Icon``, ``Icon Framework``). The other two — ``GET_LayerData``
+    / ``SET_Layer_Data`` — are ``Layer`` methods it calls by INHERITANCE
+    (``Icon Framework`` extends ``Layer``); they resolve by following
+    ``Icon Framework``'s recorded parent URL to ``Layer`` and walking the ancestor
+    chain. Every hop is a recorded path — identical on web and desktop, no scan.
+    """
+    from lvkit.graph import InMemoryVIGraph
+    from lvkit.load_mode import LoadMode
+
+    root = SAMPLES_ROOT / "ni-labview-icon-editor"
+    vi = (
+        root
+        / "vi.lib/LabVIEW Icon API/lv_icon/Classes/Icon Framework/Apply Body Text.vi"
+    )
+    if not vi.exists():
+        pytest.skip(f"sample VI absent: {vi}")
+
+    g = InMemoryVIGraph()
+    name = g.load_vi(vi, LoadMode.MINIMAL, search_paths=[root])
+    assert name is not None
+    staged = {p.name for p in g.get_dependency_paths(name)}
+
+    # All 6 SubVI callees resolve by path — including the 2 inherited Layer
+    # methods dispatched through an Icon Framework object.
+    assert {
+        "GET_IconTextClass.vi",
+        "SET_IconTextClass.vi",
+        "SET_BodyText.vi",
+        "CreateBodyText.vi",
+        "GET_LayerData.vi",
+        "SET_Layer_Data.vi",
+    } <= staged
+    # The owning classes — including the INHERITED parent Layer, reached via
+    # Icon Framework's recorded parent URL — come along.
+    assert {"Icon.lvclass", "Icon Framework.lvclass", "Layer.lvclass"} <= staged
+
+    # PATH-DRIVEN / WEB PARITY: with NO search path at all (the loader cannot
+    # name-search — the web can only see recorded paths), the same SubVIs and
+    # classes still resolve, because every one has a recorded path (subVIs via
+    # the _LIvi VIPI + inheritance; classes/typedefs via the _LIvi/_LIbd/_LIfp
+    # PTH0 link tables). Only a nested typedef with no file link (LayerType.ctl)
+    # falls out — its type is already inline, so it needs no staging.
+    g2 = InMemoryVIGraph()
+    name2 = g2.load_vi(vi, LoadMode.MINIMAL, search_paths=[])
+    assert name2 is not None
+    by_path = {p.name for p in g2.get_dependency_paths(name2)}
+    assert {
+        "GET_IconTextClass.vi",
+        "SET_IconTextClass.vi",
+        "SET_BodyText.vi",
+        "CreateBodyText.vi",
+        "GET_LayerData.vi",
+        "SET_Layer_Data.vi",
+        "Icon.lvclass",
+        "Icon Framework.lvclass",
+        "Layer.lvclass",
+    } <= by_path

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -13,17 +13,16 @@ from lvkit.parser import (
     ParsedConnectorPane,
     ParsedConnectorPaneSlot,
     ParsedConstant,
+    ParsedDependencyRef,
     ParsedFPTerminal,
     ParsedLoopStructure,
     ParsedNode,
-    ParsedSubVIPathRef,
     ParsedTerminalInfo,
     ParsedWire,
     ParsedWiringRule,
     TunnelMapping,
     parse_connector_pane,
     parse_polymorphic_info,
-    parse_subvi_paths,
     parse_vi,
     parse_vi_metadata,
 )
@@ -636,12 +635,12 @@ class TestConnectorPane:
         assert "dco2" in connected
 
 
-class TestSubVIPathRef:
-    """Tests for the ParsedSubVIPathRef dataclass."""
+class TestDependencyRef:
+    """Tests for the ParsedDependencyRef dataclass."""
 
     def test_vilib_path_ref(self):
         """Test a vi.lib path reference."""
-        ref = ParsedSubVIPathRef(
+        ref = ParsedDependencyRef(
             name="File Exists.vi",
             path_tokens=["<vilib>", "Utility", "file.llb", "File Exists.vi"],
         )
@@ -651,7 +650,7 @@ class TestSubVIPathRef:
 
     def test_userlib_path_ref(self):
         """Test a user.lib path reference."""
-        ref = ParsedSubVIPathRef(
+        ref = ParsedDependencyRef(
             name="MyHelper.vi",
             path_tokens=["<userlib>", "MyLib", "MyHelper.vi"],
         )
@@ -660,7 +659,7 @@ class TestSubVIPathRef:
 
     def test_local_path_ref(self):
         """Test a local path reference."""
-        ref = ParsedSubVIPathRef(
+        ref = ParsedDependencyRef(
             name="Local.vi",
             path_tokens=["SubFolder", "Local.vi"],
         )
@@ -1011,11 +1010,16 @@ class TestParseConnectorPane:
 
 
 class TestParseSubviPaths:
-    """Tests for parse_subvi_paths function."""
+    """Tests for VIVI-ref extraction via parse_vi(...).metadata.dependency_refs."""
+
+    _MIN_BD = """<?xml version="1.0"?>
+<root>
+    <signalList></signalList>
+</root>"""
 
     def test_parse_vilib_subvi(self, tmp_path: Path):
         """Test parsing a vi.lib SubVI reference."""
-        xml_content = """<?xml version="1.0"?>
+        main_xml_content = """<?xml version="1.0"?>
 <root>
     <LIvi>
         <Section>
@@ -1031,10 +1035,12 @@ class TestParseSubviPaths:
         </Section>
     </LIvi>
 </root>"""
-        xml_file = tmp_path / "test.xml"
-        xml_file.write_text(xml_content)
+        bd_file = tmp_path / "test_BDHb.xml"
+        bd_file.write_text(self._MIN_BD)
+        main_file = tmp_path / "test.xml"
+        main_file.write_text(main_xml_content)
 
-        refs = parse_subvi_paths(xml_file)
+        refs = parse_vi(bd_xml=bd_file, main_xml=main_file).metadata.dependency_refs
         assert len(refs) == 1
         ref = refs[0]
         assert ref.name == "File Exists.vi"
@@ -1042,7 +1048,7 @@ class TestParseSubviPaths:
 
     def test_parse_userlib_subvi(self, tmp_path: Path):
         """Test parsing a user.lib SubVI reference."""
-        xml_content = """<?xml version="1.0"?>
+        main_xml_content = """<?xml version="1.0"?>
 <root>
     <LIvi>
         <Section>
@@ -1057,10 +1063,12 @@ class TestParseSubviPaths:
         </Section>
     </LIvi>
 </root>"""
-        xml_file = tmp_path / "test.xml"
-        xml_file.write_text(xml_content)
+        bd_file = tmp_path / "test_BDHb.xml"
+        bd_file.write_text(self._MIN_BD)
+        main_file = tmp_path / "test.xml"
+        main_file.write_text(main_xml_content)
 
-        refs = parse_subvi_paths(xml_file)
+        refs = parse_vi(bd_xml=bd_file, main_xml=main_file).metadata.dependency_refs
         assert len(refs) == 1
         ref = refs[0]
         assert ref.name == "MyHelper__ogtk.vi"

--- a/tests/test_parser_regression.py
+++ b/tests/test_parser_regression.py
@@ -8,7 +8,7 @@ from lvkit.extractor import extract_vi_xml
 from lvkit.graph import InMemoryVIGraph
 from lvkit.graph.loading import LoadMode
 from lvkit.parser import ParsedVI, ParsedVIMetadata, parse_vi
-from lvkit.parser.metadata import parse_subvi_paths, parse_vi_metadata
+from lvkit.parser.metadata import parse_vi_metadata
 from lvkit.parser.type_mapping import parse_type_map_rich
 
 # Regression suite over the local-only sample corpus.
@@ -108,15 +108,11 @@ class TestMetadata:
 
 
 class TestSubVIPaths:
-    def test_refs_not_empty(self, extracted_xml):
-        _, _, main_xml = extracted_xml
-        refs = parse_subvi_paths(main_xml)
-        assert len(refs) > 0
+    def test_refs_not_empty(self, parsed_metadata):
+        assert len(parsed_metadata.dependency_refs) > 0
 
-    def test_refs_have_qualified_names(self, extracted_xml):
-        _, _, main_xml = extracted_xml
-        refs = parse_subvi_paths(main_xml)
-        for ref in refs:
+    def test_refs_have_qualified_names(self, parsed_metadata):
+        for ref in parsed_metadata.dependency_refs:
             assert ref.qualified_name is not None
 
 

--- a/tests/test_web_progressive_staging.py
+++ b/tests/test_web_progressive_staging.py
@@ -1,0 +1,75 @@
+"""Proxy for the web extension's PROGRESSIVE staging.
+
+Desktop/native tests load a VI with every dependency already on disk, so they
+NEVER exercise the loader's absent-file branches — the web-only logic where a dep
+whose file isn't staged yet must still be NAMED by its recorded path AND EDGED to
+its caller, with a stub key that matches the key a later present load produces.
+That logic regresses silently (a fix that passed 1928 present-file tests broke
+the web the moment it landed). These tests replay the actual absent->fetch loop
+in pure Python and assert it reaches the SAME closure as a single load over the
+full tree — the equality that catches under-staging.
+
+The issue29 case is committed, so it runs in CI. The icon-editor case
+(inheritance / cross-class dispatch — where the regression actually lived) needs
+the local sample corpus.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.helpers import progressive_closure, transitive_closure
+
+_ISSUE29 = Path("tests/corpus/issues/29/Test LVKit")
+_SAMPLES = Path(__file__).resolve().parent.parent / ".lvkit" / "cache" / "samples"
+
+
+def test_progressive_matches_single_pass_issue29(tmp_path: Path) -> None:
+    """A class-member SubVI (``Do.vi``, called by ``Test.vi``) must be reached by
+    the progressive absent->fetch loop exactly as a single full-tree load reaches
+    it — committed corpus, so this guards the absent-path logic in CI."""
+    entry = _ISSUE29 / "Lib2" / "Class" / "Test.vi"
+    single = transitive_closure(entry, _ISSUE29)
+    assert single, "issue29 closure should be non-empty"
+    progressive = progressive_closure(entry, _ISSUE29, tmp_path / "proj")
+    assert progressive == single, (
+        f"progressive staging reached {sorted(p.name for p in progressive)} but a "
+        f"single load reaches {sorted(p.name for p in single)} — the web "
+        "absent-path logic understages vs desktop"
+    )
+
+
+@pytest.mark.needs_samples
+def test_progressive_stages_inherited_class_methods(tmp_path: Path) -> None:
+    """The case the regression actually lived in: Apply Body Text calls 6 class
+    methods, two by INHERITANCE (Layer dispatch through an Icon Framework object).
+    The progressive loop must fetch all 6 — not just resolve them when every file
+    is already present."""
+    root = _SAMPLES / "ni-labview-icon-editor"
+    entry = (
+        root
+        / "vi.lib/LabVIEW Icon API/lv_icon/Classes/Icon Framework/Apply Body Text.vi"
+    )
+    if not entry.exists():
+        pytest.skip(f"sample absent: {entry}")
+    progressive = progressive_closure(entry, root, tmp_path / "proj")
+    names = {p.name for p in progressive}
+    # All 6 SubVIs (incl. the two INHERITED Layer dispatch methods) + their 3
+    # classes must be reached by the absent->fetch loop. This is precisely what a
+    # broken absent-path key / missing caller edge / .exists()-gate would drop —
+    # the single-pass (desktop) load can't be the oracle here because it also
+    # name-searches deps with no recorded path (e.g. the nested LayerType.ctl),
+    # which the web can't and doesn't need.
+    assert {
+        "GET_IconTextClass.vi",
+        "SET_IconTextClass.vi",
+        "SET_BodyText.vi",
+        "CreateBodyText.vi",
+        "GET_LayerData.vi",
+        "SET_Layer_Data.vi",
+        "Icon.lvclass",
+        "Icon Framework.lvclass",
+        "Layer.lvclass",
+    } <= names


### PR DESCRIPTION
## Summary

Fixes the web loader so a VI's SubVIs (icons + interfaces) actually stage and render on the web (vscode.dev / Codespaces / Cursor) — the reported "VI icons don't load" bug — and makes the whole dependency closure resolve by **recorded path** with **no name-search**, identically on desktop and web.

The root cause was two things LabVIEW records that the parser discarded:
1. **Class inheritance** declared in the `.lvclass` XML (`<Item Type="Parent" URL=…/>`), not the binary property — so `Icon Framework extends Layer` was lost and inherited dispatch methods (`GET_LayerData`) were unresolvable.
2. **`PTH0` path records** in the `_LIvi`/`_LIbd`/`_LIfp` link tables — a recorded path for every referenced file; we only read the `IUVI` subVI records, so classes/typedefs fell back to name-search the web can't do.

A second class of bug lived in the **progressive** (web) path: an absent-but-recorded dependency must be **named by its intended path AND edged to its caller** (a path-keyed stub that **upgrades** when the file stages), never `.exists()`-gated. Desktop masked this because it loads the whole tree at once.

## Commits
- `87a37cf` — resolve every MINIMAL dependency by recorded path (inheritance from XML `Item` URL; `PTH0` link-table paths; VIPI method names + ancestor-walk method resolution).
- `73f25db` — make staging work on the progressive web path (name + edge + upgrade absent deps).
- `50290d6` — design-review pass (two audit rounds, 19 findings) + a pure-Python **progressive-staging proxy test** that replays the extension's absent→fetch loop so this regression class is caught in CI.

## Verification
- **Full suite: 1930 passed / 0 failed**; ruff + pyright clean.
- `Apply Body Text` MINIMAL closure **8 → 15** (all 6 subVIs incl. inherited `Layer` methods); resolves with `search_paths=[]` (no name-search).
- `check-web-parity.sh`: **web (Pyodide/wasm) == desktop (native) render byte-identical** for all 9 fixtures (icon-editor class/inheritance included).
- **Full `vscode-test-web`**: the real extension in headless Chromium staged **15 files** via the actual `stageDependencyClosure` and **rendered via wasm in 633ms**.

## Release note
The fix is in lvkit core, so shipping it to users needs a **0.8.1** release (five version sites incl. `LVKIT_WHEEL`, so the web extension pulls the fixed wheel) + `v0.8.1`/`ext-v0.8.1` tags. Not done in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013iFpWCUT5kW3vdSMbie5xL
