### PR TITLE
Faithful render: class/cluster wires, cluster & array constants, Bundle-By-Name (closes #43, #45, #72, #79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 lvkit follows semantic versioning.
 
 ## [Unreleased]
+- **Class wires render in the class's own color** — an LVOOP class instance's wire now draws in the color (and width/line-style) set in the class's Wire Appearance, decoded from the `.lvclass`, instead of the generic default (#43).
 
 ## [0.8.1] - 2026-08-31
 - **Fix: a VI's SubVIs now render on the web** — their icons and interfaces stage on hosted editors, including methods a class inherits (#77).

--- a/src/lvkit/graph/construction.py
+++ b/src/lvkit/graph/construction.py
@@ -463,6 +463,7 @@ class ConstructionMixin:
                 raw_value=const.value,
                 label=const.label,
                 display_format=const.display_format,
+                collapsed=const.collapsed,
                 terminals=[const_terminal],
             )
             g.add_node(q_const_uid, node=const_node)

--- a/src/lvkit/graph/core.py
+++ b/src/lvkit/graph/core.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 import networkx as nx
 
 from ..load_mode import LoadMode
-from ..models import ClusterField, LVType, LVTypeKind
+from ..models import ClusterField, LVType, LVTypeKind, WireStyle
 from ..parser.models import ParsedType, ParsedVI
 
 if TYPE_CHECKING:
@@ -330,6 +330,13 @@ class InMemoryVIGraph(
         # Class/typedef fields: codegen queries dep_graph or vilib_resolver
         # by classname/typedef_name. No copies.
 
+        # A class instance carries its OWN wire style (color/width/line style),
+        # resolved from its .lvclass, so the one render lookup draws every class
+        # wire in the class's style with no graph — see LVType.wire_style /
+        # render.style.wire_style.
+        if parsed_type.classname:
+            lv_type.wire_style = self.get_class_wire_style(parsed_type.classname)
+
         return lv_type
 
     def _dep_key_for_ref(
@@ -430,6 +437,37 @@ class InMemoryVIGraph(
             if parent_fields:
                 return parent_fields + own_fields
         return own_fields
+
+    def get_class_wire_style(
+        self,
+        classname: str,
+        caller_vi_key: str | None = None,
+    ) -> WireStyle | None:
+        """A class's own wire style, or None when it (and every ancestor) uses the
+        default/generic look.
+
+        ``classname`` is resolved to its PATH-key node via :meth:`_dep_key_for_ref`
+        (pass the CALLER VI key so a duplicated class name resolves by the
+        caller's edge). A class with no custom pen inherits its parent's (LabVIEW's
+        "use parent's/default design"), so the parent chain is walked by
+        ``parent_key`` (:meth:`_parent_class_key`) until a custom style is found.
+        """
+        node_key = self._dep_key_for_ref(classname, caller_vi_key)
+        if node_key is None or not self._dep_graph.has_node(node_key):
+            return None
+        return self._class_wire_style_by_key(node_key)
+
+    def _class_wire_style_by_key(self, node_key: str) -> WireStyle | None:
+        """This class's own wire style, else the nearest ancestor's — the
+        inherited case. Follows the parent's PATH key by IDENTITY
+        (:meth:`_parent_class_key`), same as :meth:`_class_fields_by_key`."""
+        style: WireStyle | None = self._dep_graph.nodes[node_key].get("wire_style")
+        if style is not None:
+            return style
+        parent_key = self._parent_class_key(node_key)
+        if parent_key is not None:
+            return self._class_wire_style_by_key(parent_key)
+        return None
 
     def get_type_fields(
         self,

--- a/src/lvkit/graph/loading.py
+++ b/src/lvkit/graph/loading.py
@@ -274,6 +274,9 @@ class LoadingMixin:
             iuse_to_qpath: dict[str, str] | None = None,
         ) -> None: ...
         def resolve_dispatch_qnames(self) -> None: ...
+        def _dep_key_for_ref(
+            self, ref: str, caller_vi_key: str | None = None
+        ) -> str | None: ...
 
     def load_vi(
         self,
@@ -1589,6 +1592,19 @@ class LoadingMixin:
                     if caller_qname:
                         self._dep_graph.add_edge(caller_qname, found_key)
                     return
+            # Before stubbing: a SIBLING reference may already have resolved this
+            # same file by path (e.g. a type_map's BARE ``typedef_name`` —
+            # ``Parameters.ctl`` — duplicating the VICC-linked, path-resolved
+            # qualified ref ``…lvclass:Parameters.ctl``). Route this ref's edge
+            # onto that resolved node via the caller-scoped resolver instead of
+            # spawning a second, empty bare-name stub node beside it. Caller-
+            # scoped + unique-match (``_dep_key_for_ref``) so it can never point
+            # at a same-leaf file from a different library.
+            existing = self._dep_key_for_ref(qualified_name, caller_qname)
+            if existing is not None and existing not in self._stubs:
+                if caller_qname:
+                    self._dep_graph.add_edge(caller_qname, existing)
+                return
             node_type = (
                 "class"
                 if leaf.endswith(".lvclass")

--- a/src/lvkit/graph/loading.py
+++ b/src/lvkit/graph/loading.py
@@ -718,6 +718,7 @@ class LoadingMixin:
             version=cls.version,
             ancestors=cls.ancestors,
             method_paths=method_paths,
+            wire_style=cls.wire_style,
         )
         self._register_dep_node(cls_key, cls_path_r, cls_name, cls_qname)
         self._stubs.discard(cls_key)

--- a/src/lvkit/graph/models.py
+++ b/src/lvkit/graph/models.py
@@ -312,6 +312,10 @@ class ConstantNode(GraphNode):
     # (``ParsedConstant.display_format``, e.g. ``%.0x`` for hex), threaded
     # through unchanged — render/nodes.py is where it's interpreted.
     display_format: str | None = None
+    # True when this cluster/array constant is drawn COLLAPSED ("View As Icon",
+    # ``ParsedConstant.collapsed``): render shows a compact icon, not its
+    # members/elements (LabVIEW never shrinks a value's natural height).
+    collapsed: bool = False
 
 
 class LabelNode(GraphNode):

--- a/src/lvkit/graph/op_walk.py
+++ b/src/lvkit/graph/op_walk.py
@@ -178,6 +178,31 @@ def _resolve_nmux_field_name(
     return None
 
 
+def _resolve_nmux_field_path(
+    field_index: int | None,
+    *field_sources: list[ClusterField],
+    leaf_only: bool,
+) -> str | None:
+    """The full dotted navigation PATH to a NESTED field for a resolved nmux
+    index (e.g. ``Strain Config.strain gage information.poisson ratio``), or
+    None for a top-level field or when nothing resolves. Same flatten/source
+    order as :func:`_resolve_nmux_field_name` (which returns only the leaf) — the
+    flatten already carries the path per slot; this just keeps it for the
+    tooltip. Only a genuinely nested path (more than one segment) is returned."""
+    if field_index is None:
+        return None
+    flatten = _flatten_leaf_fields if leaf_only else _flatten_fields
+    for fields in field_sources:
+        if not fields:
+            continue
+        flat = flatten(fields)
+        if 0 <= field_index < len(flat):
+            path, field = flat[field_index]
+            if field.name and len(path) > 1:
+                return ".".join(path)
+    return None
+
+
 def _nmux_field_sources(
     vi_name: str,
     agg: Terminal | None,
@@ -228,12 +253,17 @@ def _nmux_lane_name(
         if name:
             return name
     own_fields, dep_fields = _nmux_field_sources(vi_name, agg, graph)
-    return _resolve_nmux_field_name(
-        term.nmux_field_index,
-        own_fields,
-        dep_fields,
-        leaf_only=_nmux_index_leaf_only(node_type, agg),
+    leaf_only = _nmux_index_leaf_only(node_type, agg)
+    name = _resolve_nmux_field_name(
+        term.nmux_field_index, own_fields, dep_fields, leaf_only=leaf_only
     )
+    if name is not None:
+        # Also keep the full dotted path (nested fields only) for the tooltip —
+        # the glyph shows the terse leaf ``name``.
+        term.field_path = _resolve_nmux_field_path(
+            term.nmux_field_index, own_fields, dep_fields, leaf_only=leaf_only
+        )
+    return name
 
 
 def stamp_nmux_lane_names(graph: InMemoryVIGraph) -> None:

--- a/src/lvkit/graph/op_walk.py
+++ b/src/lvkit/graph/op_walk.py
@@ -30,7 +30,7 @@ from ..models import (
     _is_error_cluster,
 )
 from ..num_format import format_numeric_const
-from ..parser.constants import NMUX_BY_NAME_NODE_CLASSES
+from ..parser.constants import NMUX_BY_NAME_NODE_CLASSES, NODE_CLASS_NMUX
 from ..structure import _fields_from_xml, private_data_field_to_cluster_field
 from ..vilib_resolver import get_resolver as _get_vilib_resolver
 from .models import Constant
@@ -125,26 +125,52 @@ def _own_class_private_data_fields(
     return [private_data_field_to_cluster_field(f) for f in fields]
 
 
+def _nmux_index_leaf_only(node_type: str | None, agg: Terminal | None) -> bool:
+    """How a node's flat ``<i>`` field index counts a NESTED cluster's fields.
+
+    FULL depth-first flatten (an intermediate sub-cluster is itself an
+    addressable slot) applies to exactly ONE case: a Bundle/Unbundle By Name
+    (``nMux``) over a plain typedef/cluster aggregate. Class private data —
+    accessed by ``nMux`` OR the IPES cluster border ``decomposeClusterNode`` —
+    and event data index LEAF fields only. Verified: ``nMux`` on
+    ``Parameters.ctl`` uses ``<i>``=40 for the whole ``PWM Config`` sub-cluster
+    (slot 40 of the full flatten; leaf-only has no such slot); ``nMux`` on a
+    class's own private data resolves ``pin_map_id`` (leaf); and a
+    ``decomposeClusterNode`` on ``Daqmx Module runtime`` private data uses
+    7/1/9/3 -> the leaf fields DI Index/AO Task/PWM Freq Index/DO Task. So the
+    private-data (``classname``-bearing) aggregate stays leaf even under
+    ``nMux``."""
+    if node_type != NODE_CLASS_NMUX:
+        return True
+    return not (
+        agg is not None
+        and agg.lv_type is not None
+        and agg.lv_type.classname is None
+    )
+
+
 def _resolve_nmux_field_name(
     field_index: int | None,
     *field_sources: list[ClusterField],
+    leaf_only: bool,
 ) -> str | None:
     """Resolve a field-index's LabVIEW field name, trying each of
     ``field_sources`` (in priority order) in turn — each row resolved
     independently, so one source can cover a row another source misses.
 
-    Each source is flattened LEAF-first (``_flatten_leaf_fields``):
-    LabVIEW's flat ``<i>`` index for a NESTED cluster (e.g. a class
-    private-data cluster whose own fields are themselves sub-clusters) runs
-    over leaves only — an intermediate sub-cluster is never itself an
-    addressable flat slot.
+    ``leaf_only`` picks how each source is flattened for a NESTED cluster (see
+    :func:`_nmux_index_leaf_only`): ``True`` counts LEAF fields only
+    (``_flatten_leaf_fields`` — IPES decompose / event data), ``False`` counts
+    every node depth-first so a whole sub-cluster is its own addressable slot
+    (``_flatten_fields`` — Bundle/Unbundle By Name).
     """
     if field_index is None:
         return None
+    flatten = _flatten_leaf_fields if leaf_only else _flatten_fields
     for fields in field_sources:
         if not fields:
             continue
-        flat = _flatten_leaf_fields(fields)
+        flat = flatten(fields)
         if 0 <= field_index < len(flat):
             name = flat[field_index][1].name
             if name:
@@ -183,13 +209,15 @@ def _nmux_lane_name(
     agg: Terminal | None,
     vi_name: str,
     graph: InMemoryVIGraph,
+    node_type: str | None,
 ) -> str | None:
     """THE canonical field-name resolution for an nMux/decompose LIST
     terminal, via ``term.nmux_field_index`` into the aggregate's field list
-    (``_nmux_field_sources``, then ``_resolve_nmux_field_name``). Returns
-    None when neither source resolves a name — callers keep their own
-    index/name fallback (a bracketed index or the terminal's own name is
-    display-only, never worth pinning onto ``display_name``)."""
+    (``_nmux_field_sources``, then ``_resolve_nmux_field_name`` — flattened per
+    ``node_type``, see :func:`_nmux_index_leaf_only`). Returns None when neither
+    source resolves a name — callers keep their own index/name fallback (a
+    bracketed index or the terminal's own name is display-only, never worth
+    pinning onto ``display_name``)."""
     # A MeasureData aggregate (waveform / digital data) has no VCTP fields — its
     # component names come from the built-in flavor table, keyed directly by the
     # drawer's field index (no leaf-flatten).
@@ -200,7 +228,12 @@ def _nmux_lane_name(
         if name:
             return name
     own_fields, dep_fields = _nmux_field_sources(vi_name, agg, graph)
-    return _resolve_nmux_field_name(term.nmux_field_index, own_fields, dep_fields)
+    return _resolve_nmux_field_name(
+        term.nmux_field_index,
+        own_fields,
+        dep_fields,
+        leaf_only=_nmux_index_leaf_only(node_type, agg),
+    )
 
 
 def stamp_nmux_lane_names(graph: InMemoryVIGraph) -> None:
@@ -242,7 +275,7 @@ def stamp_nmux_lane_names(graph: InMemoryVIGraph) -> None:
             for term in node.terminals:
                 if term.nmux_role != "list" or term.display_name is not None:
                     continue
-                name = _nmux_lane_name(term, agg, vi_name, graph)
+                name = _nmux_lane_name(term, agg, vi_name, graph, node.node_type)
                 if name:
                     term.display_name = name
 

--- a/src/lvkit/graph/op_walk.py
+++ b/src/lvkit/graph/op_walk.py
@@ -419,6 +419,11 @@ def _format_ranges(ranges: list[SelectorRange], fmt: Callable[[int], str]) -> st
             parts.append(f"{fmt(r.start)}..")
         elif r.is_single:
             parts.append(fmt(r.start))
+        elif r.end == r.start + 1:
+            # Exactly two values — nothing lies between them to elide, so list
+            # both ("a, b"). ".." means the contiguous middle is skipped, which
+            # only applies to a span of three or more values.
+            parts.append(f"{fmt(r.start)}, {fmt(r.end)}")
         else:
             parts.append(f"{fmt(r.start)}..{fmt(r.end)}")
     return ", ".join(parts)

--- a/src/lvkit/models.py
+++ b/src/lvkit/models.py
@@ -235,16 +235,27 @@ class WireLineStyle(IntEnum):
 
 @dataclass(frozen=True)
 class WireStyle:
-    """How a wire draws — its ``color``, pixel ``width``, and dash ``line_style``.
+    """Everything a wire needs to draw itself — the ONE style object the ONE wire
+    lookup (``render.style.wire_style``) returns and every drawing site renders.
     A type's OWN style (``LVType.wire_style``) overrides the default per-family
-    color/width at the one wire lookup (``render.style.wire_style``); most types
-    have none (that lookup derives their style from the type family), but a
-    LabVIEW class carries one decoded from its ``.lvclass``. The single knob that
-    makes wire color/style data-driven instead of a fixed table."""
+    color/width there; most types have none (the lookup derives theirs from the
+    family), but a LabVIEW class carries one decoded from its ``.lvclass``.
+
+    ``color``/``width``/``line_style`` describe a flat wire. ``edge_color`` +
+    ``core_width`` add the class two-band look — an outer ``edge_color`` band at
+    ``width`` with a ``color`` center of ``core_width`` on top; both None for a
+    flat wire (``width`` is then the single stroke). New wire styles (e.g. a fill
+    pattern) are added HERE, once, and every site renders them."""
 
     color: str
     width: float
     line_style: WireLineStyle = WireLineStyle.SOLID
+    edge_color: str | None = None
+    core_width: float | None = None
+    # The center pen's 8-row fill-pattern bitmap (one byte per row). On the thin
+    # center band it reads as a dash along the wire — the class "chain" — with the
+    # solid edge band showing through the gaps. () for a solid/flat wire.
+    fill_pattern: tuple[int, ...] = ()
 
 
 @dataclass

--- a/src/lvkit/models.py
+++ b/src/lvkit/models.py
@@ -252,9 +252,8 @@ class WireStyle:
     line_style: WireLineStyle = WireLineStyle.SOLID
     edge_color: str | None = None
     core_width: float | None = None
-    # The center pen's 8-row fill-pattern bitmap (one byte per row). On the thin
-    # center band it reads as a dash along the wire — the class "chain" — with the
-    # solid edge band showing through the gaps. () for a solid/flat wire.
+    # The pen's 8-row fill-pattern bitmap (one byte per row). Non-empty => the
+    # class wire is patterned (drawn as a chain) rather than solid; () => solid.
     fill_pattern: tuple[int, ...] = ()
 
 

--- a/src/lvkit/models.py
+++ b/src/lvkit/models.py
@@ -365,6 +365,11 @@ class Terminal(BaseModel):
     # this must never change generated code. Used by the renderer's connector-
     # pane hover / tooltip and by describe. See graph/construction.py.
     display_name: str | None = None
+    # Full dotted navigation path to a NESTED Bundle/Unbundle-By-Name field
+    # (e.g. "Strain Config.strain gage information.poisson ratio") — tooltip-only
+    # detail beside the terse leaf ``display_name`` the glyph shows. None for a
+    # top-level or leaf-only field. Set at the ``stamp_nmux_lane_names`` seam.
+    field_path: str | None = None
     lv_type: LVType | None = None
     var_name: str | None = None  # set during codegen
     nmux_role: str | None = None  # "agg" or "list"

--- a/src/lvkit/models.py
+++ b/src/lvkit/models.py
@@ -17,8 +17,8 @@ subclasses are the single source of truth for node structure.
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
-from enum import Enum
+from dataclasses import dataclass, field
+from enum import Enum, IntEnum
 from typing import Literal
 
 from pydantic import BaseModel
@@ -71,6 +71,12 @@ class LVType:
     # opaque built-in structures with no VCTP children, so their component names
     # come from a built-in table keyed by this flavor (see measure_data.py).
     measure_flavor: str | None = None
+    # This type's OWN wire style, when it has one — read by the one wire lookup
+    # (``render.style.wire_style``) so wire color/style is data-driven, not a
+    # fixed per-family table. None for a type that uses the family default (every
+    # built-in today); a LabVIEW class fills it from its ``.lvclass``.
+    # ``compare=False`` — presentation, never type identity/coercion.
+    wire_style: WireStyle | None = field(default=None, compare=False)
 
     def to_python(self) -> str:
         """Render as Python type annotation string."""
@@ -212,6 +218,33 @@ class LVType:
                 self.underlying_type or "", self.underlying_type or "?"
             )
         return "?"
+
+
+class WireLineStyle(IntEnum):
+    """A wire pen's ``Style`` — Solid/Dash/Dot/DashDot/DashDotDot. ``SOLID`` is
+    the default and the only style built-in wires use; a LabVIEW class can pick
+    another in its ``.lvclass``. ``IntEnum`` so a member equals the raw 0–4 the
+    binary stores, drop-in."""
+
+    SOLID = 0
+    DASH = 1
+    DOT = 2
+    DASH_DOT = 3
+    DASH_DOT_DOT = 4
+
+
+@dataclass(frozen=True)
+class WireStyle:
+    """How a wire draws — its ``color``, pixel ``width``, and dash ``line_style``.
+    A type's OWN style (``LVType.wire_style``) overrides the default per-family
+    color/width at the one wire lookup (``render.style.wire_style``); most types
+    have none (that lookup derives their style from the type family), but a
+    LabVIEW class carries one decoded from its ``.lvclass``. The single knob that
+    makes wire color/style data-driven instead of a fixed table."""
+
+    color: str
+    width: float
+    line_style: WireLineStyle = WireLineStyle.SOLID
 
 
 @dataclass

--- a/src/lvkit/parser/layout.py
+++ b/src/lvkit/parser/layout.py
@@ -33,6 +33,29 @@ from ..extractor import extract_vi_xml
 Point = tuple[float, float]
 Rect = tuple[float, float, float, float]  # x1, y1, x2, y2
 
+
+def bundle_aggregate_columns(box: Rect, node: Rect) -> tuple[Rect, Rect]:
+    """The two cluster columns of a Bundle-By-Name, from its shared aggregate
+    ``box`` (the one the OUTPUT owns) and the ``node`` bounds.
+
+    Returns ``(interior_input_column, edge_output_column)``. The output keeps its
+    own ``box`` — the EDGE column, flush to whichever node side it lines (right
+    for the usual right-hand aggregate). The INPUT — which the heap gives no box
+    of its own — takes the equal-width column immediately on the field-facing
+    side of that box (the empty band the heap leaves between the field cells and
+    the box). The single source of this rule: ``layout`` anchors the input
+    wire's endpoint to the interior column's top before wire decode, and
+    ``scene`` gives the two terminals these boxes for the glyph/hover panel — so
+    both agree by construction rather than by two hand-kept copies."""
+    ax1, ay1, ax2, ay2 = box
+    nx1, _, nx2, _ = node
+    w = ax2 - ax1
+    if (nx2 - ax2) <= (ax1 - nx1):  # box lines the node's RIGHT edge
+        interior = (ax1 - w, ay1, ax1, ay2)
+    else:  # left-hand aggregate: interior column on the box's right
+        interior = (ax2, ay1, ax2 + w, ay2)
+    return interior, box
+
 # Structure border DCOs that live OUTSIDE their owning node's termList (loop
 # count/index/test terminals, case selector) — each has its own uid + bounds,
 # but the graph doesn't model them as full Terminal objects. Geometry only.
@@ -579,6 +602,59 @@ class _LayoutBuilder:
                     self._wire_z_seq += 1
                 self.raw_signals.append((uids, cw.text.strip()))
 
+    def _reanchor_nmux_aggregate_inputs(self, root: ET.Element) -> None:
+        """Anchor a Bundle-By-Name's INPUT aggregate terminal to the interior
+        cluster column, BEFORE wire geometry is resolved.
+
+        A Bundle's input and output cluster terminals SHARE one aggregate DCO:
+        the output OWNS it (a ``<dco class="nmxDCO" ...>`` carrying the
+        ``termBounds``), the input is a bare ``<dco uid=.../>`` REFERENCE with no
+        box of its own — a fixed fact of the heap format (verified across Bundle
+        nodes). So the generic term walk collapses the input onto the output's
+        box centre, and the input cluster wire then terminates INSIDE the output
+        box. LabVIEW draws the two as adjacent equal-width columns: the output on
+        its own box (flush to the node's right edge), the input in the column
+        immediately to its left — the empty band between the field cells and the
+        box. Move the input's centre to that column's top.
+
+        This runs on ``terminal_centers`` BEFORE ``_resolve_wire_geometry``, so
+        the faithful wire is DECODED against the corrected anchor — its blob is
+        re-formed onto the interior column, never re-routed or overridden. Only
+        the position-less INPUT moves; the output keeps its real recorded box.
+        An Unbundle (a single aggregate that owns its own box) has no alias term
+        and is left untouched.
+        """
+        for nmux in root.iter("SL__arrayElement"):
+            if nmux.get("class") != "nMux":
+                continue
+            agg_el = nmux.find("dcoAgg")
+            tl = nmux.find("termList")
+            nmux_uid = nmux.get("uid")
+            if agg_el is None or tl is None or not nmux_uid:
+                continue
+            agg_uid = agg_el.get("uid")
+            owner_uid: str | None = None
+            alias_uid: str | None = None
+            for term in tl.findall("SL__arrayElement"):
+                if term.get("class") != "term":
+                    continue
+                dco = term.find("dco")
+                if dco is None or dco.get("uid") != agg_uid:
+                    continue
+                if dco.get("class") == "nmxDCO":
+                    owner_uid = term.get("uid")  # output: owns the box
+                else:
+                    alias_uid = term.get("uid")  # input: bare reference, no box
+            if owner_uid is None or alias_uid is None:
+                continue  # Unbundle / single aggregate — nothing to split
+            box = self.node_bounds.get(owner_uid)
+            node = self.node_bounds.get(nmux_uid)
+            if box is None or node is None:
+                continue
+            # Anchor the position-less input to the TOP of its interior column.
+            (ix1, iy1, ix2, _), _ = bundle_aggregate_columns(box, node)
+            self.terminal_centers[alias_uid] = ((ix1 + ix2) / 2, iy1)
+
     def _resolve_wire_geometry(self) -> dict[str, list[tuple[float, float]]]:
         """Decode every ``raw_signal`` into ``Layout.wire_by_uid``: each branch's
         FULL polyline (LabVIEW's own source anchor + bend points + sink anchor)
@@ -735,6 +811,9 @@ def build_layout_from_root(
 
     builder = _LayoutBuilder()
     builder.walk(root, 0.0, 0.0)
+    # Correct the position-less Bundle input aggregate anchor BEFORE the wires
+    # are decoded, so the faithful blob re-forms onto the interior column.
+    builder._reanchor_nmux_aggregate_inputs(root)
 
     return Layout(
         node_bounds=builder.node_bounds,

--- a/src/lvkit/parser/models.py
+++ b/src/lvkit/parser/models.py
@@ -68,6 +68,11 @@ class ParsedConstant:
     # default decimal display). Interpreted at render time — the parser
     # does not decide what it means.
     display_format: str | None = None
+    # True when a cluster/array constant is drawn COLLAPSED ("View As Icon") —
+    # its DDO ``objFlags`` bit 0x10000000. A collapsed constant shows a compact
+    # icon, NOT its members/elements (LabVIEW cannot shrink a value's natural
+    # height, so a small box is a collapse, never squashed content).
+    collapsed: bool = False
 
 
 @dataclass

--- a/src/lvkit/parser/nodes/case.py
+++ b/src/lvkit/parser/nodes/case.py
@@ -29,6 +29,15 @@ ALL_TUNNEL_CLASSES = ("csTun", "selTun", "commentTun")
 # objFlags bit marking a string case structure as "Case Insensitive Match".
 _CASE_INSENSITIVE_BIT = 24
 
+# LabVIEW writes INT_MIN/INT_MAX as the SYMBOLIC filler for an unbounded range
+# side — an error-cluster's status frames encode "No Error" as (INT_MIN, INT_MIN)
+# and "Error" as the full domain (INT_MIN, INT_MAX). A nonzero start/end range
+# type marks filler ONLY when the value actually is one of these sentinels; a
+# nonzero type on a REAL value (e.g. an enum member 0 in a multi-member range) is
+# a genuine match value.
+_I32_MIN = -(2**31)
+_I32_MAX = 2**31 - 1
+
 
 def _objflags_bit(elem: ET.Element, bit: int) -> bool:
     """Whether ``elem``'s ``objFlags`` integer has ``bit`` set."""
@@ -259,16 +268,26 @@ def _extract_one_case_structure(
 
         if len(entries) == 1:
             s, e, st, et = entries[0]
-            if st != 0 and et != 0:
+            s_fill = st != 0 and s in (_I32_MIN, _I32_MAX)
+            e_fill = et != 0 and e in (_I32_MIN, _I32_MAX)
+            if s_fill and e_fill:
                 if s == e:
-                    # Symbolic degenerate point — error-cluster "No Error".
+                    # Degenerate symbolic point — error-cluster "No Error".
                     no_error_diags.add(diag_idx)
                 else:
-                    # Symbolic full-domain span — the catch-all
-                    # "Error"/default frame.
+                    # Full INT_MIN..INT_MAX domain — error-cluster catch-all
+                    # (displayed "Error"; a real "Default" comes only from
+                    # SelectDefaultCase, never from a range).
                     default_symbolic_diags.add(diag_idx)
                 continue
-            if (st != 0) != (et != 0):
+            if st != 0 and et != 0:
+                # Nonzero range types but REAL endpoint values (not the sentinel)
+                # — a genuine multi-value range of the selector's own type (e.g.
+                # two adjacent enum members). Keep it as a real range so the type
+                # resolves the endpoints to member names like any other frame.
+                ranges_by_diag[diag_idx] = [SelectorRange(start=s, end=e)]
+                continue
+            if s_fill != e_fill:
                 # One-sided symbolic — a genuine open integer range. Keep
                 # only the literal endpoint's value; the symbolic side is
                 # filler and must never be surfaced.
@@ -276,8 +295,8 @@ def _extract_one_case_structure(
                     SelectorRange(
                         start=s,
                         end=e,
-                        open_start=st != 0,
-                        open_end=et != 0,
+                        open_start=s_fill,
+                        open_end=e_fill,
                     )
                 ]
                 continue

--- a/src/lvkit/parser/nodes/constant.py
+++ b/src/lvkit/parser/nodes/constant.py
@@ -92,6 +92,26 @@ def _extract_caption(dco: ET.Element) -> str | None:
     return caption or None
 
 
+_COLLAPSED_FLAG = 0x10000000  # DDO objFlags bit: "View As Icon" (collapsed)
+
+
+def _extract_collapsed(dco: ET.Element) -> bool:
+    """Whether a cluster/array constant is drawn COLLAPSED (as a compact icon),
+    from its DDO ``objFlags`` bit ``0x10000000``. Verified on DCAF
+    ``Create Test Configuration.vi``: the collapsed 4/5/7-field cluster
+    constants carry ``0x10601024`` (bit set) while the expanded ones (incl. a
+    one-boolean cluster that renders its member fine) carry ``0x00601004`` (bit
+    clear). Only meaningful for a composite (``stdClust``/``indArr``) ddo."""
+    ddo = dco.find("ddo")
+    if ddo is None or ddo.get("class") not in ("stdClust", "indArr"):
+        return False
+    try:
+        flags = int((ddo.findtext("objFlags") or "0").strip())
+    except ValueError:
+        return False
+    return bool(flags & _COLLAPSED_FLAG)
+
+
 def extract_constants(root: ET.Element) -> list[ParsedConstant]:
     """Extract constants from the block diagram.
 
@@ -126,6 +146,7 @@ def extract_constants(root: ET.Element) -> list[ParsedConstant]:
                     value=value_hex,
                     label=label,
                     display_format=_extract_display_format(dco),
+                    collapsed=_extract_collapsed(dco),
                 )
             )
 

--- a/src/lvkit/parser/nodes/constant.py
+++ b/src/lvkit/parser/nodes/constant.py
@@ -96,14 +96,27 @@ _COLLAPSED_FLAG = 0x10000000  # DDO objFlags bit: "View As Icon" (collapsed)
 
 
 def _extract_collapsed(dco: ET.Element) -> bool:
-    """Whether a cluster/array constant is drawn COLLAPSED (as a compact icon),
-    from its DDO ``objFlags`` bit ``0x10000000``. Verified on DCAF
-    ``Create Test Configuration.vi``: the collapsed 4/5/7-field cluster
-    constants carry ``0x10601024`` (bit set) while the expanded ones (incl. a
-    one-boolean cluster that renders its member fine) carry ``0x00601004`` (bit
-    clear). Only meaningful for a composite (``stdClust``/``indArr``) ddo."""
+    """Whether a cluster/array constant is drawn COLLAPSED (View As Icon / the
+    smaller collapsed form) — its display DDO's ``objFlags`` bit ``0x10000000``.
+    Verified on DCAF ``Create Test Configuration.vi``: the collapsed cluster
+    constants carry the bit (``0x10601024`` for the smaller rectangular form,
+    ``0x11600024`` for the square View-As-Icon form) while expanded ones (incl.
+    a one-boolean cluster that renders its member fine) carry ``0x00601004``.
+
+    A TYPEDEF'd cluster/array constant wraps its display DDO in a ``typeDef``
+    ddo whose own flags never carry the bit — the ``stdClust``/``indArr`` nested
+    INSIDE it does, so descend into it first (the outermost nested composite,
+    document order = the cluster itself, not a member sub-cluster)."""
     ddo = dco.find("ddo")
-    if ddo is None or ddo.get("class") not in ("stdClust", "indArr"):
+    if ddo is None:
+        return False
+    if ddo.get("class") == "typeDef":
+        inner = ddo.find(".//SL__arrayElement[@class='stdClust']")
+        if inner is None:
+            inner = ddo.find(".//SL__arrayElement[@class='indArr']")
+        if inner is not None:
+            ddo = inner
+    if ddo.get("class") not in ("stdClust", "indArr"):
         return False
     try:
         flags = int((ddo.findtext("objFlags") or "0").strip())

--- a/src/lvkit/render/__init__.py
+++ b/src/lvkit/render/__init__.py
@@ -113,7 +113,7 @@ _FRAME_CONTROLLER_JS = """(function() {
     var val = t.getAttribute("data-lv-value");
     var action = t.getAttribute("data-lv-action");
     if (val !== null) { state[s] = val; apply(); closeMenus(null); }
-    else if (action === "prev" || action === "next") {
+    else if ((action === "prev" || action === "next") && config[s]) {
       var f = config[s].frames, idx = f.indexOf(state[s]);
       state[s] = f[(idx + (action === "next" ? 1 : f.length - 1)) % f.length];
       apply(); closeMenus(null);
@@ -127,6 +127,54 @@ _FRAME_CONTROLLER_JS = """(function() {
     }
   });
   apply();
+})();"""
+
+
+# Array-constant index controller — the sibling of the frame controller, for
+# array constants (``ArrayConstantGlyph``). Each array carries an ``lv-array``
+# element with its length + per-row height; the ``▲``/``▼`` targets share the
+# ``lv-action`` prev/next + ``lv-struct`` convention the frame controller uses
+# (guarded there by ``config[s]`` so a non-frame array struct is ignored). The
+# index is clamped to the array (``[0, len-1]``) — you can't page before the
+# first element or past the last. Scrolling translates the inner ``lv-array-col``
+# column so the indexed element sits at the top of its clipped viewport (rows
+# past the array end stay greyed) and updates the ``lv-array-index`` readout.
+_ARRAY_CONTROLLER_JS = """(function() {
+  var root = document.getElementById(__ROOT_ID__);
+  if (!root || root.__lvArrInit) return;
+  root.__lvArrInit = true;
+  var cfg = {}, cur = {};
+  var cs = root.querySelectorAll("[data-lv-len]");
+  for (var i = 0; i < cs.length; i++) {
+    var el = cs[i], s = el.getAttribute("data-lv-struct");
+    cfg[s] = { len: parseInt(el.getAttribute("data-lv-len"), 10) || 0,
+               h: parseFloat(el.getAttribute("data-lv-cellh")) || 18 };
+    cur[s] = 0;
+  }
+  function apply(s) {
+    var cols = root.querySelectorAll(".lv-array-col");
+    for (var i = 0; i < cols.length; i++)
+      if (cols[i].getAttribute("data-lv-struct") === s)
+        cols[i].setAttribute("transform", "translate(0 " + (-cur[s] * cfg[s].h) + ")");
+    var labs = root.querySelectorAll(".lv-array-index");
+    for (var j = 0; j < labs.length; j++)
+      if (labs[j].getAttribute("data-lv-struct") === s) {
+        var tx = labs[j].querySelector("text");
+        if (tx) tx.textContent = "" + cur[s];
+      }
+  }
+  root.addEventListener("click", function(e) {
+    var t = e.target;
+    while (t && t !== root && t.getAttribute &&
+           t.getAttribute("data-lv-action") === null) t = t.parentNode;
+    if (!t || t === root || !t.getAttribute) return;
+    var s = t.getAttribute("data-lv-struct"), a = t.getAttribute("data-lv-action");
+    if (!cfg[s]) return;
+    if (a === "prev") cur[s] = Math.max(0, cur[s] - 1);
+    else if (a === "next") cur[s] = Math.min(Math.max(0, cfg[s].len - 1), cur[s] + 1);
+    else return;
+    apply(s);
+  });
 })();"""
 
 
@@ -496,6 +544,7 @@ def _render_scene_svg(
             scripts.append(_FRAME_CONTROLLER_JS)
         if scene.nodes:
             scripts.append(_HOVER_PANEL_JS)
+            scripts.append(_ARRAY_CONTROLLER_JS)
     if scripts:
         root_id = _root_id(vi_name)
         script = "\n".join(scripts).replace("__ROOT_ID__", json.dumps(root_id))

--- a/src/lvkit/render/backend.py
+++ b/src/lvkit/render/backend.py
@@ -111,6 +111,7 @@ class Backend(Protocol):
         stroke: str,
         stroke_width: float,
         fill: str = "none",
+        stroke_dasharray: str | None = None,
     ) -> None: ...
 
     def text(
@@ -278,11 +279,15 @@ class SvgBackend:
         stroke: str,
         stroke_width: float,
         fill: str = "none",
+        stroke_dasharray: str | None = None,
     ) -> None:
         d = "M" + " L".join(f"{x:.1f},{y:.1f}" for x, y in points)
+        dash = f' stroke-dasharray="{stroke_dasharray}"' if stroke_dasharray else ""
+        # miter (sharp) corners: LabVIEW wires bend at right angles — "round"
+        # rounds the corner visibly on a thick (class/array) wire.
         self._elements.append(
             f'<path d="{d}" fill="{fill}" stroke="{stroke}" '
-            f'stroke-width="{stroke_width}" stroke-linejoin="round"/>'
+            f'stroke-width="{stroke_width}" stroke-linejoin="miter"{dash}/>'
         )
 
     def text(

--- a/src/lvkit/render/composite.py
+++ b/src/lvkit/render/composite.py
@@ -123,11 +123,14 @@ def _draw_wire_nets(nets: list[RenderWireNet], backend: Backend, theme: Theme) -
         # selector bytes pick the preset: uniform rows = the CHAIN, otherwise
         # the DIAGONAL (the only two non-solid presets in the corpus).
         pat_color = style.edge_color or style.color
+        core_w = style.core_width or style.width
         for branch in net.branches:
             if style.fill_pattern:
                 if len(set(style.fill_pattern)) > 1:
-                    _draw_wire_diagonal(branch, backend, pat_color, style.width)
+                    # diagonal reads better at the narrower CORE width
+                    _draw_wire_diagonal(branch, backend, pat_color, core_w)
                 else:
+                    # chain rectangles need the full TOTAL width to stay hollow
                     _draw_wire_pattern(branch, backend, pat_color, style.width)
             elif style.edge_color is not None and style.core_width is not None:
                 # Two-band solid class wire: outer edge band, narrower center.

--- a/src/lvkit/render/composite.py
+++ b/src/lvkit/render/composite.py
@@ -50,7 +50,7 @@ from .scene import (
     _is_default_visible,
     encode_frame_path,
 )
-from .style import DEFAULT_THEME, Theme
+from .style import DEFAULT_THEME, Theme, wire_dasharray
 
 
 def _raw(qualified: str | None) -> str | None:
@@ -102,20 +102,90 @@ def _selector_state(rs: RenderStructure, scene: Scene) -> SelectorState:
 def _draw_wire_nets(nets: list[RenderWireNet], backend: Backend, theme: Theme) -> None:
     """One diagram's wires: per-net casing (canvas halo) then colour then
     junctions — so a net's own trunk stays solid while the NEXT net's casing
-    breaks the prior net's colour at an orthogonal crossing."""
+    breaks the prior net's colour at an orthogonal crossing.
+
+    Everything a wire draws — its width, dash, and (for a class) its two-band
+    edge/core border — is read off ``net.style`` (the one WireStyle); a flat wire
+    has no ``edge_color`` and draws as a single stroke."""
     casing = theme.wire_casing
     for net in nets:
+        style = net.style
+        dash = wire_dasharray(style)  # solid for a class pen (line style is solid)
         if casing > 0:
             for branch in net.branches:
                 backend.path(
                     branch,
                     stroke=theme.canvas,
-                    stroke_width=net.style.width + 2 * casing,
+                    stroke_width=style.width + 2 * casing,
                 )
         for branch in net.branches:
-            backend.path(branch, stroke=net.style.color, stroke_width=net.style.width)
+            if style.edge_color is not None and style.core_width is not None:
+                # Two-band class wire: solid outer edge band, then the narrower
+                # center on top.
+                backend.path(branch, stroke=style.edge_color, stroke_width=style.width)
+                if style.fill_pattern:
+                    # The class fill pattern is the actual bitmap tiled along the
+                    # wire in the center color (the "chain"), over the edge band.
+                    _draw_wire_pattern(
+                        branch, backend, style.fill_pattern, style.color, style.width
+                    )
+                else:
+                    backend.path(
+                        branch, stroke=style.color, stroke_width=style.core_width
+                    )
+            elif style.fill_pattern:
+                _draw_wire_pattern(
+                    branch, backend, style.fill_pattern, style.color, style.width
+                )
+            else:
+                backend.path(
+                    branch,
+                    stroke=style.color,
+                    stroke_width=style.width,
+                    stroke_dasharray=dash,
+                )
         for jx, jy in net.junctions:
-            backend.circle(jx, jy, 3.0, fill=net.style.color)
+            backend.circle(jx, jy, 3.0, fill=style.color)
+
+
+def _draw_wire_pattern(
+    branch: list[Point],
+    backend: Backend,
+    rows: tuple[int, ...],
+    color: str,
+    width: float,
+) -> None:
+    """Draw the class wire's actual fill-pattern bitmap tiled along the wire — the
+    real texture (chain/dash/bars) from the ``.lvclass`` bitmap, in the pen color,
+    NOT an approximated dash. The 8-row bitmap is scaled to the wire's ``width``
+    (each row a ``width/8`` band, each column a ``width/8`` step along the length)
+    and tiled along each axis-aligned segment, oriented per horizontal/vertical
+    run — a set bit is a filled cell, a clear bit lets the edge band show
+    through."""
+    n = len(rows)
+    if n == 0:
+        return
+    cell = width / n
+    for (x0, y0), (x1, y1) in zip(branch, branch[1:], strict=False):
+        horizontal = abs(x1 - x0) >= abs(y1 - y0)
+        a0, a1 = (x0, x1) if horizontal else (y0, y1)
+        lo, hi = min(a0, a1), max(a0, a1)
+        cross = (y0 + y1) / 2 if horizontal else (x0 + x1) / 2
+        t = lo
+        while t < hi:
+            for r, byte in enumerate(rows):
+                for c in range(8):
+                    if not (byte >> (7 - c)) & 1:
+                        continue
+                    along = t + c * cell
+                    if along >= hi:
+                        continue
+                    perp = cross - width / 2 + r * cell
+                    bx, by = (along, perp) if horizontal else (perp, along)
+                    backend.rect(
+                        bx, by, bx + cell, by + cell, fill=color, stroke="none"
+                    )
+            t += 8 * cell
 
 
 class RenderObject(ABC):

--- a/src/lvkit/render/composite.py
+++ b/src/lvkit/render/composite.py
@@ -144,7 +144,7 @@ def _draw_wire_nets(nets: list[RenderWireNet], backend: Backend, theme: Theme) -
             backend.circle(jx, jy, 3.0, fill=style.color)
 
 
-# A class "chain" wire: hollow rounded-rectangle LINK, short LINE connector, link,
+# A class "chain" wire: hollow hard-corner rectangle LINK, short LINE connector, link,
 # line, … repeated along the wire (as seen in every LabVIEW class-wire example).
 _LINK_LEN = 6.0  # length of one hollow link along the wire
 _LINK_CONN = 3.0  # length of the solid connector line between links
@@ -156,7 +156,7 @@ def _draw_wire_pattern(
     color: str,
     width: float,
 ) -> None:
-    """Draw a patterned class wire as a CHAIN: a hollow rounded-rectangle link,
+    """Draw a patterned class wire as a CHAIN: a hollow hard-corner rectangle link,
     then a short solid connector line, then a link, then a line — repeated along
     each axis-aligned segment and oriented with it (horizontal links on a
     horizontal run, vertical on a vertical run), in the pen color. This is
@@ -177,12 +177,12 @@ def _draw_wire_pattern(
             if horizontal:
                 backend.rect(
                     t, cross - half, end, cross + half,
-                    fill="none", stroke=color, stroke_width=lw, rx=half,
+                    fill="none", stroke=color, stroke_width=lw,
                 )
             else:
                 backend.rect(
                     cross - half, t, cross + half, end,
-                    fill="none", stroke=color, stroke_width=lw, rx=half,
+                    fill="none", stroke=color, stroke_width=lw,
                 )
             # connector line to the next link
             c0, c1 = end, min(end + _LINK_CONN, hi)

--- a/src/lvkit/render/composite.py
+++ b/src/lvkit/render/composite.py
@@ -118,25 +118,16 @@ def _draw_wire_nets(nets: list[RenderWireNet], backend: Backend, theme: Theme) -
                     stroke=theme.canvas,
                     stroke_width=style.width + 2 * casing,
                 )
+        # A patterned class pen draws as a CHAIN (hollow links + connectors) in
+        # the edge foreground — one pattern for the whole wire, not a solid band.
+        chain_color = style.edge_color or style.color
         for branch in net.branches:
-            if style.edge_color is not None and style.core_width is not None:
-                # Two-band class wire: solid outer edge band, then the narrower
-                # center on top.
+            if style.fill_pattern:
+                _draw_wire_pattern(branch, backend, chain_color, style.width)
+            elif style.edge_color is not None and style.core_width is not None:
+                # Two-band solid class wire: outer edge band, narrower center.
                 backend.path(branch, stroke=style.edge_color, stroke_width=style.width)
-                if style.fill_pattern:
-                    # The class fill pattern is the actual bitmap tiled along the
-                    # wire in the center color (the "chain"), over the edge band.
-                    _draw_wire_pattern(
-                        branch, backend, style.fill_pattern, style.color, style.width
-                    )
-                else:
-                    backend.path(
-                        branch, stroke=style.color, stroke_width=style.core_width
-                    )
-            elif style.fill_pattern:
-                _draw_wire_pattern(
-                    branch, backend, style.fill_pattern, style.color, style.width
-                )
+                backend.path(branch, stroke=style.color, stroke_width=style.core_width)
             else:
                 backend.path(
                     branch,
@@ -148,24 +139,28 @@ def _draw_wire_nets(nets: list[RenderWireNet], backend: Backend, theme: Theme) -
             backend.circle(jx, jy, 3.0, fill=style.color)
 
 
+# A class "chain" wire: hollow rounded-rectangle LINK, short LINE connector, link,
+# line, … repeated along the wire (as seen in every LabVIEW class-wire example).
+_LINK_LEN = 6.0  # length of one hollow link along the wire
+_LINK_CONN = 3.0  # length of the solid connector line between links
+
+
 def _draw_wire_pattern(
     branch: list[Point],
     backend: Backend,
-    rows: tuple[int, ...],
     color: str,
     width: float,
 ) -> None:
-    """Draw the class wire's actual fill-pattern bitmap tiled along the wire — the
-    real texture (chain/dash/bars) from the ``.lvclass`` bitmap, in the pen color,
-    NOT an approximated dash. The 8-row bitmap is scaled to the wire's ``width``
-    (each row a ``width/8`` band, each column a ``width/8`` step along the length)
-    and tiled along each axis-aligned segment, oriented per horizontal/vertical
-    run — a set bit is a filled cell, a clear bit lets the edge band show
-    through."""
-    n = len(rows)
-    if n == 0:
-        return
-    cell = width / n
+    """Draw a patterned class wire as a CHAIN: a hollow rounded-rectangle link,
+    then a short solid connector line, then a link, then a line — repeated along
+    each axis-aligned segment and oriented with it (horizontal links on a
+    horizontal run, vertical on a vertical run), in the pen color. This is
+    LabVIEW's chain wire look; a class whose pen carries a non-solid fill pattern
+    draws its wire this way rather than solid."""
+    lw = max(1.0, width * 0.4)  # link outline weight
+    conn_w = max(1.0, width * 0.5)  # connector line weight
+    half = width / 2
+    step = _LINK_LEN + _LINK_CONN
     for (x0, y0), (x1, y1) in zip(branch, branch[1:], strict=False):
         horizontal = abs(x1 - x0) >= abs(y1 - y0)
         a0, a1 = (x0, x1) if horizontal else (y0, y1)
@@ -173,19 +168,25 @@ def _draw_wire_pattern(
         cross = (y0 + y1) / 2 if horizontal else (x0 + x1) / 2
         t = lo
         while t < hi:
-            for r, byte in enumerate(rows):
-                for c in range(8):
-                    if not (byte >> (7 - c)) & 1:
-                        continue
-                    along = t + c * cell
-                    if along >= hi:
-                        continue
-                    perp = cross - width / 2 + r * cell
-                    bx, by = (along, perp) if horizontal else (perp, along)
-                    backend.rect(
-                        bx, by, bx + cell, by + cell, fill=color, stroke="none"
-                    )
-            t += 8 * cell
+            end = min(t + _LINK_LEN, hi)
+            if horizontal:
+                backend.rect(
+                    t, cross - half, end, cross + half,
+                    fill="none", stroke=color, stroke_width=lw, rx=half,
+                )
+            else:
+                backend.rect(
+                    cross - half, t, cross + half, end,
+                    fill="none", stroke=color, stroke_width=lw, rx=half,
+                )
+            # connector line to the next link
+            c0, c1 = end, min(end + _LINK_CONN, hi)
+            if c1 > c0:
+                lx0, ly0, lx1, ly1 = (
+                    (c0, cross, c1, cross) if horizontal else (cross, c0, cross, c1)
+                )
+                backend.line(lx0, ly0, lx1, ly1, stroke=color, stroke_width=conn_w)
+            t += step
 
 
 class RenderObject(ABC):

--- a/src/lvkit/render/composite.py
+++ b/src/lvkit/render/composite.py
@@ -118,12 +118,17 @@ def _draw_wire_nets(nets: list[RenderWireNet], backend: Backend, theme: Theme) -
                     stroke=theme.canvas,
                     stroke_width=style.width + 2 * casing,
                 )
-        # A patterned class pen draws as a CHAIN (hollow links + connectors) in
-        # the edge foreground — one pattern for the whole wire, not a solid band.
-        chain_color = style.edge_color or style.color
+        # A patterned class pen draws in the edge foreground as its selected
+        # SVG preset — one pattern for the whole wire, not a solid band. The
+        # selector bytes pick the preset: uniform rows = the CHAIN, otherwise
+        # the DIAGONAL (the only two non-solid presets in the corpus).
+        pat_color = style.edge_color or style.color
         for branch in net.branches:
             if style.fill_pattern:
-                _draw_wire_pattern(branch, backend, chain_color, style.width)
+                if len(set(style.fill_pattern)) > 1:
+                    _draw_wire_diagonal(branch, backend, pat_color, style.width)
+                else:
+                    _draw_wire_pattern(branch, backend, pat_color, style.width)
             elif style.edge_color is not None and style.core_width is not None:
                 # Two-band solid class wire: outer edge band, narrower center.
                 backend.path(branch, stroke=style.edge_color, stroke_width=style.width)
@@ -187,6 +192,38 @@ def _draw_wire_pattern(
                 )
                 backend.line(lx0, ly0, lx1, ly1, stroke=color, stroke_width=conn_w)
             t += step
+
+
+_DIAG_STEP = 3.0  # spacing between diagonal strokes along the wire
+
+
+def _draw_wire_diagonal(
+    branch: list[Point], backend: Backend, color: str, width: float
+) -> None:
+    """Draw a patterned class wire as the DIAGONAL preset — short parallel
+    diagonal strokes across the wire, repeated along each axis-aligned segment
+    (oriented per run), in the pen color."""
+    lw = max(1.0, width * 0.35)
+    half = width / 2
+    for (x0, y0), (x1, y1) in zip(branch, branch[1:], strict=False):
+        horizontal = abs(x1 - x0) >= abs(y1 - y0)
+        a0, a1 = (x0, x1) if horizontal else (y0, y1)
+        lo, hi = min(a0, a1), max(a0, a1)
+        cross = (y0 + y1) / 2 if horizontal else (x0 + x1) / 2
+        t = lo
+        while t + width <= hi:
+            # a "\" stroke spanning the wire width over one step of length
+            if horizontal:
+                backend.line(
+                    t, cross - half, t + width, cross + half,
+                    stroke=color, stroke_width=lw,
+                )
+            else:
+                backend.line(
+                    cross - half, t, cross + half, t + width,
+                    stroke=color, stroke_width=lw,
+                )
+            t += _DIAG_STEP
 
 
 class RenderObject(ABC):

--- a/src/lvkit/render/draw.py
+++ b/src/lvkit/render/draw.py
@@ -474,9 +474,16 @@ def _node_doc_url(node: AnyGraphNode) -> str | None:
 
 def _terminal_label(t: Terminal) -> str:
     """A terminal's display label: the resolved def name (``display_name``,
-    e.g. "x"/"difference"), else a caller-side ``name`` if any, else
-    ``terminal N`` from its connector-pane index."""
-    return _terminal_display_name(t) or f"terminal {t.index}"
+    e.g. "x"/"difference"), else a caller-side ``name`` if any, else — for a
+    Bundle/Unbundle aggregate terminal — "input cluster"/"output cluster"
+    (LabVIEW's own names for the whole-cluster port), else ``terminal N`` from
+    its connector-pane index."""
+    name = _terminal_display_name(t)
+    if name:
+        return name
+    if getattr(t, "nmux_role", None) == "agg":
+        return "output cluster" if t.direction == "output" else "input cluster"
+    return f"terminal {t.index}"
 
 
 def _terminal_is_informative(t: Terminal) -> bool:

--- a/src/lvkit/render/draw.py
+++ b/src/lvkit/render/draw.py
@@ -1193,7 +1193,10 @@ def draw_fp_terminal(
     # type its wire color.
     style = wire_style(scalar_type, theme)
     color = style.edge_color or style.color
-    stroke_width = 1.5 if terminal.is_indicator else 3.0
+    # A control's box border is a touch heavier than an indicator's, but NOT bold
+    # — the wire-port arrow already carries the direction, so a heavy control
+    # outline just adds noise (and fights the type label).
+    stroke_width = 1.5 if terminal.is_indicator else 2.0
 
     backend.rect(
         x1, y1, x2, y2, fill=theme.fp_panel, stroke=color, stroke_width=stroke_width

--- a/src/lvkit/render/draw.py
+++ b/src/lvkit/render/draw.py
@@ -1188,7 +1188,11 @@ def draw_fp_terminal(
     lv_type = terminal.lv_type
     is_array = lv_type is not None and lv_type.kind == LVTypeKind.ARRAY
     scalar_type = lv_type.element_type if lv_type is not None and is_array else lv_type
-    color = wire_style(scalar_type, theme).color
+    # Box border from the one wire lookup: a class terminal takes its edge-band
+    # color (LabVIEW borders the class terminal with the edge pen), any other
+    # type its wire color.
+    style = wire_style(scalar_type, theme)
+    color = style.edge_color or style.color
     stroke_width = 1.5 if terminal.is_indicator else 3.0
 
     backend.rect(

--- a/src/lvkit/render/draw.py
+++ b/src/lvkit/render/draw.py
@@ -506,7 +506,11 @@ def _terminal_help_lines(node: AnyGraphNode) -> list[str]:
 
     def fmt(t: Terminal) -> str:
         ty = lv_type_label(t.lv_type)
-        return f"  {_terminal_label(t)}: {ty}"
+        # A nested Bundle/Unbundle-By-Name field shows its FULL dotted path here
+        # (the tooltip never truncates), while the glyph row + connector panel
+        # keep the terse leaf ``display_name``.
+        label = t.field_path or _terminal_label(t)
+        return f"  {label}: {ty}"
 
     ins = sorted((t for t in terms if t.direction == "input"), key=lambda t: t.index)
     outs = sorted((t for t in terms if t.direction == "output"), key=lambda t: t.index)

--- a/src/lvkit/render/draw.py
+++ b/src/lvkit/render/draw.py
@@ -190,6 +190,37 @@ def _draw_formula_tunnel(
         )
 
 
+def _draw_bundle_by_name(
+    node: RenderNode,
+    bounds: tuple[float, float, float, float],
+    backend: Backend,
+    theme: Theme,
+) -> None:
+    """Draw a Bundle/Unbundle By Name, sizing its cluster column from the
+    aggregate terminals' REAL heap ``termBounds`` — their union: the interior
+    input column plus the output box for a Bundle, the single box for an
+    Unbundle (see ``scene._reposition_mux_terminals``). So the drawn columns line
+    up with where the aggregate wires actually anchor, never an invented width."""
+    glyph = node.glyph
+    if not isinstance(glyph, BundleByNameGlyph):
+        return
+    agg = [
+        rt.bounds
+        for rt in node.terminals
+        if rt.terminal.nmux_role == "agg" and rt.bounds is not None
+    ]
+    if agg:
+        glyph.draw(
+            backend,
+            bounds,
+            theme,
+            agg_x1=min(b[0] for b in agg),
+            agg_x2=max(b[2] for b in agg),
+        )
+    else:
+        glyph.draw(backend, bounds, theme)
+
+
 # A primitive whose glyph is drawn as one of these keeps its own aspect ratio
 # (a real extracted raster icon or a declared/procedural SVG designed for a
 # fixed shape), or is a cluster-mux drawer whose heap ``bounds`` IS its true
@@ -334,6 +365,12 @@ def draw_node(node: RenderNode, backend: Backend, theme: Theme = DEFAULT_THEME) 
         # tunnels together (the script inset depends on the tunnel column
         # widths), so it takes the whole draw rather than the generic glyph.
         _draw_formula_node(node, bounds, backend, theme)
+    elif isinstance(node.glyph, BundleByNameGlyph):
+        # The Bundle/Unbundle glyph sizes its cluster column from the aggregate
+        # terminal's REAL heap rect (never an invented width), so its drawn
+        # column lines up with the aggregate wire's own anchor.
+        _draw_bundle_by_name(node, bounds, backend, theme)
+        _draw_invert_bubbles(node, backend, theme)
     else:
         node.glyph.draw(backend, bounds, theme)
         _draw_invert_bubbles(node, backend, theme)

--- a/src/lvkit/render/glyph.py
+++ b/src/lvkit/render/glyph.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from .glyphs.nodes.arith import ArithGlyph
 from .glyphs.nodes.array_build import ArrayBuildGlyph
+from .glyphs.nodes.array_constant import ArrayConstantGlyph
 from .glyphs.nodes.array_reverse import ArrayReverseGlyph
 from .glyphs.nodes.array_search import ArraySearchGlyph
 from .glyphs.nodes.array_size import ArraySizeGlyph
@@ -75,6 +76,7 @@ __all__ = [
     "BundleByNameGlyph",
     "BundleGlyph",
     "CenteredSvgGlyph",
+    "ArrayConstantGlyph",
     "ClusterConstantGlyph",
     "CompoundArithGlyph",
     "ConstantGlyph",

--- a/src/lvkit/render/glyphs/nodes/array_constant.py
+++ b/src/lvkit/render/glyphs/nodes/array_constant.py
@@ -126,10 +126,10 @@ class ArrayConstantGlyph:
         )
         arrow_w = 8.0
         mid = (iy1 + iy2) / 2
-        # ▲ = previous (index - 1), ▼ = next (index + 1).
+        # ▲ (top) = index UP / next (index + 1); ▼ (bottom) = index down / prev.
         backend.begin_group(
             cls="lv-selector lv-clickable",
-            data={"lv-action": "prev", "lv-struct": self.struct_uid},
+            data={"lv-action": "next", "lv-struct": self.struct_uid},
         )
         backend.rect(ix1, iy1, ix1 + arrow_w, mid, fill="transparent", stroke="none")
         backend.polygon(
@@ -143,7 +143,7 @@ class ArrayConstantGlyph:
         backend.end_group()
         backend.begin_group(
             cls="lv-selector lv-clickable",
-            data={"lv-action": "next", "lv-struct": self.struct_uid},
+            data={"lv-action": "prev", "lv-struct": self.struct_uid},
         )
         backend.rect(ix1, mid, ix1 + arrow_w, iy2, fill="transparent", stroke="none")
         backend.polygon(

--- a/src/lvkit/render/glyphs/nodes/array_constant.py
+++ b/src/lvkit/render/glyphs/nodes/array_constant.py
@@ -1,0 +1,172 @@
+"""``ArrayConstantGlyph`` — a LabVIEW array constant.
+
+LabVIEW draws an array constant as a per-dimension INDEX control on the left
+(``▲``/``▼`` to change the index) plus a scrolling column of ELEMENT cells: the
+INDEXED element sits at the top and a whole number of further rows fill the
+bounding box. Elements past the array's end are greyed (unset). The index is
+clamped to the array — you can't page before element 0 or past the last.
+
+The glyph stays PURE (scales to the given ``bounds`` — the constant's real heap
+box). The index is INTERACTIVE in the viewer: the ``lv-array`` carrier + the
+``lv-array-col`` translatable column are read by the array controller JS (a
+sibling of the case/sequence frame controller), which scrolls the column and
+updates the index readout on ``▲``/``▼``. With no JS the glyph shows index 0.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ....parser.layout import Rect
+from ...backend import Backend
+from ...style import Theme
+from .base import Glyph, fit_label
+
+# One element row + the index box — LabVIEW's element-cell height. The box is the
+# real developer-sized heap bounds, so the visible-row count falls out as
+# ``floor(viewport_height / _CELL_H)`` — a whole number of elements, as LabVIEW
+# always shows.
+_CELL_H = 18.0
+_INDEX_W = 22.0  # width of the index-control column (left of the elements)
+_INDEX_H = 16.0  # height of one dimension's index box
+_PAD = 2.0
+
+
+@dataclass(frozen=True)
+class ArrayConstantGlyph:
+    """An array constant: an index control (one box per dimension) + a clipped,
+    scrollable column of the element values' own glyphs. ``elements`` is one
+    composed glyph per array value (built by the resolver from the element
+    type), so an array of clusters composes each cluster into its cell."""
+
+    elements: tuple[Glyph, ...]
+    element_color: str
+    struct_uid: str
+    dimensions: int = 1
+
+    def draw(self, backend: Backend, bounds: Rect, theme: Theme) -> None:
+        x1, y1, x2, y2 = bounds
+        backend.rect(
+            x1, y1, x2, y2,
+            fill=theme.const_fill,
+            stroke=self.element_color,
+            stroke_width=1.0,
+        )
+        n_idx = max(1, self.dimensions)
+        idx_right = x1 + _INDEX_W
+        for d in range(n_idx):
+            iy1 = y1 + _PAD + d * (_INDEX_H + 1.0)
+            iy2 = min(iy1 + _INDEX_H, y2 - _PAD)
+            if iy2 - iy1 < 6.0:
+                break
+            self._draw_index_box(
+                backend, (x1 + _PAD, iy1, idx_right - _PAD, iy2), theme
+            )
+
+        # Element viewport, to the right of the index column.
+        vx1, vy1, vx2, vy2 = idx_right, y1 + _PAD, x2 - _PAD, y2 - _PAD
+        if vx2 - vx1 < 6.0 or vy2 - vy1 < 6.0:
+            return
+        visible = max(1, int((vy2 - vy1) // _CELL_H))
+        total = len(self.elements)
+
+        # A FIXED clip viewport (outer group) holding a TRANSLATABLE column
+        # (inner ``lv-array-col``): every element cell at its natural row, plus
+        # up to ``visible - 1`` greyed past-end rows so scrolling near the end
+        # reveals the "unset" cells. The controller JS translates the inner group
+        # by ``-index * _CELL_H`` so element[index] lands at the viewport top
+        # (the clip must stay on the OUTER group, or it would scroll too). With
+        # no JS it shows rows [0, visible).
+        backend.begin_group(clip=(vx1, vy1, vx2, vy2))
+        backend.begin_group(
+            cls="lv-array-col",
+            data={"lv-struct": self.struct_uid},
+        )
+        for i in range(total + max(0, visible - 1)):
+            cy1 = vy1 + i * _CELL_H
+            cy2 = cy1 + _CELL_H
+            cell = (vx1 + 1.0, cy1 + 1.0, vx2 - 1.0, cy2 - 1.0)
+            if i < total:
+                self.elements[i].draw(backend, cell, theme)
+            else:
+                # Past the array end: a greyed, disabled cell.
+                backend.rect(*cell, fill=theme.fp_panel, stroke="none")
+            if i + 1 < total + max(0, visible - 1):
+                backend.line(
+                    vx1, cy2, vx2, cy2, stroke=theme.struct_border, stroke_width=0.4
+                )
+        backend.end_group()  # lv-array-col (translatable)
+        backend.end_group()  # clip viewport (fixed)
+
+        # The carrier the array controller reads: array length, visible-row
+        # count, and the per-row height it scrolls by.
+        backend.begin_group(
+            cls="lv-array",
+            data={
+                "lv-struct": self.struct_uid,
+                "lv-len": str(total),
+                "lv-visible": str(visible),
+                "lv-cellh": str(_CELL_H),
+            },
+        )
+        backend.end_group()
+
+    def _draw_index_box(
+        self, backend: Backend, box: Rect, theme: Theme
+    ) -> None:
+        """One dimension's index control: a box with ``▲``/``▼`` decrement /
+        increment click targets on the left and the current index readout on the
+        right (updated live by the controller; ``0`` with no JS)."""
+        ix1, iy1, ix2, iy2 = box
+        backend.rect(
+            ix1, iy1, ix2, iy2,
+            fill=theme.case_bar_fill,
+            stroke=theme.struct_border,
+            stroke_width=0.75,
+        )
+        arrow_w = 8.0
+        mid = (iy1 + iy2) / 2
+        # ▲ = previous (index - 1), ▼ = next (index + 1).
+        backend.begin_group(
+            cls="lv-selector lv-clickable",
+            data={"lv-action": "prev", "lv-struct": self.struct_uid},
+        )
+        backend.rect(ix1, iy1, ix1 + arrow_w, mid, fill="transparent", stroke="none")
+        backend.polygon(
+            [
+                (ix1 + arrow_w / 2, iy1 + 2.5),
+                (ix1 + 1.5, mid - 1.5),
+                (ix1 + arrow_w - 1.5, mid - 1.5),
+            ],
+            fill=theme.case_bar_text,
+        )
+        backend.end_group()
+        backend.begin_group(
+            cls="lv-selector lv-clickable",
+            data={"lv-action": "next", "lv-struct": self.struct_uid},
+        )
+        backend.rect(ix1, mid, ix1 + arrow_w, iy2, fill="transparent", stroke="none")
+        backend.polygon(
+            [
+                (ix1 + 1.5, mid + 1.5),
+                (ix1 + arrow_w - 1.5, mid + 1.5),
+                (ix1 + arrow_w / 2, iy2 - 2.5),
+            ],
+            fill=theme.case_bar_text,
+        )
+        backend.end_group()
+        # The live index readout (JS sets textContent; 0 by default).
+        size = min(9.0, (iy2 - iy1) * 0.7)
+        label = fit_label("0", (ix2 - (ix1 + arrow_w)) - 2.0, backend, size)
+        backend.begin_group(
+            cls="lv-array-index",
+            data={"lv-struct": self.struct_uid},
+        )
+        backend.text(
+            (ix1 + arrow_w + ix2) / 2,
+            mid + size * 0.34,
+            label,
+            size,
+            fill=theme.case_bar_text,
+        )
+        backend.end_group()

--- a/src/lvkit/render/glyphs/nodes/bundle_by_name.py
+++ b/src/lvkit/render/glyphs/nodes/bundle_by_name.py
@@ -5,19 +5,22 @@ from dataclasses import dataclass
 from ....parser.layout import Rect
 from ...backend import Backend
 from ...style import Theme
-from .base import _CLUSTER_ARROW, draw_split_box
+from .base import fit_label
+
+# Width of the cluster (aggregate) column — the narrow column holding the
+# direction arrow, on the RIGHT for Bundle, LEFT for Unbundle.
+_CLUSTER_COL_W = 13.0
 
 
 @dataclass(frozen=True)
 class BundleByNameGlyph:
-    """Bundle / Unbundle By Name (heap class ``nMux``): a box with one row per
-    accessed field, each row LABELED with the field's NAME. Unlike the compact
-    positional Bundle/Unbundle (``BundleGlyph``/``UnbundleGlyph``, terminals
-    only), By Name shows the names — resolved from the wired cluster's type by
-    the resolver. The small cluster (refnum) terminal is drawn separately at the
-    node's corner; the named rows fill the box, one per ``list`` terminal in
-    top-to-bottom order. Scales to the node's heap bounds (names left-aligned,
-    truncated to fit)."""
+    """Bundle / Unbundle By Name (heap class ``nMux``): a stack of bordered
+    field-NAME cells beside a narrow CLUSTER column that carries the direction
+    arrow. For Bundle the cluster column is on the RIGHT (the aggregate exits
+    there, its "input cluster" attaching at the column top — see
+    ``scene._bundle_agg_centers``); for Unbundle it is on the LEFT. Each field's
+    name fills one cell, top-to-bottom in ``list``-terminal order. Scales to the
+    node's heap bounds (names left-aligned, truncated to fit)."""
 
     names: tuple[str, ...]
     bundling: bool = True  # True: Bundle By Name; False: Unbundle By Name
@@ -26,24 +29,58 @@ class BundleByNameGlyph:
     text_attr: str = "prim_text"
 
     def draw(self, backend: Backend, bounds: Rect, theme: Theme) -> None:
-        # Same skeleton as positional Bundle/Unbundle: a narrow cluster-direction
-        # arrow cell (RIGHT when bundling, LEFT when unbundling) plus one row per
-        # field — here the rows are LABELED with the field names. The arrow cell
-        # is kept thin (~one row tall) since By-Name boxes grow with field count.
         x1, y1, x2, y2 = bounds
         rows = self.names or ("",)
         n = len(rows)
-        arrow_w = min((x2 - x1) * 0.33, max(10.0, (y2 - y1) / n))
-        draw_split_box(
-            backend,
-            bounds,
-            theme,
-            symbol=_CLUSTER_ARROW,
-            num_cells=n,
-            symbol_side="right" if self.bundling else "left",
-            fill_attr=self.fill_attr,
-            stroke_attr=self.stroke_attr,
-            text_attr=self.text_attr,
-            cell_labels=rows,
-            sym_w=arrow_w,
+        fill = getattr(theme, self.fill_attr)
+        stroke = getattr(theme, self.stroke_attr)
+        text = getattr(theme, self.text_attr)
+
+        col_w = min(_CLUSTER_COL_W, (x2 - x1) * 0.4)
+        if self.bundling:  # cluster column on the RIGHT
+            cell_x1, cell_x2 = x1, x2 - col_w
+            col_x1, col_x2 = x2 - col_w, x2
+            points_right = True
+        else:  # Unbundle: cluster column on the LEFT
+            col_x1, col_x2 = x1, x1 + col_w
+            cell_x1, cell_x2 = x1 + col_w, x2
+            points_right = False
+
+        # Field-name cells: one bordered box per field, stacked.
+        row_h = (y2 - y1) / n
+        lsize = max(6.0, min(9.0, row_h * 0.62))
+        for i, name in enumerate(rows):
+            ry1 = y1 + i * row_h
+            ry2 = ry1 + row_h
+            backend.rect(
+                cell_x1, ry1, cell_x2, ry2, fill=fill, stroke=stroke, stroke_width=1.0
+            )
+            label = fit_label(name, (cell_x2 - cell_x1) - 4.0, backend, lsize)
+            backend.text(
+                cell_x1 + 2.0,
+                (ry1 + ry2) / 2 + lsize * 0.34,
+                label,
+                lsize,
+                anchor="start",
+                fill=text,
+            )
+
+        # Cluster column + the direction arrow (a filled triangle) at mid — the
+        # aggregate OUTPUT sits at mid; the INPUT attaches at the column top.
+        backend.rect(
+            col_x1, y1, col_x2, y2, fill=fill, stroke=stroke, stroke_width=1.0
+        )
+        mid_y = (y1 + y2) / 2
+        acx = (col_x1 + col_x2) / 2
+        aw = (col_x2 - col_x1) * 0.62
+        ah = min(row_h * 0.5, 5.0)
+        back_x = acx - aw / 2 if points_right else acx + aw / 2
+        tip_x = acx + aw / 2 if points_right else acx - aw / 2
+        backend.polygon(
+            [
+                (back_x, mid_y - ah),
+                (tip_x, mid_y),
+                (back_x, mid_y + ah),
+            ],
+            fill=text,
         )

--- a/src/lvkit/render/glyphs/nodes/bundle_by_name.py
+++ b/src/lvkit/render/glyphs/nodes/bundle_by_name.py
@@ -7,20 +7,51 @@ from ...backend import Backend
 from ...style import Theme
 from .base import fit_label
 
-# Width of the cluster (aggregate) column — the narrow column holding the
-# direction arrow, on the RIGHT for Bundle, LEFT for Unbundle.
-_CLUSTER_COL_W = 13.0
+# Fallback width for the cluster (aggregate) column when the node carries no
+# real aggregate ``termBounds`` to size it from — otherwise the column spans the
+# terminal's actual heap rect (see ``draw._draw_bundle_by_name``).
+_CLUSTER_COL_W = 8.0
+
+
+def _draw_bundle_arrow(
+    backend: Backend,
+    x1: float,
+    x2: float,
+    y1: float,
+    y2: float,
+    color: str,
+) -> None:
+    """A small RIGHTWARD arrow (a shaft plus a filled triangular head) centered
+    in the aggregate's cluster column. Both Bundle and Unbundle point right —
+    data assembles/extracts left-to-right. The shaft is what distinguishes it
+    from a bare triangle (which reads as a media "play" button); scaled to the
+    narrow column it stays a small, clean arrow."""
+    cy = (y1 + y2) / 2
+    acx = (x1 + x2) / 2
+    aw = (x2 - x1) * 0.72  # arrow spans most of the column width
+    ax1, ax2 = acx - aw / 2, acx + aw / 2
+    head = aw * 0.6  # 40% shaft, 60% triangular head
+    hh = head * 0.75  # head half-height (full head height = 2*hh)
+    sw = hh  # shaft thickness tracks the head height
+    backend.line(ax1, cy, ax2 - head, cy, stroke=color, stroke_width=sw)
+    backend.polygon(
+        [(ax2 - head, cy - hh), (ax2, cy), (ax2 - head, cy + hh)],
+        fill=color,
+    )
 
 
 @dataclass(frozen=True)
 class BundleByNameGlyph:
     """Bundle / Unbundle By Name (heap class ``nMux``): a stack of bordered
-    field-NAME cells beside a narrow CLUSTER column that carries the direction
-    arrow. For Bundle the cluster column is on the RIGHT (the aggregate exits
-    there, its "input cluster" attaching at the column top — see
-    ``scene._bundle_agg_centers``); for Unbundle it is on the LEFT. Each field's
-    name fills one cell, top-to-bottom in ``list``-terminal order. Scales to the
-    node's heap bounds (names left-aligned, truncated to fit)."""
+    field-NAME cells beside the aggregate CLUSTER column. For Bundle the cluster
+    column is on the RIGHT — drawn as two equal columns matching LabVIEW's
+    connector pane: the INTERIOR (left) takes the input source cluster (entering
+    at the top), the EDGE (right) the assembled output cluster (exiting the
+    right). For Unbundle the single cluster column is on the LEFT. Name cells
+    are filled with the
+    diagram background (they read as data cells, like LabVIEW), the cluster
+    column with the aggregate fill. Each field's name fills one cell,
+    top-to-bottom in ``list``-terminal order; scales to the node's heap bounds."""
 
     names: tuple[str, ...]
     bundling: bool = True  # True: Bundle By Name; False: Unbundle By Name
@@ -28,23 +59,39 @@ class BundleByNameGlyph:
     stroke_attr: str = "prim_stroke"
     text_attr: str = "prim_text"
 
-    def draw(self, backend: Backend, bounds: Rect, theme: Theme) -> None:
+    def draw(
+        self,
+        backend: Backend,
+        bounds: Rect,
+        theme: Theme,
+        *,
+        agg_x1: float | None = None,
+        agg_x2: float | None = None,
+    ) -> None:
         x1, y1, x2, y2 = bounds
         rows = self.names or ("",)
         n = len(rows)
-        fill = getattr(theme, self.fill_attr)
+        col_fill = getattr(theme, self.fill_attr)
         stroke = getattr(theme, self.stroke_attr)
         text = getattr(theme, self.text_attr)
+        # Name cells read as data: the diagram background, not the node fill.
+        cell_fill = theme.canvas
 
-        col_w = min(_CLUSTER_COL_W, (x2 - x1) * 0.4)
+        # Aggregate column spans the terminal's real heap rect when the caller
+        # supplies it; otherwise fall back to a fixed sliver on the right/left.
+        if agg_x1 is not None and agg_x2 is not None and agg_x2 > agg_x1:
+            col_x1, col_x2 = agg_x1, agg_x2
+        elif self.bundling:
+            w = min(_CLUSTER_COL_W, (x2 - x1) * 0.2)
+            col_x1, col_x2 = x2 - w, x2
+        else:
+            w = min(_CLUSTER_COL_W, (x2 - x1) * 0.2)
+            col_x1, col_x2 = x1, x1 + w
+
         if self.bundling:  # cluster column on the RIGHT
-            cell_x1, cell_x2 = x1, x2 - col_w
-            col_x1, col_x2 = x2 - col_w, x2
-            points_right = True
+            cell_x1, cell_x2 = x1, col_x1
         else:  # Unbundle: cluster column on the LEFT
-            col_x1, col_x2 = x1, x1 + col_w
-            cell_x1, cell_x2 = x1 + col_w, x2
-            points_right = False
+            cell_x1, cell_x2 = col_x2, x2
 
         # Field-name cells: one bordered box per field, stacked.
         row_h = (y2 - y1) / n
@@ -53,7 +100,8 @@ class BundleByNameGlyph:
             ry1 = y1 + i * row_h
             ry2 = ry1 + row_h
             backend.rect(
-                cell_x1, ry1, cell_x2, ry2, fill=fill, stroke=stroke, stroke_width=1.0
+                cell_x1, ry1, cell_x2, ry2, fill=cell_fill, stroke=stroke,
+                stroke_width=1.0,
             )
             label = fit_label(name, (cell_x2 - cell_x1) - 4.0, backend, lsize)
             backend.text(
@@ -65,22 +113,17 @@ class BundleByNameGlyph:
                 fill=text,
             )
 
-        # Cluster column + the direction arrow (a filled triangle) at mid — the
-        # aggregate OUTPUT sits at mid; the INPUT attaches at the column top.
+        # Aggregate cluster column.
         backend.rect(
-            col_x1, y1, col_x2, y2, fill=fill, stroke=stroke, stroke_width=1.0
+            col_x1, y1, col_x2, y2, fill=col_fill, stroke=stroke, stroke_width=1.0
         )
-        mid_y = (y1 + y2) / 2
-        acx = (col_x1 + col_x2) / 2
-        aw = (col_x2 - col_x1) * 0.62
-        ah = min(row_h * 0.5, 5.0)
-        back_x = acx - aw / 2 if points_right else acx + aw / 2
-        tip_x = acx + aw / 2 if points_right else acx - aw / 2
-        backend.polygon(
-            [
-                (back_x, mid_y - ah),
-                (tip_x, mid_y),
-                (back_x, mid_y + ah),
-            ],
-            fill=text,
-        )
+        mid_x = (col_x1 + col_x2) / 2
+        if self.bundling:
+            # Two equal columns (LabVIEW's connector pane): the INTERIOR (left)
+            # takes the input source cluster entering at the top, the EDGE
+            # (right) the assembled output exiting the right — the arrow sits in
+            # that edge column.
+            backend.line(mid_x, y1, mid_x, y2, stroke=stroke, stroke_width=1.0)
+            _draw_bundle_arrow(backend, mid_x, col_x2, y1, y2, text)
+        else:
+            _draw_bundle_arrow(backend, col_x1, col_x2, y1, y2, text)

--- a/src/lvkit/render/glyphs/nodes/cluster_constant.py
+++ b/src/lvkit/render/glyphs/nodes/cluster_constant.py
@@ -58,20 +58,40 @@ class ClusterConstantGlyph:
         label_size = 7.0
         row_h = (y2 - y1 - 2 * pad) / len(self.fields)
         if row_h < self._MIN_ROW_H or (x2 - x1 - 2 * pad) < self._MIN_FIELD_W:
-            # Too small for labeled rows: draw just the field VALUES, stacked
-            # and scaled to fit, so the box is never blank. Names on hover.
-            vpad = 1.0
-            vrow = (y2 - y1 - 2 * vpad) / len(self.fields)
-            for i, (_name, field_glyph) in enumerate(self.fields):
-                ry1 = y1 + vpad + i * vrow
-                ry2 = ry1 + vrow
-                if x2 - vpad > x1 + vpad and ry2 - 0.5 > ry1 + 0.5:
-                    field_glyph.draw(
-                        backend,
-                        (x1 + vpad, ry1 + 0.5, x2 - vpad, ry2 - 0.5),
-                        theme,
-                    )
+            # Icon size: too small for a labeled/value grid, so draw LabVIEW's
+            # generic cluster-constant ICON — the shell already drawn above, plus
+            # a couple of small element squares (as the standard shared icon
+            # shows), NOT a garbled stack of the real field values. Names on hover.
+            self._draw_generic_icon(backend, bounds, theme)
             return
+        self._draw_labeled_rows(backend, bounds, theme, border, pad, label_size)
+
+    def _draw_generic_icon(self, backend: Backend, bounds: Rect, theme: Theme) -> None:
+        """LabVIEW's generic cluster-constant icon: the cluster shell (already
+        drawn) with a couple of small element squares inside — the standard
+        shared look, independent of the real field values."""
+        x1, y1, x2, y2 = bounds
+        w, h = x2 - x1, y2 - y1
+        s = max(2.0, min(w, h) * 0.22)  # element-square size
+        gap = s * 0.5
+        # two element squares (a string-pink + an int-blue), the mixed-element
+        # motif of the standard icon; positioned upper-left with a small margin.
+        colors = (theme.wire_string, theme.wire_int)
+        ex = x1 + w * 0.22
+        ey = y1 + h * 0.28
+        for i, col in enumerate(colors):
+            bx = ex + i * (s + gap)
+            backend.rect(bx, ey, bx + s, ey + s, fill=col, stroke="none")
+        # a third (bool-green) square below the first, per the icon's layout
+        backend.rect(ex, ey + s + gap, ex + s, ey + 2 * s + gap,
+                     fill=theme.wire_bool, stroke="none")
+
+    def _draw_labeled_rows(
+        self, backend: Backend, bounds: Rect, theme: Theme,
+        border: str, pad: float, label_size: float,
+    ) -> None:
+        x1, y1, x2, y2 = bounds
+        row_h = (y2 - y1 - 2 * pad) / len(self.fields)
         label_w = min(
             0.4 * (x2 - x1),
             max(backend.measure_text(nm, label_size) for nm, _ in self.fields) + 4.0,

--- a/src/lvkit/render/glyphs/nodes/cluster_constant.py
+++ b/src/lvkit/render/glyphs/nodes/cluster_constant.py
@@ -53,7 +53,10 @@ class ClusterConstantGlyph:
             stroke_width=1.5,
         )
         if not self.fields:
-            return  # a genuinely empty cluster (no elements) — box only
+            # No resolved fields (or a genuinely empty cluster): the generic
+            # cluster icon, never a raw value repr.
+            self._draw_generic_icon(backend, bounds, theme)
+            return
         pad = 3.0
         label_size = 7.0
         row_h = (y2 - y1 - 2 * pad) / len(self.fields)

--- a/src/lvkit/render/glyphs/nodes/cluster_constant.py
+++ b/src/lvkit/render/glyphs/nodes/cluster_constant.py
@@ -25,6 +25,11 @@ class ClusterConstantGlyph:
 
     fields: tuple[tuple[str, Glyph], ...]
     is_error: bool = False
+    # Drawn COLLAPSED ("View As Icon") — show the compact cluster icon, never the
+    # members. A collapsed constant's box is deliberately too small for content;
+    # LabVIEW cannot shrink a value's natural height, so a small box is always a
+    # collapse, never squashed members. (``ConstantNode.collapsed``.)
+    collapsed: bool = False
     fill_attr: str = "const_fill"
     # The cluster's own wire color (brown for an all-numeric cluster, pink for a
     # mixed/common one) — the icon border matches the wire. None -> brown.
@@ -58,9 +63,10 @@ class ClusterConstantGlyph:
             stroke=border,
             stroke_width=1.5,
         )
-        if not self.fields:
-            # Genuinely unresolved / empty cluster (no field info to compose):
-            # the generic shell icon, never a raw value repr.
+        if self.collapsed or not self.fields:
+            # COLLAPSED ("View As Icon"), or a genuinely unresolved / empty
+            # cluster (no field info): the compact cluster icon, never squashed
+            # members or a raw value repr.
             self._draw_generic_icon(backend, bounds, theme)
             return
         pad = 3.0

--- a/src/lvkit/render/glyphs/nodes/cluster_constant.py
+++ b/src/lvkit/render/glyphs/nodes/cluster_constant.py
@@ -26,6 +26,9 @@ class ClusterConstantGlyph:
     fields: tuple[tuple[str, Glyph], ...]
     is_error: bool = False
     fill_attr: str = "const_fill"
+    # The cluster's own wire color (brown for an all-numeric cluster, pink for a
+    # mixed/common one) — the icon border matches the wire. None -> brown.
+    border_color: str | None = None
     # ``name: value`` per field, for a hover tooltip — useful when the cluster
     # is drawn small/collapsed and the inline values aren't legible.
     value_summary: str = ""
@@ -42,7 +45,10 @@ class ClusterConstantGlyph:
 
     def draw(self, backend: Backend, bounds: Rect, theme: Theme) -> None:
         x1, y1, x2, y2 = bounds
-        border = theme.wire_error if self.is_error else theme.wire_cluster
+        if self.is_error:
+            border = theme.wire_error
+        else:
+            border = self.border_color or theme.wire_cluster
         backend.rect(
             x1,
             y1,

--- a/src/lvkit/render/glyphs/nodes/cluster_constant.py
+++ b/src/lvkit/render/glyphs/nodes/cluster_constant.py
@@ -59,39 +59,54 @@ class ClusterConstantGlyph:
             stroke_width=1.5,
         )
         if not self.fields:
-            # No resolved fields (or a genuinely empty cluster): the generic
-            # cluster icon, never a raw value repr.
+            # Genuinely unresolved / empty cluster (no field info to compose):
+            # the generic shell icon, never a raw value repr.
             self._draw_generic_icon(backend, bounds, theme)
             return
         pad = 3.0
         label_size = 7.0
         row_h = (y2 - y1 - 2 * pad) / len(self.fields)
         if row_h < self._MIN_ROW_H or (x2 - x1 - 2 * pad) < self._MIN_FIELD_W:
-            # Icon size: too small for a labeled/value grid, so draw LabVIEW's
-            # generic cluster-constant ICON — the shell already drawn above, plus
-            # a couple of small element squares (as the standard shared icon
-            # shows), NOT a garbled stack of the real field values. Names on hover.
-            self._draw_generic_icon(backend, bounds, theme)
+            # Too small for name+value rows: draw the field VALUE glyphs alone,
+            # fit to the box. A one-boolean cluster shows its boolean; a small
+            # multi-field cluster shows its members' value glyphs — the REAL
+            # content and field count, never a generic mixed-element icon that
+            # misstates them. Names stay on the hover tooltip. Fits inside the
+            # given box, so it also composes into an array-of-clusters' per-
+            # element cell (LabVIEW lays the element cluster out in that box).
+            self._draw_value_cells(backend, bounds, theme)
             return
         self._draw_labeled_rows(backend, bounds, theme, border, pad, label_size)
 
+    def _draw_value_cells(self, backend: Backend, bounds: Rect, theme: Theme) -> None:
+        """Stack each field's VALUE glyph (no name label) to fill the box — one
+        equal-height row per field. The field glyphs draw themselves at whatever
+        size the cell gives, so this fits any box down to a single-member
+        square."""
+        x1, y1, x2, y2 = bounds
+        pad = 1.5
+        n = len(self.fields)
+        cell_h = (y2 - y1 - 2 * pad) / n
+        for i, (_name, field_glyph) in enumerate(self.fields):
+            cy1 = y1 + pad + i * cell_h
+            field_glyph.draw(backend, (x1 + pad, cy1, x2 - pad, cy1 + cell_h), theme)
+
     def _draw_generic_icon(self, backend: Backend, bounds: Rect, theme: Theme) -> None:
-        """LabVIEW's generic cluster-constant icon: the cluster shell (already
-        drawn) with a couple of small element squares inside — the standard
-        shared look, independent of the real field values."""
+        """The fallback shell icon for a cluster whose fields could NOT be
+        resolved (no composed field glyphs) — a couple of small element squares
+        inside the shell, so an unresolved cluster still reads as a cluster
+        rather than an empty box. A cluster WITH fields draws its real members
+        (:meth:`_draw_value_cells`) instead."""
         x1, y1, x2, y2 = bounds
         w, h = x2 - x1, y2 - y1
         s = max(2.0, min(w, h) * 0.22)  # element-square size
         gap = s * 0.5
-        # two element squares (a string-pink + an int-blue), the mixed-element
-        # motif of the standard icon; positioned upper-left with a small margin.
         colors = (theme.wire_string, theme.wire_int)
         ex = x1 + w * 0.22
         ey = y1 + h * 0.28
         for i, col in enumerate(colors):
             bx = ex + i * (s + gap)
             backend.rect(bx, ey, bx + s, ey + s, fill=col, stroke="none")
-        # a third (bool-green) square below the first, per the icon's layout
         backend.rect(ex, ey + s + gap, ex + s, ey + 2 * s + gap,
                      fill=theme.wire_bool, stroke="none")
 

--- a/src/lvkit/render/nodes.py
+++ b/src/lvkit/render/nodes.py
@@ -1124,9 +1124,12 @@ class GeneratedGlyphResolver:
                 composed = _cluster_const_glyph(node, is_error=fam == "error_cluster")
                 if composed is not None:
                     return composed
-                # No field info to compose from — keep the old schematic.
+                # No field info to compose from: an error cluster keeps its
+                # schematic; any other cluster draws the generic cluster ICON
+                # (never the raw dict/list value repr).
                 if fam == "error_cluster":
                     return ErrorClusterGlyph()
+                return ClusterConstantGlyph(fields=())
             raw = node.raw_value if node.value is None else node.value
             return _leaf_const_glyph(node.lv_type, raw, node.display_format)
         if isinstance(node, FormulaNode):

--- a/src/lvkit/render/nodes.py
+++ b/src/lvkit/render/nodes.py
@@ -1173,6 +1173,18 @@ def _field_summary_value(lv_type: LVType | None, raw: object) -> str:
         return _format_const(0 if raw is None else raw)
     if fam == "string":
         return string_const_display(raw) if raw is not None else ""
+    if fam in ("cluster", "error_cluster") and lv_type and lv_type.fields:
+        # Recurse so a nested cluster reads as LABELED sub-fields
+        # ``{Idle State: False}`` in the hover, not a raw Python dict
+        # ``{'Idle State': False}``.
+        vals = _cluster_field_values(raw)
+        inner = ", ".join(
+            f"{f.name}: {_field_summary_value(f.type, vals.get(f.name))}"
+            for f in lv_type.fields
+        )
+        return "{" + inner + "}"
+    if fam == "array" and isinstance(raw, (list, tuple)):
+        return f"[{len(raw)} element{'s' if len(raw) != 1 else ''}]"
     return str(raw) if raw is not None else ""
 
 

--- a/src/lvkit/render/nodes.py
+++ b/src/lvkit/render/nodes.py
@@ -1083,7 +1083,12 @@ def _cluster_const_glyph(node: ConstantNode, is_error: bool) -> Glyph | None:
     summary = "\n".join(
         f"{f.name}: {_field_summary_value(f.type, values.get(f.name))}" for f in fields
     )
-    return ClusterConstantGlyph(composed, is_error=is_error, value_summary=summary)
+    return ClusterConstantGlyph(
+        composed,
+        is_error=is_error,
+        value_summary=summary,
+        border_color=wire_style(node.lv_type).color,
+    )
 
 
 def _field_summary_value(lv_type: LVType | None, raw: object) -> str:
@@ -1129,7 +1134,9 @@ class GeneratedGlyphResolver:
                 # (never the raw dict/list value repr).
                 if fam == "error_cluster":
                     return ErrorClusterGlyph()
-                return ClusterConstantGlyph(fields=())
+                return ClusterConstantGlyph(
+                    fields=(), border_color=wire_style(node.lv_type).color
+                )
             raw = node.raw_value if node.value is None else node.value
             return _leaf_const_glyph(node.lv_type, raw, node.display_format)
         if isinstance(node, FormulaNode):

--- a/src/lvkit/render/nodes.py
+++ b/src/lvkit/render/nodes.py
@@ -1101,6 +1101,7 @@ def _cluster_const_glyph(node: ConstantNode, is_error: bool) -> Glyph | None:
     return ClusterConstantGlyph(
         composed,
         is_error=is_error,
+        collapsed=node.collapsed,
         value_summary=summary,
         border_color=wire_style(node.lv_type).color,
     )

--- a/src/lvkit/render/nodes.py
+++ b/src/lvkit/render/nodes.py
@@ -43,6 +43,7 @@ from ..graph.models import (
 )
 from ..graph.op_walk import (
     _nmux_field_sources,
+    _nmux_index_leaf_only,
     _resolve_nmux_field_name,
     correlate_property_terminals,
 )
@@ -594,6 +595,7 @@ class JsonGlyphResolver:
 def _resolve_bundle_by_name_labels(
     field_terms: list[Terminal],
     *field_sources: list[ClusterField],
+    leaf_only: bool,
 ) -> tuple[str, ...]:
     """Resolve each By-Name field terminal's label via the fall-through
     chain (``_resolve_nmux_field_name`` over ``field_sources``, then the
@@ -621,7 +623,9 @@ def _resolve_bundle_by_name_labels(
     names: list[str] = []
     for t in field_terms:
         fi = t.nmux_field_index
-        name = t.display_name or _resolve_nmux_field_name(fi, *field_sources)
+        name = t.display_name or _resolve_nmux_field_name(
+            fi, *field_sources, leaf_only=leaf_only
+        )
         if name:
             t.display_name = name
             names.append(name)
@@ -671,7 +675,12 @@ def _bundle_by_name_glyph(
     # its terminal's ``display_name`` so the hover connector-panel (which has
     # room to show the name untruncated) shows the SAME resolved name as this
     # glyph row, not a generic "terminal N".
-    names = _resolve_bundle_by_name_labels(field_terms, own_fields, dep_fields)
+    names = _resolve_bundle_by_name_labels(
+        field_terms,
+        own_fields,
+        dep_fields,
+        leaf_only=_nmux_index_leaf_only(node.node_type, agg),
+    )
     # Direction comes from the FIELD terminals, not the aggregate — there can
     # be TWO aggregate terminals (an input source cluster and an output
     # assembled cluster) sharing one DCO, so ``agg.direction`` is ambiguous.
@@ -719,7 +728,12 @@ def _event_data_glyph(
     rows: list[tuple[str, LVType | None]] = []
     for t in field_terms:
         fi = t.nmux_field_index
-        name = t.display_name or _resolve_nmux_field_name(fi, own_fields, dep_fields)
+        name = t.display_name or _resolve_nmux_field_name(
+            fi,
+            own_fields,
+            dep_fields,
+            leaf_only=_nmux_index_leaf_only(node.node_type, agg),
+        )
         if name:
             t.display_name = name
         elif t.name:

--- a/src/lvkit/render/nodes.py
+++ b/src/lvkit/render/nodes.py
@@ -57,6 +57,7 @@ from ..vilib_resolver import get_resolver as get_vilib_resolver
 from .glyph import (
     ArithGlyph,
     ArrayBuildGlyph,
+    ArrayConstantGlyph,
     ArrayReverseGlyph,
     ArraySearchGlyph,
     ArraySizeGlyph,
@@ -1105,6 +1106,58 @@ def _cluster_const_glyph(node: ConstantNode, is_error: bool) -> Glyph | None:
     )
 
 
+def _array_const_values(value: object) -> list[object]:
+    """An array constant's values as a Python list. The graph stores the value
+    as its ``repr`` string (``"[0, 0, 1, ...]"`` / ``"['a', 'b']"``); parse it
+    back with ``ast.literal_eval`` the same way the cluster path does."""
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    if isinstance(value, str) and value:
+        try:
+            parsed = ast.literal_eval(value)
+        except (ValueError, SyntaxError):
+            return []
+        if isinstance(parsed, (list, tuple)):
+            return list(parsed)
+    return []
+
+
+def _element_glyph(element_type: LVType | None, value: object) -> Glyph:
+    """One array element's glyph, from the element TYPE + its value. A cluster
+    element composes its fields (so an array of clusters draws each cluster in
+    its cell); anything else is a leaf constant glyph."""
+    fam = type_family(element_type)
+    if fam in ("cluster", "error_cluster") and element_type and element_type.fields:
+        vals = _cluster_field_values(value)
+        composed = tuple(
+            (f.name, _leaf_const_glyph(f.type, vals.get(f.name)))
+            for f in element_type.fields
+        )
+        return ClusterConstantGlyph(
+            composed,
+            is_error=fam == "error_cluster",
+            border_color=wire_style(element_type).color,
+        )
+    return _leaf_const_glyph(element_type, value)
+
+
+def _array_const_glyph(node: ConstantNode) -> Glyph:
+    """Compose an array constant: one element glyph per value (from the element
+    type), drawn by :class:`ArrayConstantGlyph` as an indexed, scrollable column
+    of cells — never the raw ``[…]`` list repr."""
+    lv_type = node.lv_type
+    element_type = lv_type.element_type if lv_type is not None else None
+    raw = node.raw_value if node.value is None else node.value
+    values = _array_const_values(raw)
+    elements = tuple(_element_glyph(element_type, v) for v in values)
+    return ArrayConstantGlyph(
+        elements=elements,
+        element_color=wire_style(lv_type).color,
+        struct_uid=node.id,
+        dimensions=(lv_type.dimensions if lv_type is not None else 1) or 1,
+    )
+
+
 def _field_summary_value(lv_type: LVType | None, raw: object) -> str:
     """A cluster field's value as short text for the hover tooltip — mirrors
     what ``_leaf_const_glyph`` draws (type defaults for an unset field)."""
@@ -1151,6 +1204,8 @@ class GeneratedGlyphResolver:
                 return ClusterConstantGlyph(
                     fields=(), border_color=wire_style(node.lv_type).color
                 )
+            if fam == "array":
+                return _array_const_glyph(node)
             raw = node.raw_value if node.value is None else node.value
             return _leaf_const_glyph(node.lv_type, raw, node.display_format)
         if isinstance(node, FormulaNode):

--- a/src/lvkit/render/scene.py
+++ b/src/lvkit/render/scene.py
@@ -38,8 +38,13 @@ from ..models import (
     TunnelTerminal,
     _is_error_cluster,
 )
-from ..parser.constants import NMUX_BY_NAME_NODE_CLASSES
-from ..parser.layout import Layout, Point, Rect, build_layout
+from ..parser.layout import (
+    Layout,
+    Point,
+    Rect,
+    build_layout,
+    bundle_aggregate_columns,
+)
 from ..parser.wire_table import FAITHFUL_WIRE_TABLE
 from .backend import SvgBackend
 from .glyph import ArithGlyph, CompoundArithGlyph, Glyph, wrap_label
@@ -721,46 +726,6 @@ def _formula_border_centers(
     return out
 
 
-# How far below the node's top edge the Bundle "input cluster" terminal sits.
-_BUNDLE_AGG_TOP_INSET = 5.0
-
-
-def _bundle_agg_centers(
-    by_id: dict[str, AnyGraphNode],
-    vi_name: str,
-    layout: Layout,
-) -> dict[str, tuple[float, float]]:
-    """Re-anchor a Bundle-By-Name's INPUT-cluster terminal to the TOP of the
-    aggregate's right column. The aggregate is a FULL-HEIGHT right column whose
-    input ("input cluster") attaches at its TOP while the output exits mid-right;
-    both share one heap DCO, so the layout collapses them onto the single mid
-    center and the input wire wrongly lands at mid. Move the INPUT up to the
-    column top (x kept at the aggregate column, y at the node top) — matching
-    LabVIEW's split cluster column. Only a Bundle (an aggregate INPUT *and*
-    OUTPUT both present) is touched; an Unbundle (aggregate input only) is left
-    alone."""
-    out: dict[str, tuple[float, float]] = {}
-    for node in by_id.values():
-        if getattr(node, "node_type", None) not in NMUX_BY_NAME_NODE_CLASSES:
-            continue
-        aggs = [
-            t
-            for t in getattr(node, "terminals", [])
-            if getattr(t, "nmux_role", None) == "agg"
-        ]
-        agg_out = next((t for t in aggs if t.direction == "output"), None)
-        agg_in = next((t for t in aggs if t.direction == "input"), None)
-        if agg_out is None or agg_in is None:
-            continue
-        raw = _strip_prefix(node.id, vi_name)
-        nb = layout.node_bounds.get(raw)
-        oc = layout.terminal_centers.get(_strip_prefix(agg_out.id, vi_name))
-        if nb is None or oc is None:
-            continue
-        out[_strip_prefix(agg_in.id, vi_name)] = (oc[0], nb[1] + _BUNDLE_AGG_TOP_INSET)
-    return out
-
-
 def _render_terminals(
     node: AnyGraphNode,
     layout: Layout,
@@ -790,43 +755,40 @@ def _reposition_mux_terminals(
     terminals: list[RenderTerminal],
     node_bounds: Rect,
 ) -> list[RenderTerminal]:
-    """Snap a Bundle/Unbundle node's terminals to the node edges.
+    """Give a Bundle's two aggregate terminals DISTINCT connector-pane boxes.
 
-    A ``nMux``/``mux``/``demux`` node has up to TWO aggregate terminals (an
-    input source cluster and an output assembled cluster) that share one DCO
-    uid. In the heap, the agg-input often carries no ``termBounds`` of its
-    own, so both aggregate terminals resolve to the SAME center point —
-    collapsing the incoming and outgoing cluster wires onto one spot. LabVIEW
-    draws the input (source) cluster entering at the TOP-CENTER of the node and
-    the assembled output cluster exiting at the right edge.
+    A Bundle-By-Name ``nMux`` has TWO aggregate terminals — the input source
+    cluster and the output assembled cluster — that share ONE heap DCO box (the
+    output owns it; the input aliases it with no box of its own). Left as-is they
+    resolve to the SAME rect, so the hover connector-panel treats them as one
+    shared slot and cannot tell input from output — it then draws the input
+    cluster entering on the same side as the output (the reported tooltip
+    "double-drive"). Give each its own column: the OUTPUT keeps its real box (the
+    EDGE column, flush to the node's exposed side — right for the usual
+    right-hand aggregate); the INPUT takes the equal-width column immediately on
+    the field-facing side of it — the empty band the heap leaves between the
+    field cells and the box. ``draw._term_side_and_frac`` then reads the edge box
+    as its exposed side and the interior column as TOP — LabVIEW's connector pane
+    (input cluster in at the top, output cluster out at the exposed side), and
+    the two boxes' union is the full aggregate width the glyph draws its two
+    columns across.
 
-    The FIELD (``nmux_role=="list"``) terminals' heap centers sit by their
-    field-name label (mid-box, near the divider), NOT on the node edge — so a
-    wire to a Bundle input field would run into the middle of the box and cross
-    the assembled output exiting the right edge (the reported "bundle terminals
-    cross" bug). LabVIEW attaches each field wire at the node EDGE on its
-    dataflow side, matching the glyph's element rows (``draw_split_box``):
-    input fields (Bundle) at the LEFT edge, output fields (Unbundle) at the
-    RIGHT edge. The heap-derived row Y already lines up with the drawn rows, so
-    snap only the X.
+    This sets only the panel/glyph geometry (``bounds``). The on-diagram wire
+    endpoint of the position-less input is corrected separately, before wire
+    decode, in ``layout._reanchor_nmux_aggregate_inputs`` (keep the two in step);
+    the wires themselves are LabVIEW's own decoded geometry, never re-routed. An
+    Unbundle (a single aggregate that already owns its edge box) is left alone.
     """
-    left_x, top_y, right_x, bottom_y = node_bounds
-    mid_x = (left_x + right_x) / 2
-    mid_y = (top_y + bottom_y) / 2
+    aggs = [rt for rt in terminals if rt.terminal.nmux_role == "agg"]
+    agg_box = next((rt.bounds for rt in aggs if rt.bounds is not None), None)
+    if agg_box is None or len(aggs) < 2:
+        return terminals
+    interior, edge = bundle_aggregate_columns(agg_box, node_bounds)
     out: list[RenderTerminal] = []
     for rt in terminals:
-        role = rt.terminal.nmux_role
-        if role == "agg":
-            if rt.terminal.direction == "output":
-                center = (right_x, mid_y)  # assembled cluster exits right-middle
-            else:
-                center = (mid_x, top_y)  # source cluster enters top-center
-            out.append(replace(rt, center=center))
-        elif role == "list":
-            # Field wire attaches at the node edge on its dataflow side —
-            # Bundle inputs LEFT, Unbundle outputs RIGHT — keeping the row Y.
-            edge_x = left_x if rt.terminal.direction == "input" else right_x
-            out.append(replace(rt, center=(edge_x, rt.center[1])))
+        if rt.terminal.nmux_role == "agg" and rt.bounds == agg_box:
+            box = edge if rt.terminal.direction == "output" else interior
+            out.append(replace(rt, bounds=box))
         else:
             out.append(rt)
     return out
@@ -1850,14 +1812,6 @@ def build_scene(graph: InMemoryVIGraph, vi_name: str) -> Scene | None:
         layout = replace(
             layout,
             terminal_centers={**layout.terminal_centers, **fbox_centers},
-        )
-    # A Bundle-By-Name's "input cluster" attaches at the TOP of the aggregate's
-    # right column, not the mid where the layout collapses it (see the helper).
-    agg_centers = _bundle_agg_centers(by_id, vi_name, layout)
-    if agg_centers:
-        layout = replace(
-            layout,
-            terminal_centers={**layout.terminal_centers, **agg_centers},
         )
     default_frame, frame_values, frame_labels, error_frame_no_error = _frame_info(
         all_nodes,

--- a/src/lvkit/render/scene.py
+++ b/src/lvkit/render/scene.py
@@ -38,6 +38,7 @@ from ..models import (
     TunnelTerminal,
     _is_error_cluster,
 )
+from ..parser.constants import NMUX_BY_NAME_NODE_CLASSES
 from ..parser.layout import Layout, Point, Rect, build_layout
 from ..parser.wire_table import FAITHFUL_WIRE_TABLE
 from .backend import SvgBackend
@@ -717,6 +718,46 @@ def _formula_border_centers(
             if center is None:
                 continue
             out[key] = (x1 if t.direction != "output" else x2, center[1])
+    return out
+
+
+# How far below the node's top edge the Bundle "input cluster" terminal sits.
+_BUNDLE_AGG_TOP_INSET = 5.0
+
+
+def _bundle_agg_centers(
+    by_id: dict[str, AnyGraphNode],
+    vi_name: str,
+    layout: Layout,
+) -> dict[str, tuple[float, float]]:
+    """Re-anchor a Bundle-By-Name's INPUT-cluster terminal to the TOP of the
+    aggregate's right column. The aggregate is a FULL-HEIGHT right column whose
+    input ("input cluster") attaches at its TOP while the output exits mid-right;
+    both share one heap DCO, so the layout collapses them onto the single mid
+    center and the input wire wrongly lands at mid. Move the INPUT up to the
+    column top (x kept at the aggregate column, y at the node top) — matching
+    LabVIEW's split cluster column. Only a Bundle (an aggregate INPUT *and*
+    OUTPUT both present) is touched; an Unbundle (aggregate input only) is left
+    alone."""
+    out: dict[str, tuple[float, float]] = {}
+    for node in by_id.values():
+        if getattr(node, "node_type", None) not in NMUX_BY_NAME_NODE_CLASSES:
+            continue
+        aggs = [
+            t
+            for t in getattr(node, "terminals", [])
+            if getattr(t, "nmux_role", None) == "agg"
+        ]
+        agg_out = next((t for t in aggs if t.direction == "output"), None)
+        agg_in = next((t for t in aggs if t.direction == "input"), None)
+        if agg_out is None or agg_in is None:
+            continue
+        raw = _strip_prefix(node.id, vi_name)
+        nb = layout.node_bounds.get(raw)
+        oc = layout.terminal_centers.get(_strip_prefix(agg_out.id, vi_name))
+        if nb is None or oc is None:
+            continue
+        out[_strip_prefix(agg_in.id, vi_name)] = (oc[0], nb[1] + _BUNDLE_AGG_TOP_INSET)
     return out
 
 
@@ -1809,6 +1850,14 @@ def build_scene(graph: InMemoryVIGraph, vi_name: str) -> Scene | None:
         layout = replace(
             layout,
             terminal_centers={**layout.terminal_centers, **fbox_centers},
+        )
+    # A Bundle-By-Name's "input cluster" attaches at the TOP of the aggregate's
+    # right column, not the mid where the layout collapses it (see the helper).
+    agg_centers = _bundle_agg_centers(by_id, vi_name, layout)
+    if agg_centers:
+        layout = replace(
+            layout,
+            terminal_centers={**layout.terminal_centers, **agg_centers},
         )
     default_frame, frame_values, frame_labels, error_frame_no_error = _frame_info(
         all_nodes,

--- a/src/lvkit/render/style.py
+++ b/src/lvkit/render/style.py
@@ -158,6 +158,12 @@ _LINE_W = 1.2
 # bolder than its scalar element (1D ~2.8px vs 1.2px), thicker still for 2D+.
 _ARRAY_W_PER_DIM = 1.6
 
+# Fill pattern for an UNRESOLVED class wire's default grey CHAIN. Any non-empty,
+# UNIFORM 8-row pattern selects the chain preset (uniform -> chain, mixed rows ->
+# diagonal; see render/composite.py); the exact bytes don't affect the drawn
+# hollow-link chain, only chain-vs-diagonal selection.
+_CLASS_CHAIN_PATTERN: tuple[int, ...] = (0xC3,) * 8
+
 
 _INT_TYPES = {
     "NumInt8",
@@ -342,16 +348,14 @@ def type_family(lv_type: LVType | None) -> str:
             # LabVIEW I/O-name types (DAQmx physical channel / task name, VISA
             # resource name, …) — reference-family wires, LV's dark green.
             return "refnum"
-        if ut == "Refnum":
-            # Generic refnum — VI reference, DAQmx/VISA driver session, queue,
-            # notifier, control refnum, etc. — draws LabVIEW's dark-green
-            # reference wire. An LVOOP class instance is ALSO carried as a Refnum
-            # but with a ``classname``: when its class (or an ancestor) sets a
-            # wire style, ``wire_style`` returns that before reaching here, so we
-            # only see a class refnum with NO style in its whole ancestry — which
-            # falls back to the same generic reference green, never grey.
-            if not lv_type.classname or lv_type.wire_style is None:
-                return "refnum"
+        if ut == "Refnum" and not lv_type.classname:
+            # GENERIC refnum only — VI reference, DAQmx/VISA driver session,
+            # queue, notifier, control refnum, etc. — draws LabVIEW's reference
+            # wire. An LVOOP class instance is ALSO carried as a Refnum but with a
+            # ``classname``: it is NOT a refnum wire. ``wire_style`` handles it
+            # (its own/inherited pen, else the default GREY CHAIN for an
+            # unresolved class), returning before the family is consulted.
+            return "refnum"
     return "unknown"
 
 
@@ -422,6 +426,17 @@ def wire_style(
             core_width=(
                 inner.core_width + extra if inner.core_width is not None else None
             ),
+        )
+
+    # An LVOOP class refnum with no pen anywhere in its ancestry — an UNRESOLVED
+    # class (its ``.lvclass`` or a parent is unfound, often a ``<vilib>`` class
+    # with no configured root) — is NOT a refnum wire. LabVIEW draws every class
+    # with the CHAIN pattern, so draw a GREY CHAIN: grey = unresolved, chain =
+    # still visibly a class (an array OF such a class inherits it, thicker, via
+    # the array branch above).
+    if lv_type.underlying_type == "Refnum" and lv_type.classname:
+        return WireStyle(
+            theme.wire_default, _LINE_W, fill_pattern=_CLASS_CHAIN_PATTERN
         )
 
     family = type_family(lv_type)

--- a/src/lvkit/render/style.py
+++ b/src/lvkit/render/style.py
@@ -11,11 +11,13 @@ from __future__ import annotations
 import dataclasses
 import re
 from dataclasses import dataclass
+from itertools import groupby
 
 from ..models import (
     _NUMERIC_TYPE_DESCRIPTOR,
     LVType,
     LVTypeKind,
+    WireLineStyle,
     WireStyle,
     _is_error_cluster,
 )
@@ -99,7 +101,10 @@ class Theme:
     wire_bool: str = "#4a9c3e"  # green — boolean
     wire_string: str = "#e05fa0"  # pink — string
     wire_path: str = "#1f8a8a"  # teal — path
-    wire_cluster: str = "#8a5a2b"  # brown — clusters / typedefs
+    wire_cluster: str = "#8a5a2b"  # brown — all-numeric (fixed-size) clusters
+    # pink — a mixed/"common" cluster (any string/array/refnum/... field). Same
+    # NI pink family as the string wire; a mixed cluster reads pink in LabVIEW.
+    wire_cluster_mixed: str = "#e05fa0"
     wire_refnum: str = "#1f6b2e"  # dark green — refnums (VI refs, driver/DAQ/
     #                                VISA sessions, queues, notifiers, controls);
     #                                LabVIEW's generic reference wire color
@@ -275,10 +280,26 @@ _FAMILY_COLOR = {
     "string": "wire_string",
     "path": "wire_path",
     "cluster": "wire_cluster",
+    "cluster_mixed": "wire_cluster_mixed",
     "error_cluster": "wire_error",
     "variant": "wire_variant",
     "refnum": "wire_refnum",
 }
+
+
+def _cluster_all_numeric(lv_type: LVType) -> bool:
+    """True when every field of a cluster is numeric/boolean (or a nested cluster
+    that is itself all-numeric) — a fixed-size "numeric cluster" (brown). False
+    when any field is a string/array/refnum/variant/etc. (variable-size, pink).
+    Fields unknown (None — resolved lazily elsewhere) -> True, keeping the prior
+    brown default rather than guessing pink."""
+    fields = lv_type.fields
+    if not fields:
+        return True
+    return all(
+        type_family(f.type) in ("int", "float", "bool", "enum", "cluster")
+        for f in fields
+    )
 
 
 def type_family(lv_type: LVType | None) -> str:
@@ -294,7 +315,13 @@ def type_family(lv_type: LVType | None) -> str:
     if lv_type.kind in (LVTypeKind.ENUM, LVTypeKind.RING):
         return "enum"
     if lv_type.kind in (LVTypeKind.CLUSTER, LVTypeKind.TYPEDEF_REF):
-        return "error_cluster" if _is_error_cluster(lv_type) else "cluster"
+        if _is_error_cluster(lv_type):
+            return "error_cluster"
+        # A cluster is BROWN only when every field is numeric/boolean (a fixed-
+        # size "numeric cluster"); any string/path/array/refnum/variant field
+        # makes it a variable-size "common cluster" -> PINK. Fields unknown
+        # (resolved lazily) -> brown, matching the prior default.
+        return "cluster" if _cluster_all_numeric(lv_type) else "cluster_mixed"
     if lv_type.kind == LVTypeKind.PRIMITIVE:
         ut = lv_type.underlying_type or ""
         if ut in _FLOAT_TYPES or ut in _COMPLEX_TYPES:
@@ -380,15 +407,58 @@ def wire_style(
         return lv_type.wire_style
 
     if lv_type.kind == LVTypeKind.ARRAY:
+        # An array draws in its element's style, thicker per dimension — so an
+        # array OF a class keeps the class color AND its two-band border.
         inner = wire_style(lv_type.element_type, theme)
-        return WireStyle(
-            inner.color,
-            inner.width + _ARRAY_W_PER_DIM * (lv_type.dimensions or 1),
+        extra = _ARRAY_W_PER_DIM * (lv_type.dimensions or 1)
+        return dataclasses.replace(
+            inner,
+            width=inner.width + extra,
+            core_width=(
+                inner.core_width + extra if inner.core_width is not None else None
+            ),
         )
 
     family = type_family(lv_type)
     color = getattr(theme, _FAMILY_COLOR.get(family, ""), theme.wire_default)
     return WireStyle(color, _LINE_W)
+
+
+# A wire's line style -> SVG ``stroke-dasharray`` (in stroke-width units), or None
+# for a solid stroke. Read at every wire-drawing site off the one WireStyle.
+_LINE_STYLE_DASH: dict[WireLineStyle, str | None] = {
+    WireLineStyle.SOLID: None,
+    WireLineStyle.DASH: "6,4",
+    WireLineStyle.DOT: "1,3",
+    WireLineStyle.DASH_DOT: "6,3,1,3",
+    WireLineStyle.DASH_DOT_DOT: "6,3,1,3,1,3",
+}
+
+
+def wire_dasharray(style: WireStyle) -> str | None:
+    """The SVG ``stroke-dasharray`` for a wire style's line style (None = solid).
+    The one place a line style becomes a dash pattern."""
+    return _LINE_STYLE_DASH.get(style.line_style)
+
+
+def core_dasharray(style: WireStyle) -> str | None:
+    """The dash the wire's CENTER band draws with: the class fill pattern read as
+    a 1-px dash along the wire (the "chain" — solid edge shows through the gaps),
+    else the line-style dash, else solid. The one place a fill pattern becomes a
+    dash. A row byte's set bits are the on-runs; the periodic run-lengths (rotated
+    to start on an on-run) are the dash array."""
+    pattern = style.fill_pattern
+    if pattern:
+        row = pattern[len(pattern) // 2]  # the band rides the pattern's center row
+        if row not in (0x00, 0xFF):
+            bits = [(row >> (7 - i)) & 1 for i in range(8)]  # MSB = leftmost pixel
+            start = next(
+                (i for i in range(8) if bits[i] and not bits[(i - 1) % 8]), 0
+            )
+            seq = [bits[(start + k) % 8] for k in range(8)]
+            runs = [len(list(g)) for _, g in groupby(seq)]
+            return ",".join(str(r) for r in runs)
+    return wire_dasharray(style)
 
 
 # --------------------------------------------------------------------- #

--- a/src/lvkit/render/style.py
+++ b/src/lvkit/render/style.py
@@ -12,7 +12,13 @@ import dataclasses
 import re
 from dataclasses import dataclass
 
-from ..models import _NUMERIC_TYPE_DESCRIPTOR, LVType, LVTypeKind, _is_error_cluster
+from ..models import (
+    _NUMERIC_TYPE_DESCRIPTOR,
+    LVType,
+    LVTypeKind,
+    WireStyle,
+    _is_error_cluster,
+)
 
 # LabVIEW help/description strings carry rich-text tags (<B>..</B>, <BR>, ...).
 _HELP_TAG_RE = re.compile(r"<[^>]+>")
@@ -144,12 +150,6 @@ _LINE_W = 1.2
 # Extra stroke width per array dimension — an array wire is drawn markedly
 # bolder than its scalar element (1D ~2.8px vs 1.2px), thicker still for 2D+.
 _ARRAY_W_PER_DIM = 1.6
-
-
-@dataclass(frozen=True)
-class WireStyle:
-    color: str
-    width: float
 
 
 _INT_TYPES = {
@@ -363,15 +363,21 @@ def wire_style(
     lv_type: LVType | None,
     theme: Theme = DEFAULT_THEME,
 ) -> WireStyle:
-    """Color/width for a wire, from the SOURCE terminal's LVType.
+    """Color/width/style for a wire, from the SOURCE terminal's LVType — the ONE
+    lookup every wire/tunnel/terminal drawing site calls.
 
-    Branches on ``kind`` then ``underlying_type``: DBL orange (default),
-    ints blue, bool green, string pink, path teal, cluster brown, error
-    cluster dark, array thicker (by ``dimensions``, color inherited from
-    the element type).
+    First it ASKS THE TYPE: a type that carries its OWN ``wire_style`` (a LabVIEW
+    class, whose style is decoded from its ``.lvclass``) draws in that. Otherwise
+    the per-family default: DBL orange, ints blue, bool green, string pink, path
+    teal, cluster brown, error cluster dark; an array is thicker (by
+    ``dimensions``, color inherited from the element type — so an array OF a class
+    keeps the class color).
     """
     if lv_type is None:
         return WireStyle(theme.wire_default, _LINE_W)
+
+    if lv_type.wire_style is not None:
+        return lv_type.wire_style
 
     if lv_type.kind == LVTypeKind.ARRAY:
         inner = wire_style(lv_type.element_type, theme)

--- a/src/lvkit/render/style.py
+++ b/src/lvkit/render/style.py
@@ -105,9 +105,11 @@ class Theme:
     # pink — a mixed/"common" cluster (any string/array/refnum/... field). Same
     # NI pink family as the string wire; a mixed cluster reads pink in LabVIEW.
     wire_cluster_mixed: str = "#e05fa0"
-    wire_refnum: str = "#1f6b2e"  # dark green — refnums (VI refs, driver/DAQ/
-    #                                VISA sessions, queues, notifiers, controls);
-    #                                LabVIEW's generic reference wire color
+    # dark teal — refnums (VI refs, driver/DAQ/VISA sessions, queues, notifiers,
+    # controls). LabVIEW's generic "Refnum Wire" user-color default is
+    # 0x00007F7F (per the LabVIEW Wiki Color reference) — a dark teal, NOT green.
+    # Sits near ``wire_path`` (also teal) as it does in LabVIEW itself.
+    wire_refnum: str = "#007f7f"
     wire_error: str = "#a88d1e"  # mustard/dark-yellow — error clusters (LV 8.2+)
     wire_variant: str = "#840984"  # purple — Variant (NI rgb(132,9,132))
     # Unresolved / unknown-type wires — a DISTINCT dark grey, NOT the float

--- a/src/lvkit/render/style.py
+++ b/src/lvkit/render/style.py
@@ -163,6 +163,12 @@ _ARRAY_W_PER_DIM = 1.6
 # diagonal; see render/composite.py); the exact bytes don't affect the drawn
 # hollow-link chain, only chain-vs-diagonal selection.
 _CLASS_CHAIN_PATTERN: tuple[int, ...] = (0xC3,) * 8
+# Total/core widths for the default class chain — matched to what REAL class
+# pens decode to across the corpus (edge ``Width`` 3.0, core 1.0; see
+# structure._parse_wire_style / _pen_width), so an UNRESOLVED class wire is the
+# same size as a resolved one, not the thin scalar ``_LINE_W``.
+_CLASS_WIRE_W = 3.0
+_CLASS_WIRE_CORE_W = 1.0
 
 
 _INT_TYPES = {
@@ -436,7 +442,10 @@ def wire_style(
     # the array branch above).
     if lv_type.underlying_type == "Refnum" and lv_type.classname:
         return WireStyle(
-            theme.wire_default, _LINE_W, fill_pattern=_CLASS_CHAIN_PATTERN
+            theme.wire_default,
+            _CLASS_WIRE_W,
+            core_width=_CLASS_WIRE_CORE_W,
+            fill_pattern=_CLASS_CHAIN_PATTERN,
         )
 
     family = type_family(lv_type)

--- a/src/lvkit/render/style.py
+++ b/src/lvkit/render/style.py
@@ -280,7 +280,6 @@ _FAMILY_COLOR = {
     "string": "wire_string",
     "path": "wire_path",
     "cluster": "wire_cluster",
-    "cluster_mixed": "wire_cluster_mixed",
     "error_cluster": "wire_error",
     "variant": "wire_variant",
     "refnum": "wire_refnum",
@@ -315,13 +314,10 @@ def type_family(lv_type: LVType | None) -> str:
     if lv_type.kind in (LVTypeKind.ENUM, LVTypeKind.RING):
         return "enum"
     if lv_type.kind in (LVTypeKind.CLUSTER, LVTypeKind.TYPEDEF_REF):
-        if _is_error_cluster(lv_type):
-            return "error_cluster"
-        # A cluster is BROWN only when every field is numeric/boolean (a fixed-
-        # size "numeric cluster"); any string/path/array/refnum/variant field
-        # makes it a variable-size "common cluster" -> PINK. Fields unknown
-        # (resolved lazily) -> brown, matching the prior default.
-        return "cluster" if _cluster_all_numeric(lv_type) else "cluster_mixed"
+        # One "cluster" family (so every cluster glyph/constant path keeps
+        # working); brown-vs-pink is decided in ``wire_style`` from field
+        # homogeneity, not by a separate family.
+        return "error_cluster" if _is_error_cluster(lv_type) else "cluster"
     if lv_type.kind == LVTypeKind.PRIMITIVE:
         ut = lv_type.underlying_type or ""
         if ut in _FLOAT_TYPES or ut in _COMPLEX_TYPES:
@@ -420,6 +416,10 @@ def wire_style(
         )
 
     family = type_family(lv_type)
+    if family == "cluster" and not _cluster_all_numeric(lv_type):
+        # A cluster with any non-numeric field is a variable-size "common"
+        # cluster -> pink (else the all-numeric brown).
+        return WireStyle(theme.wire_cluster_mixed, _LINE_W)
     color = getattr(theme, _FAMILY_COLOR.get(family, ""), theme.wire_default)
     return WireStyle(color, _LINE_W)
 

--- a/src/lvkit/render/style.py
+++ b/src/lvkit/render/style.py
@@ -336,13 +336,20 @@ def type_family(lv_type: LVType | None) -> str:
             return "path"
         if ut in ("Variant", "LVVariant"):
             return "variant"
-        if ut == "Refnum" and not lv_type.classname:
-            # Generic refnum — VI reference, DAQmx/VISA driver session, queue,
-            # notifier, control refnum, etc. LabVIEW draws all of these in the
-            # same dark-green reference-wire color. An LVOOP class instance is
-            # ALSO carried as a Refnum but has a ``classname`` (its wire is the
-            # class's own colour, not the generic reference green), so exclude it.
+        if ut == "Tag":
+            # LabVIEW I/O-name types (DAQmx physical channel / task name, VISA
+            # resource name, …) — reference-family wires, LV's dark green.
             return "refnum"
+        if ut == "Refnum":
+            # Generic refnum — VI reference, DAQmx/VISA driver session, queue,
+            # notifier, control refnum, etc. — draws LabVIEW's dark-green
+            # reference wire. An LVOOP class instance is ALSO carried as a Refnum
+            # but with a ``classname``: when its class (or an ancestor) sets a
+            # wire style, ``wire_style`` returns that before reaching here, so we
+            # only see a class refnum with NO style in its whole ancestry — which
+            # falls back to the same generic reference green, never grey.
+            if not lv_type.classname or lv_type.wire_style is None:
+                return "refnum"
     return "unknown"
 
 

--- a/src/lvkit/render/theme_web.py
+++ b/src/lvkit/render/theme_web.py
@@ -70,6 +70,7 @@ DARK_PALETTE: dict[str, str] = {
     "wire_string": "#f284bd",
     "wire_path": "#38b6b6",
     "wire_cluster": "#c8965a",
+    "wire_cluster_mixed": "#f284bd",
     "wire_refnum": "#3f9e58",
     "wire_error": "#cdb03e",
     "wire_variant": "#c452c4",

--- a/src/lvkit/render/theme_web.py
+++ b/src/lvkit/render/theme_web.py
@@ -71,7 +71,7 @@ DARK_PALETTE: dict[str, str] = {
     "wire_path": "#38b6b6",
     "wire_cluster": "#c8965a",
     "wire_cluster_mixed": "#f284bd",
-    "wire_refnum": "#3f9e58",
+    "wire_refnum": "#12b2b2",  # dark teal — LabVIEW refnum wire 0x007F7F, lightened
     "wire_error": "#cdb03e",
     "wire_variant": "#c452c4",
     "wire_default": "#8a8a8a",

--- a/src/lvkit/structure.py
+++ b/src/lvkit/structure.py
@@ -1,4 +1,9 @@
-"""Parse LabVIEW library and class files for structural mapping."""
+"""Parse LabVIEW library, class, and project files (``.lvlib`` / ``.lvclass`` /
+``.lvproj``) — the single reader of those container files. Extracts what each
+file records: a class's methods, inheritance, private-data fields and version,
+plus its block-diagram wire appearance (Wire Appearance page). NOT block-diagram
+"structures" (while/for/case/sequence) — those are graph nodes parsed elsewhere.
+"""
 
 from __future__ import annotations
 
@@ -11,7 +16,14 @@ from pathlib import Path
 from typing import Any
 
 from lvkit.extractor import extract_vi_xml
-from lvkit.models import _LV_TO_PYTHON_TYPE, ClusterField, LVType, LVTypeKind
+from lvkit.models import (
+    _LV_TO_PYTHON_TYPE,
+    ClusterField,
+    LVType,
+    LVTypeKind,
+    WireLineStyle,
+    WireStyle,
+)
 
 
 @dataclass
@@ -72,6 +84,11 @@ class LVClass:
     # located, so it may be a PREFIX of the true chain for a class whose
     # ancestor tree isn't fully present in this checkout.
     ancestors: list[str] = field(default_factory=list)
+    # The class's own wire style (Class Properties -> Wire Appearance), decoded
+    # from its CoreWirePen/EdgeWirePen properties. None when the class uses the
+    # default/inherited look (no pen properties) -- callers then fall back to the
+    # parent chain or the generic per-family wire color.
+    wire_style: WireStyle | None = None
 
 
 @dataclass
@@ -618,6 +635,7 @@ def parse_lvclass(lvclass_path: Path | str) -> LVClass:
         private_data_fields=private_data_fields,
         version=version,
         ancestors=ancestors,
+        wire_style=_parse_wire_style(root),
     )
 
 
@@ -714,6 +732,71 @@ def _lv_base64_decode(text: str) -> bytes:
 
 _PRINTABLE_RUN_RE = re.compile(rb"[ -~]{4,}")
 _LVCLASS_TOKEN_RE = re.compile(r"([^\\/<>]+\.lvclass)$")
+
+
+def _lv_color_hex(val: int) -> str:
+    """A LabVIEW 24-bit ``0x00RRGGBB`` color int -> ``#RRGGBB``."""
+    return f"#{val & 0xFFFFFF:06X}"
+
+
+def _named_val(cluster: ET.Element, name: str) -> str | None:
+    """The ``<Val>`` text of the direct child of ``cluster`` whose ``<Name>`` is
+    ``name`` (the wire-pen fragment is a flat ``<Cluster>`` of named scalar
+    elements). None if absent."""
+    for child in cluster:
+        if child.findtext("Name") == name:
+            return child.findtext("Val")
+    return None
+
+
+def _pen_fragment(prop_text: str) -> ET.Element | None:
+    """The self-describing ``<Cluster>`` XML fragment inside a LabVIEW-base64
+    ``CoreWirePen``/``EdgeWirePen`` property (Foreground Color, Width, Style, …).
+    None if missing/malformed."""
+    decoded = _lv_base64_decode(prop_text)
+    start = decoded.find(b"<Cluster>")
+    end = decoded.rfind(b"</Cluster>")
+    if start == -1 or end == -1:
+        return None
+    fragment = decoded[start : end + len(b"</Cluster>")].decode("ascii", "replace")
+    try:
+        return ET.fromstring(fragment)  # noqa: S314 -- our own decoded blob
+    except ET.ParseError:
+        return None
+
+
+def _parse_wire_style(root: ET.Element) -> WireStyle | None:
+    """The class's own wire style from its ``CoreWirePen`` + ``EdgeWirePen``
+    properties: color from the core (center) pen, total width from the edge pen,
+    line style from the core pen. None when the class sets no custom pen (uses the
+    default/inherited look — the properties are absent)."""
+    core_text = edge_text = None
+    for prop in root.findall("Property"):
+        name = prop.get("Name")
+        if name == "NI.LVClass.CoreWirePen":
+            core_text = "".join(prop.itertext())
+        elif name == "NI.LVClass.EdgeWirePen":
+            edge_text = "".join(prop.itertext())
+    core = _pen_fragment(core_text) if core_text else None
+    if core is None:
+        return None
+    fg = _named_val(core, "Foreground Color")
+    if fg is None:
+        return None
+    edge = _pen_fragment(edge_text) if edge_text else None
+    width = _named_val(edge if edge is not None else core, "Width")
+    style = _named_val(core, "Style")
+    try:
+        line_style = (
+            WireLineStyle(int(style)) if style is not None else WireLineStyle.SOLID
+        )
+    except ValueError:
+        line_style = WireLineStyle.SOLID
+    return WireStyle(
+        color=_lv_color_hex(int(fg)),
+        width=float(width) if width is not None else 1.0,
+        line_style=line_style,
+    )
 
 
 def _parent_from_item(root: ET.Element) -> tuple[str, str | None] | None:

--- a/src/lvkit/structure.py
+++ b/src/lvkit/structure.py
@@ -835,7 +835,10 @@ def _parse_wire_style(root: ET.Element) -> WireStyle | None:
         width=total_w,
         line_style=line_style,
         edge_color=edge_color if has_border else None,
-        core_width=core_w if has_border else None,
+        # Core (center) width is always carried — the fill pattern draws at the
+        # CORE band width, not the wider total (edge) width. The two-band solid
+        # look still keys off edge_color being present.
+        core_width=core_w,
         fill_pattern=_pen_fill_pattern(core),
     )
 

--- a/src/lvkit/structure.py
+++ b/src/lvkit/structure.py
@@ -765,11 +765,39 @@ def _pen_fragment(prop_text: str) -> ET.Element | None:
         return None
 
 
+def _pen_width(frag: ET.Element | None) -> float | None:
+    """A pen fragment's ``Width`` in pixels, or None."""
+    val = _named_val(frag, "Width") if frag is not None else None
+    return float(val) if val is not None else None
+
+
+def _pen_fill_pattern(frag: ET.Element) -> tuple[int, ...]:
+    """A pen fragment's 8-row ``Fill Pattern`` bitmap (one byte per row), or ()
+    when absent or solid (all rows 0x00/0xFF — a flat fill, no chain)."""
+    for child in frag:
+        if child.findtext("Name") != "Fill Pattern":
+            continue
+        rows: list[int] = []
+        for row in child:
+            v = row.findtext("Val")
+            if v is not None:
+                try:
+                    rows.append(int(v) & 0xFF)
+                except ValueError:
+                    return ()
+        if all(r == 0x00 for r in rows) or all(r == 0xFF for r in rows):
+            return ()  # solid fill
+        return tuple(rows)
+    return ()
+
+
 def _parse_wire_style(root: ET.Element) -> WireStyle | None:
     """The class's own wire style from its ``CoreWirePen`` + ``EdgeWirePen``
-    properties: color from the core (center) pen, total width from the edge pen,
-    line style from the core pen. None when the class sets no custom pen (uses the
-    default/inherited look — the properties are absent)."""
+    properties. Color/line-style come from the core (center) pen; total width and
+    the outer band come from the edge pen. When the edge foreground differs from
+    the core the wire has a visible two-band border, so ``edge_color`` + the
+    narrower ``core_width`` are carried. None when the class sets no custom pen
+    (uses the default/inherited look — the properties are absent)."""
     core_text = edge_text = None
     for prop in root.findall("Property"):
         name = prop.get("Name")
@@ -784,7 +812,8 @@ def _parse_wire_style(root: ET.Element) -> WireStyle | None:
     if fg is None:
         return None
     edge = _pen_fragment(edge_text) if edge_text else None
-    width = _named_val(edge if edge is not None else core, "Width")
+    core_w = _pen_width(core)
+    total_w = _pen_width(edge) or core_w or 1.0
     style = _named_val(core, "Style")
     try:
         line_style = (
@@ -792,10 +821,22 @@ def _parse_wire_style(root: ET.Element) -> WireStyle | None:
         )
     except ValueError:
         line_style = WireLineStyle.SOLID
+    color = _lv_color_hex(int(fg))
+    edge_fg = _named_val(edge, "Foreground Color") if edge is not None else None
+    edge_color = _lv_color_hex(int(edge_fg)) if edge_fg is not None else None
+    has_border = (
+        edge_color is not None
+        and edge_color != color
+        and core_w is not None
+        and core_w < total_w
+    )
     return WireStyle(
-        color=_lv_color_hex(int(fg)),
-        width=float(width) if width is not None else 1.0,
+        color=color,
+        width=total_w,
         line_style=line_style,
+        edge_color=edge_color if has_border else None,
+        core_width=core_w if has_border else None,
+        fill_pattern=_pen_fill_pattern(core),
     )
 
 

--- a/tests/test_class_wire_appearance.py
+++ b/tests/test_class_wire_appearance.py
@@ -1,0 +1,119 @@
+"""Tests for class (LVOOP) wire style (issue #43): decoding a class's
+``CoreWirePen``/``EdgeWirePen`` into a ``WireStyle`` (structure.py::
+_parse_wire_style), resolving it through the graph with ancestry inheritance
+(core.py::get_class_wire_style), stamping it onto the class-instance type
+(_enrich_type), and — via the one wire lookup (render.style.wire_style) — drawing
+a class wire in the class's own color instead of the generic default.
+
+Sample-backed; skipped when the corpus isn't present, matching the other
+sample-backed tests (e.g. test_class_parent_linkinfo.py).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from lvkit.cli import _auto_search_paths
+from lvkit.graph.core import InMemoryVIGraph
+from lvkit.graph.loading import LoadMode
+from lvkit.models import WireLineStyle
+from lvkit.render import render_vi
+from lvkit.structure import parse_lvclass
+
+AF_ROOT = Path(".lvkit/cache/samples/actor-framework/Core/ActorFramework")
+JKI_ROOT = Path(".lvkit/cache/samples/JKI-VI-Tester/source")
+CAF_ROOT = Path(".lvkit/cache/samples/configurable-af-example/source")
+
+ACTOR_CLASS = AF_ROOT / "Actor" / "Actor.lvclass"
+ACTOR_METHOD = AF_ROOT / "Actor" / "Handle Error.vi"
+TESTLOADER_CLASS = JKI_ROOT / "Classes" / "TestLoader" / "TestLoader.lvclass"
+CONFIG_ACTOR_CLASS = CAF_ROOT / "ConfigurableActor" / "ConfigurableActor.lvclass"
+
+
+pytestmark = pytest.mark.skipif(
+    not ACTOR_CLASS.exists(), reason="actor-framework sample not present"
+)
+
+
+def test_class_pen_decodes_to_its_wire_style() -> None:
+    """Actor.lvclass sets a custom pen — its wire is the Actor-Framework blue,
+    total width 3, solid."""
+    cls = parse_lvclass(ACTOR_CLASS)
+    assert cls.wire_style is not None
+    assert cls.wire_style.color == "#006CFF"
+    assert cls.wire_style.width == 3
+    assert cls.wire_style.line_style == WireLineStyle.SOLID
+
+
+@pytest.mark.skipif(not TESTLOADER_CLASS.exists(), reason="JKI sample not present")
+def test_each_class_decodes_its_own_color() -> None:
+    """A different class decodes a different color — the style is data-driven,
+    not a shared constant."""
+    cls = parse_lvclass(TESTLOADER_CLASS)
+    assert cls.wire_style is not None
+    assert cls.wire_style.color == "#94A27C"
+
+
+@pytest.mark.skipif(not CONFIG_ACTOR_CLASS.exists(), reason="CAF sample not present")
+def test_no_pen_is_none() -> None:
+    """A class that never customized its wire has no pen properties → None
+    (it uses the default/inherited look)."""
+    cls = parse_lvclass(CONFIG_ACTOR_CLASS)
+    assert cls.wire_style is None
+
+
+def _load(vi_path: Path) -> tuple[InMemoryVIGraph, str]:
+    graph = InMemoryVIGraph()
+    sp = _auto_search_paths([], vi_path, vi_path)
+    graph.load_vi(str(vi_path), LoadMode.MINIMAL, search_paths=sp, layout=True)
+    return graph, graph.resolve_vi_name(vi_path.name)
+
+
+def test_graph_resolves_qualified_classname() -> None:
+    """get_class_wire_style resolves the library-qualified classname a wire
+    actually carries (``Actor Framework.lvlib:Actor.lvclass``) to the class's
+    own style."""
+    graph, vi_name = _load(ACTOR_METHOD)
+    style = graph.get_class_wire_style("Actor Framework.lvlib:Actor.lvclass", vi_name)
+    assert style is not None
+    assert style.color == "#006CFF"
+
+
+def test_type_carries_its_wire_style() -> None:
+    """The class-instance type is given its wire style at enrichment, so the one
+    lookup reads it off the type with no graph."""
+    from lvkit.render.style import wire_style
+
+    graph, vi_name = _load(ACTOR_METHOD)
+    ctx = graph.get_vi_context(vi_name)
+    class_terms = [
+        t
+        for t in (*ctx.inputs, *ctx.outputs)
+        if t.lv_type is not None and t.lv_type.classname
+    ]
+    assert class_terms, "no Actor class terminal found"
+    for t in class_terms:
+        assert t.lv_type is not None and t.lv_type.wire_style is not None
+        assert wire_style(t.lv_type).color == "#006CFF"
+
+
+def test_class_wire_rendered_in_class_color() -> None:
+    """The Actor object wire on Handle Error.vi renders in the class's own blue,
+    not the generic default wire color."""
+    graph, vi_name = _load(ACTOR_METHOD)
+    svg = render_vi(graph, vi_name)
+    assert svg is not None
+    assert 'stroke="#006CFF"' in svg
+
+
+def test_class_color_reaches_pane_and_terminal_via_the_one_lookup() -> None:
+    """Because every surface goes through wire_style, the class color also shows
+    on the connector-pane cell — no per-surface plumbing."""
+    graph, vi_name = _load(ACTOR_METHOD)
+    svg = render_vi(graph, vi_name)
+    assert svg is not None
+    cells = re.findall(r'lv-pane-cell[^>]*fill="([^"]+)"', svg)
+    assert "#006CFF" in cells

--- a/tests/test_cluster_wire_color.py
+++ b/tests/test_cluster_wire_color.py
@@ -1,12 +1,13 @@
 """The cluster wire color rule: a cluster is BROWN only when every field is
 numeric/boolean (a fixed-size numeric cluster); any string/array/refnum/etc.
 field makes it a variable-size "common" cluster -> PINK (NI's rule). Fields
-unknown (resolved lazily) keep the brown default."""
+unknown (resolved lazily) keep the brown default. Decided in ``wire_style``
+(one "cluster" type family, color chosen by field homogeneity)."""
 
 from __future__ import annotations
 
 from lvkit.models import ClusterField, LVType, LVTypeKind
-from lvkit.render.style import DEFAULT_THEME, type_family, wire_style
+from lvkit.render.style import DEFAULT_THEME, wire_style
 
 
 def _prim(underlying: str) -> LVType:
@@ -23,27 +24,26 @@ def _cluster(*fields: LVType) -> LVType:
 
 def test_all_numeric_cluster_is_brown() -> None:
     c = _cluster(_prim("NumInt32"), _prim("NumFloat64"), _prim("Boolean"))
-    assert type_family(c) == "cluster"
     assert wire_style(c).color == DEFAULT_THEME.wire_cluster
 
 
 def test_cluster_with_string_field_is_pink() -> None:
     c = _cluster(_prim("NumInt32"), _prim("String"))
-    assert type_family(c) == "cluster_mixed"
     assert wire_style(c).color == DEFAULT_THEME.wire_cluster_mixed
 
 
 def test_cluster_with_array_field_is_pink() -> None:
     arr = LVType(kind=LVTypeKind.ARRAY, element_type=_prim("NumFloat64"))
-    assert type_family(_cluster(_prim("NumInt32"), arr)) == "cluster_mixed"
+    c = _cluster(_prim("NumInt32"), arr)
+    assert wire_style(c).color == DEFAULT_THEME.wire_cluster_mixed
 
 
 def test_nested_all_numeric_cluster_stays_brown() -> None:
     inner = _cluster(_prim("NumInt32"), _prim("NumFloat64"))
-    assert type_family(_cluster(_prim("NumInt32"), inner)) == "cluster"
+    c = _cluster(_prim("NumInt32"), inner)
+    assert wire_style(c).color == DEFAULT_THEME.wire_cluster
 
 
 def test_fields_unknown_defaults_to_brown() -> None:
-    assert type_family(LVType(kind=LVTypeKind.CLUSTER, underlying_type="Cluster")) == (
-        "cluster"
-    )
+    c = LVType(kind=LVTypeKind.CLUSTER, underlying_type="Cluster")
+    assert wire_style(c).color == DEFAULT_THEME.wire_cluster

--- a/tests/test_cluster_wire_color.py
+++ b/tests/test_cluster_wire_color.py
@@ -1,0 +1,49 @@
+"""The cluster wire color rule: a cluster is BROWN only when every field is
+numeric/boolean (a fixed-size numeric cluster); any string/array/refnum/etc.
+field makes it a variable-size "common" cluster -> PINK (NI's rule). Fields
+unknown (resolved lazily) keep the brown default."""
+
+from __future__ import annotations
+
+from lvkit.models import ClusterField, LVType, LVTypeKind
+from lvkit.render.style import DEFAULT_THEME, type_family, wire_style
+
+
+def _prim(underlying: str) -> LVType:
+    return LVType(kind=LVTypeKind.PRIMITIVE, underlying_type=underlying)
+
+
+def _cluster(*fields: LVType) -> LVType:
+    return LVType(
+        kind=LVTypeKind.CLUSTER,
+        underlying_type="Cluster",
+        fields=[ClusterField(f"f{i}", t) for i, t in enumerate(fields)],
+    )
+
+
+def test_all_numeric_cluster_is_brown() -> None:
+    c = _cluster(_prim("NumInt32"), _prim("NumFloat64"), _prim("Boolean"))
+    assert type_family(c) == "cluster"
+    assert wire_style(c).color == DEFAULT_THEME.wire_cluster
+
+
+def test_cluster_with_string_field_is_pink() -> None:
+    c = _cluster(_prim("NumInt32"), _prim("String"))
+    assert type_family(c) == "cluster_mixed"
+    assert wire_style(c).color == DEFAULT_THEME.wire_cluster_mixed
+
+
+def test_cluster_with_array_field_is_pink() -> None:
+    arr = LVType(kind=LVTypeKind.ARRAY, element_type=_prim("NumFloat64"))
+    assert type_family(_cluster(_prim("NumInt32"), arr)) == "cluster_mixed"
+
+
+def test_nested_all_numeric_cluster_stays_brown() -> None:
+    inner = _cluster(_prim("NumInt32"), _prim("NumFloat64"))
+    assert type_family(_cluster(_prim("NumInt32"), inner)) == "cluster"
+
+
+def test_fields_unknown_defaults_to_brown() -> None:
+    assert type_family(LVType(kind=LVTypeKind.CLUSTER, underlying_type="Cluster")) == (
+        "cluster"
+    )

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -511,6 +511,43 @@ def test_cluster_constant_collapses_when_box_too_small_for_field_rows():
     assert ">V<" in small_svg  # the field value glyphs are drawn, fit to the box
 
 
+def test_array_constant_renders_indexed_cells_not_raw_repr():
+    """An array constant draws an index control + a column of the elements' own
+    value glyphs (the indexed element at top), with a greyed past-end cell and
+    the interactive ``lv-array`` carrier — never the raw ``[…]`` Python list."""
+    from lvkit.render.backend import SvgBackend
+    from lvkit.render.glyph import ArrayConstantGlyph, ConstantGlyph
+    from lvkit.render.nodes import _array_const_values
+    from lvkit.render.style import DEFAULT_THEME
+
+    # Value parsing: the repr string is parsed back to a list.
+    assert _array_const_values("['a', 'b', 'c']") == ["a", "b", "c"]
+    assert _array_const_values("[0, 1, 2]") == [0, 1, 2]
+    assert _array_const_values("not-a-list") == []
+
+    elems = tuple(
+        ConstantGlyph(s, "#e05fa0", multiline=True) for s in ("Alpha", "Beta")
+    )
+    glyph = ArrayConstantGlyph(
+        elements=elems, element_color="#e05fa0", struct_uid="v::9"
+    )
+    b = SvgBackend()
+    bounds = (0.0, 0.0, 140.0, 90.0)
+    glyph.draw(b, bounds, DEFAULT_THEME)
+    svg = b.render(bounds)
+    assert "Alpha" in svg and "Beta" in svg  # real element value glyphs
+    assert ">0<" in svg  # the index readout
+    assert "['" not in svg and "[0," not in svg  # never the raw list repr
+    # The interactive contract the array controller JS reads: the carrier's
+    # length + per-row height, the translatable column, the index readout, and
+    # the ▲/▼ prev/next click targets — all keyed by the same struct uid.
+    assert 'data-lv-len="2"' in svg and "data-lv-cellh" in svg
+    assert 'class="lv-array-col"' in svg
+    assert 'class="lv-array-index"' in svg
+    assert 'data-lv-action="prev"' in svg and 'data-lv-action="next"' in svg
+    assert svg.count('data-lv-struct="v::9"') >= 3  # carrier + col + index all keyed
+
+
 def test_local_variable_glyph_badge_and_read_write_border_weight():
     """A Local Variable node draws the ▶ badge (a filled triangle polygon) that
     tells it apart from a same-shaped constant box, with a BOLD border on both

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -3079,12 +3079,14 @@ def test_bundle_by_name_glyph_draws_field_names():
     svg = b.render(bounds)
     for name in ("level", "parent name", "xml index"):
         assert name in svg
-    assert "▶" in svg  # By Name carries the same direction arrow as positional
+    # The direction arrow is a filled triangle (polygon), not a text glyph.
+    assert "<polygon" in svg
 
 
 def test_bundle_by_name_arrow_side_follows_direction():
-    """The arrow cell sits on the cluster side: RIGHT for Bundle By Name
-    (fields in -> cluster out), LEFT for Unbundle By Name (task #89)."""
+    """The cluster arrow sits on the cluster side: RIGHT for Bundle By Name
+    (fields in -> cluster out), LEFT for Unbundle By Name (task #89). The arrow
+    is a filled triangle (polygon) in the narrow cluster column."""
     from lvkit.render.glyph import BundleByNameGlyph
 
     bounds = (0.0, 0.0, 100.0, 40.0)
@@ -3094,9 +3096,10 @@ def test_bundle_by_name_arrow_side_follows_direction():
         BundleByNameGlyph(names=("a", "b"), bundling=bundling).draw(
             b, bounds, DEFAULT_THEME
         )
-        m = re.search(r'<text x="([\d.]+)"[^>]*>▶</text>', b.render(bounds))
+        m = re.search(r'<polygon points="([^"]+)"', b.render(bounds))
         assert m is not None
-        return float(m.group(1))
+        xs = [float(p.split(",")[0]) for p in m.group(1).split()]
+        return sum(xs) / len(xs)  # mean x of the arrow triangle
 
     assert arrow_x(True) > 50.0  # Bundle By Name -> arrow on the RIGHT half
     assert arrow_x(False) < 50.0  # Unbundle By Name -> arrow on the LEFT half

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -727,10 +727,12 @@ def test_class_refnum_constant_labeled_by_class_name_not_refnum():
     """A CLASS/LVObject constant (underlying ``Refnum`` WITH a ``classname``)
     draws its CLASS NAME — wrapped-and-shrunk to fill the box (``fit``) — never
     the parser's placeholder raw value (``"Refnum(1)"``) and never a generic
-    "Refnum". A class refnum is ``type_family=="unknown"`` (that family reserves
-    "refnum" for GENERIC refs whose wire is reference-green), so the constant
-    path keys on ``underlying_type``. Same class-name rule shared with terminal
-    labels — ``style.lv_type_label``."""
+    "Refnum". The constant/label path keys on ``underlying_type`` +
+    ``classname``, independent of the wire family. A class refnum with no wire
+    style anywhere in its ancestry is the ``refnum`` family (reference-green
+    wire, like any driver/session ref) — a class that sets its own style draws
+    that instead. Same class-name rule shared with terminal labels —
+    ``style.lv_type_label``."""
     from lvkit.models import LVType
     from lvkit.render.glyph import ConstantGlyph
     from lvkit.render.nodes import _leaf_const_glyph
@@ -742,7 +744,8 @@ def test_class_refnum_constant_labeled_by_class_name_not_refnum():
         ref_type="UDClassInst",
         classname="NI DAQmx.lvlib:DAQmx Module Configuration.lvclass",
     )
-    assert type_family(cls) == "unknown"  # NOT the "refnum" family
+    # No custom wire style -> the generic reference-green refnum wire, never grey.
+    assert type_family(cls) == "refnum"
     assert lv_type_label(cls) == "DAQmx Module Configuration.lvclass"
 
     glyph = _leaf_const_glyph(cls, raw="Refnum(1)")
@@ -759,6 +762,37 @@ def test_class_refnum_constant_labeled_by_class_name_not_refnum():
     assert type_family(gen) == "refnum"
     assert lv_type_label(gen) == "Occurrence Refnum"
     assert _leaf_const_glyph(gen, raw="Refnum(1)").value == "Occurrence Refnum"
+
+
+def test_io_name_tag_and_pen_less_class_are_reference_green():
+    """LabVIEW I/O-name types (``Tag`` — DAQmx physical channel / task name,
+    VISA resource name) and a class refnum with no wire style in its ancestry
+    both draw the dark-green reference wire, never grey ``unknown``. An array of
+    a ``Tag`` inherits that green (thicker per dimension). A class that DOES set
+    a wire style keeps it — that path returns from ``wire_style`` before family
+    is consulted."""
+    import dataclasses
+
+    from lvkit.models import LVType, WireStyle
+    from lvkit.render.style import DEFAULT_THEME, type_family, wire_style
+
+    tag = LVType(kind=LVTypeKind.PRIMITIVE, underlying_type="Tag")
+    assert type_family(tag) == "refnum"
+    assert wire_style(tag).color == DEFAULT_THEME.wire_refnum
+
+    tag_arr = LVType(kind=LVTypeKind.ARRAY, element_type=tag)
+    assert wire_style(tag_arr).color == DEFAULT_THEME.wire_refnum
+
+    pen_less_class = LVType(
+        kind=LVTypeKind.PRIMITIVE, underlying_type="Refnum", classname="Foo.lvclass"
+    )
+    assert type_family(pen_less_class) == "refnum"
+    assert wire_style(pen_less_class).color == DEFAULT_THEME.wire_refnum
+
+    styled = dataclasses.replace(
+        pen_less_class, wire_style=WireStyle(color="#abcdef", width=2.0)
+    )
+    assert wire_style(styled).color == "#abcdef"
 
 
 def test_builtin_reference_constants_render():
@@ -3856,8 +3890,12 @@ def test_node_type_flavor_carries_doc_url():
 def test_refnum_wire_is_dark_green_not_grey():
     """Generic refnums (VI reference, driver/DAQ/VISA session, queue, ...) use
     LabVIEW's dark-green reference-wire color — not the grey "unresolved" color.
-    An LVOOP class instance is also a Refnum but carries a classname; it must NOT
-    take the generic green (its wire is the class's own colour)."""
+    An LVOOP class instance is also a Refnum but carries a classname: a class
+    that sets its own wire style draws in that, and a class with NO style in its
+    ancestry falls back to the SAME generic green (a reference wire), never grey."""
+    import dataclasses
+
+    from lvkit.models import WireStyle
     from lvkit.render.style import type_family
 
     generic_ref = LVType(
@@ -3873,7 +3911,15 @@ def test_refnum_wire_is_dark_green_not_grey():
         ref_type="UDClassInst",
         classname="Camera.lvclass",
     )
-    assert type_family(lvoop) != "refnum"
+    # No wire style anywhere in its ancestry -> generic reference green, not grey.
+    assert type_family(lvoop) == "refnum"
+    assert wire_style(lvoop).color == DEFAULT_THEME.wire_refnum
+
+    # A class that DOES carry a wire style draws in that, not the generic green.
+    styled = dataclasses.replace(
+        lvoop, wire_style=WireStyle(color="#123456", width=2.0)
+    )
+    assert wire_style(styled).color == "#123456"
 
 
 def test_property_node_glyph_shows_named_rows_with_read_write():

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -104,10 +104,17 @@ def test_selector_label_enum_names_ranges_and_list():
     names = ["Digital Input", "Digital Output", "Voltage Input", "PWM"]
     t = _enum_type(names)
     assert _selector_label(_frame("3", [(3, 3)]), t, False) == "PWM"
+    # Two contiguous values have no middle to elide -> list both, comma-separated.
     assert (
         _selector_label(_frame("0", [(0, 1)]), t, False)
-        == "Digital Input..Digital Output"
+        == "Digital Input, Digital Output"
     )
+    # Three-plus contiguous -> "first..last" (the middle member is elided).
+    assert (
+        _selector_label(_frame("0", [(0, 2)]), t, False)
+        == "Digital Input..Voltage Input"
+    )
+    # Non-contiguous match values are always comma-listed.
     assert (
         _selector_label(_frame("0", [(0, 0), (2, 2)]), t, False)
         == "Digital Input, Voltage Input"

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -823,11 +823,10 @@ def test_class_refnum_constant_labeled_by_class_name_not_refnum():
     draws its CLASS NAME — wrapped-and-shrunk to fill the box (``fit``) — never
     the parser's placeholder raw value (``"Refnum(1)"``) and never a generic
     "Refnum". The constant/label path keys on ``underlying_type`` +
-    ``classname``, independent of the wire family. A class refnum with no wire
-    style anywhere in its ancestry is the ``refnum`` family (reference-green
-    wire, like any driver/session ref) — a class that sets its own style draws
-    that instead. Same class-name rule shared with terminal labels —
-    ``style.lv_type_label``."""
+    ``classname``, independent of the wire family. A class refnum is NOT the
+    ``refnum`` family (that is reserved for GENERIC refs); with no custom wire
+    style it draws the default grey class chain, not a reference wire. Same
+    class-name rule shared with terminal labels — ``style.lv_type_label``."""
     from lvkit.models import LVType
     from lvkit.render.glyph import ConstantGlyph
     from lvkit.render.nodes import _leaf_const_glyph
@@ -839,8 +838,7 @@ def test_class_refnum_constant_labeled_by_class_name_not_refnum():
         ref_type="UDClassInst",
         classname="NI DAQmx.lvlib:DAQmx Module Configuration.lvclass",
     )
-    # No custom wire style -> the generic reference-green refnum wire, never grey.
-    assert type_family(cls) == "refnum"
+    assert type_family(cls) == "unknown"  # a class refnum is NOT the refnum family
     assert lv_type_label(cls) == "DAQmx Module Configuration.lvclass"
 
     glyph = _leaf_const_glyph(cls, raw="Refnum(1)")
@@ -859,13 +857,14 @@ def test_class_refnum_constant_labeled_by_class_name_not_refnum():
     assert _leaf_const_glyph(gen, raw="Refnum(1)").value == "Occurrence Refnum"
 
 
-def test_io_name_tag_and_pen_less_class_are_reference_green():
-    """LabVIEW I/O-name types (``Tag`` — DAQmx physical channel / task name,
-    VISA resource name) and a class refnum with no wire style in its ancestry
-    both draw the dark-green reference wire, never grey ``unknown``. An array of
-    a ``Tag`` inherits that green (thicker per dimension). A class that DOES set
-    a wire style keeps it — that path returns from ``wire_style`` before family
-    is consulted."""
+def test_io_name_tag_is_reference_wire_and_unresolved_class_is_grey_chain():
+    """A LabVIEW I/O-name type (``Tag`` — DAQmx physical channel / task name,
+    VISA resource name) draws the reference wire. But an UNRESOLVED class refnum
+    (a ``classname`` with no wire style anywhere in its ancestry — its
+    ``.lvclass``/parent unfound) is NOT a refnum wire: it draws the default GREY
+    CHAIN (grey = unresolved, chain = still visibly a class), thicker per array
+    dimension. A class that DOES set a wire style keeps it (``wire_style``
+    returns before the family/default is consulted)."""
     import dataclasses
 
     from lvkit.models import LVType, WireStyle
@@ -878,14 +877,22 @@ def test_io_name_tag_and_pen_less_class_are_reference_green():
     tag_arr = LVType(kind=LVTypeKind.ARRAY, element_type=tag)
     assert wire_style(tag_arr).color == DEFAULT_THEME.wire_refnum
 
-    pen_less_class = LVType(
+    unresolved_class = LVType(
         kind=LVTypeKind.PRIMITIVE, underlying_type="Refnum", classname="Foo.lvclass"
     )
-    assert type_family(pen_less_class) == "refnum"
-    assert wire_style(pen_less_class).color == DEFAULT_THEME.wire_refnum
+    ws = wire_style(unresolved_class)
+    assert ws.color == DEFAULT_THEME.wire_default  # grey, not refnum
+    assert ws.fill_pattern and len(set(ws.fill_pattern)) == 1  # a (uniform) CHAIN
+    assert type_family(unresolved_class) == "unknown"  # NOT the refnum family
+
+    # An array OF the unresolved class inherits the grey chain, thicker.
+    arr = LVType(kind=LVTypeKind.ARRAY, element_type=unresolved_class)
+    arr_ws = wire_style(arr)
+    assert arr_ws.color == DEFAULT_THEME.wire_default and bool(arr_ws.fill_pattern)
+    assert arr_ws.width > ws.width
 
     styled = dataclasses.replace(
-        pen_less_class, wire_style=WireStyle(color="#abcdef", width=2.0)
+        unresolved_class, wire_style=WireStyle(color="#abcdef", width=2.0)
     )
     assert wire_style(styled).color == "#abcdef"
 
@@ -4066,10 +4073,10 @@ def test_node_type_flavor_carries_doc_url():
 
 def test_refnum_wire_is_dark_green_not_grey():
     """Generic refnums (VI reference, driver/DAQ/VISA session, queue, ...) use
-    LabVIEW's dark-green reference-wire color — not the grey "unresolved" color.
-    An LVOOP class instance is also a Refnum but carries a classname: a class
-    that sets its own wire style draws in that, and a class with NO style in its
-    ancestry falls back to the SAME generic green (a reference wire), never grey."""
+    LabVIEW's reference-wire color. An LVOOP class instance is also a Refnum but
+    carries a classname: it is NOT a reference wire — a class that sets its own
+    wire style draws in that, and an UNRESOLVED class (no style in its ancestry)
+    draws the default grey class chain, never the reference wire."""
     import dataclasses
 
     from lvkit.models import WireStyle
@@ -4088,11 +4095,12 @@ def test_refnum_wire_is_dark_green_not_grey():
         ref_type="UDClassInst",
         classname="Camera.lvclass",
     )
-    # No wire style anywhere in its ancestry -> generic reference green, not grey.
-    assert type_family(lvoop) == "refnum"
-    assert wire_style(lvoop).color == DEFAULT_THEME.wire_refnum
+    # Unresolved class -> the default grey class chain, NOT the reference wire.
+    assert type_family(lvoop) == "unknown"
+    lvoop_ws = wire_style(lvoop)
+    assert lvoop_ws.color == DEFAULT_THEME.wire_default and bool(lvoop_ws.fill_pattern)
 
-    # A class that DOES carry a wire style draws in that, not the generic green.
+    # A class that DOES carry a wire style draws in that, not the grey chain.
     styled = dataclasses.replace(
         lvoop, wire_style=WireStyle(color="#123456", width=2.0)
     )

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -518,31 +518,41 @@ def test_cluster_constant_collapses_when_box_too_small_for_field_rows():
     assert ">V<" in small_svg  # the field value glyphs are drawn, fit to the box
 
 
-def test_bundle_input_cluster_terminal_reanchored_to_column_top():
-    """A Bundle-By-Name's aggregate is a full-height right column: the OUTPUT
-    exits mid-right, but the INPUT ("input cluster") attaches at the column TOP.
-    Both share one heap DCO so the layout collapses them to the mid center;
-    ``_bundle_agg_centers`` pulls the input up to the node top (x kept)."""
-    from lvkit.graph.models import PrimitiveNode
+def test_bundle_aggregate_split_into_interior_input_and_edge_output():
+    """A Bundle-By-Name's input + output aggregate terminals share ONE heap DCO
+    box (the output owns it; the input aliases it). ``_reposition_mux_terminals``
+    splits that real box in half so the connector panel can tell them apart: the
+    OUTPUT keeps the exposed EDGE half (right, here), the INPUT takes the
+    INTERIOR half — which ``_term_side_and_frac`` then reads as the TOP entry.
+    The wire endpoints (centers) are left at the real heap anchor: the on-diagram
+    aggregate wire is drawn from LabVIEW's own decoded geometry, never moved."""
     from lvkit.models import Terminal
-    from lvkit.parser.layout import Layout
-    from lvkit.render.scene import _bundle_agg_centers
+    from lvkit.render.scene import RenderTerminal, _reposition_mux_terminals
 
-    agg_in = Terminal(id="ai", index=0, direction="input", nmux_role="agg")
-    agg_out = Terminal(id="ao", index=1, direction="output", nmux_role="agg")
-    node = PrimitiveNode(
-        id="n", vi_path="v", node_type="nMux", terminals=[agg_in, agg_out]
-    )
-    layout = Layout()
-    layout.node_bounds["n"] = (100.0, 200.0, 226.0, 269.0)  # top y=200
-    layout.terminal_centers["ai"] = (222.0, 234.0)  # both collapsed to mid
-    layout.terminal_centers["ao"] = (222.0, 234.0)
+    node_bounds = (100.0, 200.0, 226.0, 269.0)  # left..right = 100..226
+    shared = (218.0, 200.0, 226.0, 269.0)  # 8px column flush to the RIGHT edge
 
-    out = _bundle_agg_centers({node.id: node}, "v", layout)
-    assert "ai" in out and "ao" not in out  # only the INPUT is moved
-    x, y = out["ai"]
-    assert x == 222.0  # column x kept
-    assert 200.0 <= y < 215.0  # pulled to the column top, not the mid (234)
+    def rt(direction):
+        return RenderTerminal(
+            terminal=Terminal(
+                id=direction, index=0, direction=direction, nmux_role="agg"
+            ),
+            center=(222.0, 234.5),  # both collapsed onto the shared box center
+            bounds=shared,
+        )
+
+    out = {
+        t.terminal.direction: t
+        for t in _reposition_mux_terminals([rt("input"), rt("output")], node_bounds)
+    }
+    # Output keeps its own recorded box (edge column); the input takes the
+    # equal-width interior column immediately to its left (the empty gap).
+    assert out["output"].bounds == (218.0, 200.0, 226.0, 269.0)
+    assert out["input"].bounds == (210.0, 200.0, 218.0, 269.0)
+    # Centers here are untouched; the wire-anchor correction lives in layout
+    # (``_reanchor_nmux_aggregate_inputs``), applied before wire decode.
+    assert out["input"].center == (222.0, 234.5)
+    assert out["output"].center == (222.0, 234.5)
 
 
 def test_collapsed_cluster_constant_draws_icon_not_members():
@@ -2550,45 +2560,33 @@ def test_single_field_bundle_is_not_dropped():
     assert glyph.num_fields == 1
 
 
-def test_mux_field_terminals_snap_to_node_edge():
-    """Bundle/Unbundle FIELD (``list``) terminals attach at the node EDGE on
-    their dataflow side — input fields (Bundle) at the LEFT edge, output fields
-    (Unbundle) at the RIGHT edge — keeping their row Y. Regression for the
-    "every bundle node crosses its input and output terminals" bug: field
-    terminals' heap centers sit by the field-name label (mid-box, near the
-    divider), so an input wire attached there ran into the middle of the box
-    and crossed the assembled output exiting the right edge."""
+def test_reposition_mux_leaves_fields_and_lone_unbundle_aggregate_alone():
+    """``_reposition_mux_terminals`` touches ONLY a Bundle's two shared-box
+    aggregate terminals (splitting them into interior-input / edge-output
+    halves). FIELD (``list``) terminals — whose wires are drawn from LabVIEW's
+    own faithful geometry and covered by the opaque name cells — and a lone
+    Unbundle aggregate, which already lines an edge on its own, are returned
+    unchanged. Nothing here moves an on-diagram wire endpoint."""
     from lvkit.models import Terminal
     from lvkit.render.scene import RenderTerminal, _reposition_mux_terminals
 
-    bounds = (100.0, 400.0, 200.0, 460.0)  # left, top, right, bottom (mid_y=430)
+    bounds = (100.0, 400.0, 200.0, 460.0)
 
-    def rt(direction, role, cx, cy):
+    def rt(direction, role, box):
         return RenderTerminal(
             terminal=Terminal(id="t", index=0, direction=direction, nmux_role=role),
-            center=(cx, cy),
-            bounds=None,
+            center=((box[0] + box[2]) / 2, (box[1] + box[3]) / 2),
+            bounds=box,
         )
 
-    # A Bundle: two field INPUTS whose heap centers sit near the right/divider
-    # (the WRONG side), plus the assembled aggregate OUTPUT.
-    out = _reposition_mux_terminals(
-        [
-            rt("input", "list", 190.0, 415.0),
-            rt("input", "list", 188.0, 445.0),
-            rt("output", "agg", 150.0, 430.0),
-        ],
-        bounds,
-    )
-    fins = [t for t in out if t.terminal.nmux_role == "list"]
-    assert [t.center[0] for t in fins] == [100.0, 100.0]  # snapped to LEFT edge
-    assert [t.center[1] for t in fins] == [415.0, 445.0]  # row Y preserved
-    agg = next(t for t in out if t.terminal.nmux_role == "agg")
-    assert agg.center == (200.0, 430.0)  # cluster exits right-mid
-
-    # An Unbundle field OUTPUT snaps to the RIGHT edge (mirror).
-    ub = _reposition_mux_terminals([rt("output", "list", 140.0, 430.0)], bounds)
-    assert ub[0].center[0] == 200.0
+    # A single Unbundle aggregate (input at the LEFT edge) + a field output:
+    # only two aggs sharing a box trigger the split, so both are untouched.
+    lone = rt("input", "agg", (100.0, 400.0, 116.0, 460.0))
+    field = rt("output", "list", (116.0, 405.0, 200.0, 422.0))
+    out = _reposition_mux_terminals([lone, field], bounds)
+    assert out[0].bounds == lone.bounds  # lone aggregate not split
+    assert out[1].bounds == field.bounds  # field terminal untouched
+    assert out[1].center == field.center
 
 
 def test_cluster_constant_compacted_to_natural_rows():
@@ -3108,30 +3106,45 @@ def test_bundle_by_name_glyph_draws_field_names():
     svg = b.render(bounds)
     for name in ("level", "parent name", "xml index"):
         assert name in svg
-    # The direction arrow is a filled triangle (polygon), not a text glyph.
+    # The direction arrow is a proper rightward arrow: a triangular head
+    # (<polygon>) OVER a shaft (<line>). The shaft is what keeps it from reading
+    # as a bare "play" triangle.
     assert "<polygon" in svg
+    assert "<line" in svg
 
 
-def test_bundle_by_name_arrow_side_follows_direction():
-    """The cluster arrow sits on the cluster side: RIGHT for Bundle By Name
-    (fields in -> cluster out), LEFT for Unbundle By Name (task #89). The arrow
-    is a filled triangle (polygon) in the narrow cluster column."""
+def test_bundle_by_name_arrow_sits_on_cluster_column_and_points_right():
+    """The direction arrow sits in the cluster column — RIGHT for Bundle By Name
+    (fields in -> cluster out), LEFT for Unbundle By Name — and points RIGHT in
+    BOTH cases (data assembles/extracts left-to-right). The head is a filled
+    ``<polygon>`` triangle whose apex (max x) is to the right of its base."""
     from lvkit.render.glyph import BundleByNameGlyph
 
     bounds = (0.0, 0.0, 100.0, 40.0)
 
-    def arrow_x(bundling: bool) -> float:
+    def head_pts(bundling: bool) -> list[tuple[float, float]]:
         b = SvgBackend()
         BundleByNameGlyph(names=("a", "b"), bundling=bundling).draw(
             b, bounds, DEFAULT_THEME
         )
         m = re.search(r'<polygon points="([^"]+)"', b.render(bounds))
         assert m is not None
-        xs = [float(p.split(",")[0]) for p in m.group(1).split()]
-        return sum(xs) / len(xs)  # mean x of the arrow triangle
+        return [
+            (float(x), float(y))
+            for x, y in re.findall(r"([-\d.]+),([-\d.]+)", m.group(1))
+        ]
 
-    assert arrow_x(True) > 50.0  # Bundle By Name -> arrow on the RIGHT half
-    assert arrow_x(False) < 50.0  # Unbundle By Name -> arrow on the LEFT half
+    for bundling, side in ((True, "right"), (False, "left")):
+        pts = head_pts(bundling)
+        xs = [p[0] for p in pts]
+        apex_x = max(xs)  # the single rightmost vertex is the tip
+        base_x = min(xs)
+        assert apex_x > base_x  # points RIGHT for both directions
+        mean_x = sum(xs) / len(xs)
+        if side == "right":
+            assert mean_x > 50.0  # Bundle: cluster column on the RIGHT
+        else:
+            assert mean_x < 50.0  # Unbundle: cluster column on the LEFT
 
 
 def test_nmux_renders_as_bundle_by_name_and_skips_boundary_mux():

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1932,7 +1932,8 @@ def test_control_border_thicker_than_indicator_border():
         LVType(kind=LVTypeKind.PRIMITIVE, underlying_type="NumFloat64"),
         is_indicator=True,
     )
-    assert 'stroke-width="3.0"' in control_svg
+    # Control is heavier than an indicator, but no longer bold (2.0 vs 1.5).
+    assert 'stroke-width="2.0"' in control_svg
     assert 'stroke-width="1.5"' in indicator_svg
 
 

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -511,6 +511,37 @@ def test_cluster_constant_collapses_when_box_too_small_for_field_rows():
     assert ">V<" in small_svg  # the field value glyphs are drawn, fit to the box
 
 
+def test_collapsed_cluster_constant_draws_icon_not_members():
+    """A cluster constant flagged COLLAPSED ("View As Icon", DDO objFlags bit
+    0x10000000) draws the compact cluster icon, never its members — LabVIEW
+    can't shrink a value's natural height, so a small box is a collapse, not
+    squashed content. An expanded cluster still draws its members."""
+    from lvkit.render.glyph import ClusterConstantGlyph
+    from lvkit.render.style import DEFAULT_THEME
+
+    class _Dot:
+        def draw(self, backend, bounds, theme):  # noqa: ANN001
+            x1, y1, x2, y2 = bounds
+            backend.text((x1 + x2) / 2, (y1 + y2) / 2, "V", 7.0)
+
+    fields = (("a", _Dot()), ("b", _Dot()), ("c", _Dot()))
+    box = (0.0, 0.0, 90.0, 60.0)
+
+    collapsed = SvgBackend()
+    ClusterConstantGlyph(fields=fields, collapsed=True).draw(
+        collapsed, box, DEFAULT_THEME
+    )
+    csvg = collapsed.render(box)
+    assert ">V<" not in csvg  # members NOT drawn when collapsed
+    assert csvg.count("<rect") >= 3  # shell + element squares (the icon)
+
+    expanded = SvgBackend()
+    ClusterConstantGlyph(fields=fields, collapsed=False).draw(
+        expanded, box, DEFAULT_THEME
+    )
+    assert ">V<" in expanded.render(box)  # members ARE drawn when expanded
+
+
 def test_array_constant_renders_indexed_cells_not_raw_repr():
     """An array constant draws an index control + a column of the elements' own
     value glyphs (the indexed element at top), with a greyed past-end cell and

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -511,6 +511,33 @@ def test_cluster_constant_collapses_when_box_too_small_for_field_rows():
     assert ">V<" in small_svg  # the field value glyphs are drawn, fit to the box
 
 
+def test_bundle_input_cluster_terminal_reanchored_to_column_top():
+    """A Bundle-By-Name's aggregate is a full-height right column: the OUTPUT
+    exits mid-right, but the INPUT ("input cluster") attaches at the column TOP.
+    Both share one heap DCO so the layout collapses them to the mid center;
+    ``_bundle_agg_centers`` pulls the input up to the node top (x kept)."""
+    from lvkit.graph.models import PrimitiveNode
+    from lvkit.models import Terminal
+    from lvkit.parser.layout import Layout
+    from lvkit.render.scene import _bundle_agg_centers
+
+    agg_in = Terminal(id="ai", index=0, direction="input", nmux_role="agg")
+    agg_out = Terminal(id="ao", index=1, direction="output", nmux_role="agg")
+    node = PrimitiveNode(
+        id="n", vi_path="v", node_type="nMux", terminals=[agg_in, agg_out]
+    )
+    layout = Layout()
+    layout.node_bounds["n"] = (100.0, 200.0, 226.0, 269.0)  # top y=200
+    layout.terminal_centers["ai"] = (222.0, 234.0)  # both collapsed to mid
+    layout.terminal_centers["ao"] = (222.0, 234.0)
+
+    out = _bundle_agg_centers({node.id: node}, "v", layout)
+    assert "ai" in out and "ao" not in out  # only the INPUT is moved
+    x, y = out["ai"]
+    assert x == 222.0  # column x kept
+    assert 200.0 <= y < 215.0  # pulled to the column top, not the mid (234)
+
+
 def test_collapsed_cluster_constant_draws_icon_not_members():
     """A cluster constant flagged COLLAPSED ("View As Icon", DDO objFlags bit
     0x10000000) draws the compact cluster icon, never its members — LabVIEW

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -503,11 +503,12 @@ def test_cluster_constant_collapses_when_box_too_small_for_field_rows():
     small = SvgBackend()
     glyph.draw(small, (0.0, 0.0, 17.0, 42.0), DEFAULT_THEME)
     small_svg = small.render((0.0, 0.0, 17.0, 42.0))
-    # Too small for labeled rows: field NAMES are dropped, but both field
-    # VALUE glyphs (the _Dot "V") are still drawn — never a blank box.
+    # Icon size: LabVIEW's generic cluster icon — the shell plus a few element
+    # squares — NOT the field names or the real field VALUE glyphs (no "V").
     assert "Horizontal" not in small_svg and "Vertical" not in small_svg
-    assert "<rect" in small_svg
-    assert small_svg.count(">V<") == 2
+    assert ">V<" not in small_svg
+    # shell + element squares (the generic icon)
+    assert small_svg.count("<rect") >= 4
 
 
 def test_local_variable_glyph_badge_and_read_write_border_weight():

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -503,12 +503,12 @@ def test_cluster_constant_collapses_when_box_too_small_for_field_rows():
     small = SvgBackend()
     glyph.draw(small, (0.0, 0.0, 17.0, 42.0), DEFAULT_THEME)
     small_svg = small.render((0.0, 0.0, 17.0, 42.0))
-    # Icon size: LabVIEW's generic cluster icon — the shell plus a few element
-    # squares — NOT the field names or the real field VALUE glyphs (no "V").
+    # Too small for name+value rows: the field NAME labels drop off (names move
+    # to the hover tooltip), but the real field VALUE glyphs are STILL drawn —
+    # a cluster shows its members (a one-boolean cluster shows its boolean),
+    # never a generic mixed-element icon that misstates the field count/types.
     assert "Horizontal" not in small_svg and "Vertical" not in small_svg
-    assert ">V<" not in small_svg
-    # shell + element squares (the generic icon)
-    assert small_svg.count("<rect") >= 4
+    assert ">V<" in small_svg  # the field value glyphs are drawn, fit to the box
 
 
 def test_local_variable_glyph_badge_and_read_write_border_weight():

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -3256,6 +3256,44 @@ def test_resolve_nmux_field_name_full_mode_addresses_whole_subclusters():
     assert _nmux_index_leaf_only("eventDataNode", agg(None)) is True
 
 
+def test_nested_bundle_field_tooltip_shows_dotted_path():
+    """A NESTED Bundle/Unbundle-By-Name field carries its FULL dotted path for
+    the hover ``<title>`` tooltip (which never truncates), while the terse leaf
+    label the glyph row + connector panel show is unchanged. A top-level field
+    (the sub-cluster itself) gets no path."""
+    from lvkit.graph.op_walk import _resolve_nmux_field_path
+    from lvkit.models import ClusterField, Terminal
+    from lvkit.render.draw import _terminal_help_lines, _terminal_label
+
+    inner = LVType(
+        kind=LVTypeKind.CLUSTER, fields=[ClusterField(name="leaf", type=None)]
+    )
+    fields = [ClusterField(name="Sub", type=inner)]
+    # Full mode: the nested leaf keeps its dotted path; the sub-cluster itself
+    # (a top-level slot) has none.
+    assert _resolve_nmux_field_path(1, fields, leaf_only=False) == "Sub.leaf"
+    assert _resolve_nmux_field_path(0, fields, leaf_only=False) is None
+    # Leaf-only mode (decompose/event): the sub-cluster is not a slot, but its
+    # leaf at 0 still carries its full nested path for the tooltip.
+    assert _resolve_nmux_field_path(0, fields, leaf_only=True) == "Sub.leaf"
+
+    t = Terminal(
+        id="f",
+        index=0,
+        direction="output",
+        nmux_role="list",
+        nmux_field_index=1,
+        display_name="leaf",
+        field_path="Sub.leaf",
+        lv_type=LVType(kind=LVTypeKind.PRIMITIVE, underlying_type="NumFloat64"),
+    )
+    node = PrimitiveNode(id="n", vi_path="v", node_type="nMux", terminals=[t])
+    # Tooltip lines show the FULL dotted path...
+    assert any("Sub.leaf" in ln for ln in _terminal_help_lines(node))
+    # ...while the terse label (glyph row / connector panel) stays the leaf.
+    assert _terminal_label(t) == "leaf"
+
+
 def test_resolve_nmux_field_name_falls_through_multiple_sources():
     """Each row is resolved independently across BOTH sources in priority
     order: the first source that has a name for THIS index wins, even if

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -884,12 +884,27 @@ def test_io_name_tag_is_reference_wire_and_unresolved_class_is_grey_chain():
     assert ws.color == DEFAULT_THEME.wire_default  # grey, not refnum
     assert ws.fill_pattern and len(set(ws.fill_pattern)) == 1  # a (uniform) CHAIN
     assert type_family(unresolved_class) == "unknown"  # NOT the refnum family
+    # Gauge matched to what REAL class pens decode to across the corpus (total
+    # ``Width`` 3.0, core 1.0) so an unresolved class is the same size as a
+    # resolved one, not the thin scalar wire.
+    assert ws.width == pytest.approx(3.0)
+    assert ws.core_width == pytest.approx(1.0)
 
-    # An array OF the unresolved class inherits the grey chain, thicker.
+    # An array OF the unresolved class inherits the grey chain, widened the same
+    # per-dimension amount EVERY array gets (generic bolding, chain preserved) —
+    # no class-specific branch: each dimension adds a fixed step to width & core.
     arr = LVType(kind=LVTypeKind.ARRAY, element_type=unresolved_class)
     arr_ws = wire_style(arr)
-    assert arr_ws.color == DEFAULT_THEME.wire_default and bool(arr_ws.fill_pattern)
-    assert arr_ws.width > ws.width
+    assert arr_ws.color == DEFAULT_THEME.wire_default
+    assert arr_ws.fill_pattern == ws.fill_pattern  # element pattern carried through
+    step = arr_ws.width - ws.width
+    assert step > 0
+    assert arr_ws.core_width == pytest.approx((ws.core_width or 0.0) + step)
+
+    arr2 = LVType(kind=LVTypeKind.ARRAY, element_type=arr)  # 2-D
+    arr2_ws = wire_style(arr2)
+    assert arr2_ws.width == pytest.approx(ws.width + 2 * step)  # one step per dim
+    assert arr2_ws.fill_pattern == ws.fill_pattern
 
     styled = dataclasses.replace(
         unresolved_class, wire_style=WireStyle(color="#abcdef", width=2.0)

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -3158,12 +3158,14 @@ def test_parse_private_data_fields_is_authoritative_to_the_class():
 
 
 def test_resolve_nmux_field_name_flattens_nested_clusters_leaf_first():
-    """``_resolve_nmux_field_name`` (backing ``_bundle_by_name_glyph``) must
-    flatten a NESTED private-data cluster LEAF-first — an intermediate
-    sub-cluster (``DAQ Tasks``, ``Channel Indeces``) is never itself an
-    addressable flat slot. Reproduces the exact corpus shape/indices (task:
-    DAQmx Module Runtime, indices 7/1/9/3 -> DI Index/AO Task/PWM Freq
-    Index/DO Task) without needing the sample VI on disk."""
+    """In LEAF-only mode (IPES ``decomposeClusterNode`` / event data),
+    ``_resolve_nmux_field_name`` flattens a NESTED private-data cluster
+    LEAF-first — an intermediate sub-cluster (``DAQ Tasks``, ``Channel
+    Indeces``) is never itself an addressable flat slot. Reproduces the exact
+    corpus shape/indices (task: DAQmx Module Runtime decompose, indices 7/1/9/3
+    -> DI Index/AO Task/PWM Freq Index/DO Task) without needing the sample VI on
+    disk. Bundle-By-Name (``nMux``) counts sub-clusters too — see the full-mode
+    assertions below and ``test_resolve_nmux_field_name_full_mode_...``."""
     from lvkit.graph.op_walk import _resolve_nmux_field_name
     from lvkit.models import ClusterField
 
@@ -3205,14 +3207,53 @@ def test_resolve_nmux_field_name_flattens_nested_clusters_leaf_first():
     )
     fields = [daq_tasks, channel_indeces]
 
-    assert _resolve_nmux_field_name(7, fields) == "DI Index"
-    assert _resolve_nmux_field_name(1, fields) == "AO Task"
-    assert _resolve_nmux_field_name(9, fields) == "PWM Freq Index"
-    assert _resolve_nmux_field_name(3, fields) == "DO Task"
+    assert _resolve_nmux_field_name(7, fields, leaf_only=True) == "DI Index"
+    assert _resolve_nmux_field_name(1, fields, leaf_only=True) == "AO Task"
+    assert _resolve_nmux_field_name(9, fields, leaf_only=True) == "PWM Freq Index"
+    assert _resolve_nmux_field_name(3, fields, leaf_only=True) == "DO Task"
     # Out of range (beyond every leaf) -> no name, caller falls back further.
-    assert _resolve_nmux_field_name(99, fields) is None
+    assert _resolve_nmux_field_name(99, fields, leaf_only=True) is None
     # No field index at all -> no name.
-    assert _resolve_nmux_field_name(None, fields) is None
+    assert _resolve_nmux_field_name(None, fields, leaf_only=True) is None
+
+
+def test_resolve_nmux_field_name_full_mode_addresses_whole_subclusters():
+    """In FULL mode (Bundle/Unbundle By Name ``nMux``) the flat ``<i>`` index
+    counts EVERY node depth-first, so a whole sub-cluster is its own addressable
+    slot — the same shape a LEAF-only flatten cannot reach. Mirrors the DCAF
+    ``Create Test Configuration`` Bundle node: index 0 is the first sub-cluster
+    itself, and its own leaf is index 1 (leaf-only would put that leaf at 0)."""
+    from lvkit.graph.op_walk import _nmux_index_leaf_only, _resolve_nmux_field_name
+    from lvkit.models import ClusterField, Terminal
+
+    inner = LVType(
+        kind=LVTypeKind.CLUSTER,
+        fields=[ClusterField(name="leaf", type=None)],
+    )
+    fields = [ClusterField(name="Sub", type=inner)]
+    # FULL: slot 0 = the sub-cluster, slot 1 = its leaf.
+    assert _resolve_nmux_field_name(0, fields, leaf_only=False) == "Sub"
+    assert _resolve_nmux_field_name(1, fields, leaf_only=False) == "leaf"
+    # LEAF-only: the sub-cluster is NOT a slot — only its leaf, at 0.
+    assert _resolve_nmux_field_name(0, fields, leaf_only=True) == "leaf"
+    assert _resolve_nmux_field_name(1, fields, leaf_only=True) is None
+
+    # The discriminator: full-mode is ONLY an ``nMux`` over a plain (non-class)
+    # cluster/typedef. Class private data (``classname``) stays leaf even under
+    # ``nMux``; IPES decompose / event data are always leaf.
+    def agg(classname: str | None) -> Terminal:
+        return Terminal(
+            id="a",
+            index=0,
+            direction="input",
+            nmux_role="agg",
+            lv_type=LVType(kind=LVTypeKind.CLUSTER, classname=classname),
+        )
+
+    assert _nmux_index_leaf_only("nMux", agg(None)) is False
+    assert _nmux_index_leaf_only("nMux", agg("Foo.lvclass")) is True
+    assert _nmux_index_leaf_only("decomposeClusterNode", agg(None)) is True
+    assert _nmux_index_leaf_only("eventDataNode", agg(None)) is True
 
 
 def test_resolve_nmux_field_name_falls_through_multiple_sources():
@@ -3229,13 +3270,13 @@ def test_resolve_nmux_field_name_falls_through_multiple_sources():
         ClusterField(name="second", type=None),
     ]
     # index 0 resolves from the first (own) source.
-    assert _resolve_nmux_field_name(0, own, dep) == "onlyInOwn"
+    assert _resolve_nmux_field_name(0, own, dep, leaf_only=True) == "onlyInOwn"
     # index 1 is out of range for own, falls through to dep.
-    assert _resolve_nmux_field_name(1, own, dep) == "second"
+    assert _resolve_nmux_field_name(1, own, dep, leaf_only=True) == "second"
     # Empty own source -> straight to dep.
-    assert _resolve_nmux_field_name(1, [], dep) == "second"
+    assert _resolve_nmux_field_name(1, [], dep, leaf_only=True) == "second"
     # Neither source covers it.
-    assert _resolve_nmux_field_name(5, own, dep) is None
+    assert _resolve_nmux_field_name(5, own, dep, leaf_only=True) is None
 
 
 def test_bundle_by_name_resolves_nested_class_private_data_field_names():
@@ -3441,7 +3482,7 @@ def test_resolve_bundle_by_name_labels_only_attaches_real_names():
     )
     field_terms = [resolved, named_by_terminal, unresolved]
 
-    names = _resolve_bundle_by_name_labels(field_terms, fields)
+    names = _resolve_bundle_by_name_labels(field_terms, fields, leaf_only=False)
     assert names == ("widgetCount", "caller side name", "[5]")
     assert resolved.display_name == "widgetCount"
     assert named_by_terminal.display_name is None

--- a/tests/test_type_loading.py
+++ b/tests/test_type_loading.py
@@ -160,3 +160,42 @@ class TestFindFile:
         graph = InMemoryVIGraph()
         result = graph._find_file("nowhere.ctl", [tmp_path], tmp_path)
         assert result is None
+
+
+DCAF_VI = (
+    SAMPLES
+    / "DCAF-DAQModule"
+    / "source"
+    / "testing"
+    / "Create Test Configuration.vi"
+)
+
+
+@pytest.mark.skipif(
+    not DCAF_VI.exists(),
+    reason="DCAF-DAQModule samples not available",
+)
+class TestTypedefRefDoesNotDuplicateStub:
+    """A typedef the VI links by a qualified VICC ref (recorded caller-relative
+    path) AND also carries as a BARE ``typedef_name`` in its type_map must
+    resolve to ONE path-keyed node — never a second bare-name stub node beside
+    the resolved one. Regression: PATH is the dep-graph identity, so a
+    path-less bare ref must route onto the already-resolved node, not spawn a
+    duplicate (``_load_dependency``'s pre-stub caller-scoped guard)."""
+
+    def test_resolvable_typedef_has_no_bare_name_duplicate(self):
+        graph = InMemoryVIGraph()
+        graph.load_vi(DCAF_VI, mode=LoadMode.MINIMAL)
+        dg = graph._dep_graph
+        for leaf in ("Parameters.ctl", "Line.ctl", "Measurement Type.ctl"):
+            resolved = [
+                n
+                for n in dg.nodes
+                if n.endswith(leaf) and "/" in n and n not in graph._stubs
+            ]
+            assert len(resolved) >= 1, f"{leaf}: no resolved path node"
+            # The BARE name must NOT exist as its own (stub) node beside it.
+            assert not dg.has_node(leaf), (
+                f"{leaf}: bare-name duplicate stub node exists beside the "
+                f"resolved path node(s) {resolved}"
+            )


### PR DESCRIPTION
## Faithful block-diagram rendering: class/cluster wires, cluster & array constants, Bundle-By-Name

This branch reworks several block-diagram render paths to match what LabVIEW
actually draws — every color, gauge, and terminal position grounded in the
parsed heap (`termBounds`, DCO ownership, `.lvclass` pens) rather than invented
values.

### Closes #43 — Class (LVOOP) wires render in the class's own color
- A type now carries its own `WireStyle` (data-driven color/width/pattern) —
  `style.py`, replacing the default-color fallback.
- Class wires draw as LabVIEW's **chain** (hollow links + connectors, hard
  corners) at the real class-pen gauge; unresolved/default classes use a grey
  chain at the same gauge.
- Cluster wires use LabVIEW's pink/brown rule (all-numeric brown, mixed pink);
  refnum wires use the real teal `0x007F7F`; I/O-name Tag / pen-less class
  refnums draw reference-green.

### Closes #45 — Cluster constants render faithfully
- Small clusters draw their real members; icon-size/collapsed clusters draw the
  generic cluster icon (honoring the "View As Icon" flag, incl. typedef'd ones).
- Constant icon border matches its wire color; oversized typedef layouts are
  compacted so they no longer overlap neighbors.

### Closes #72 — Array constants render LV-style
- Interactive, indexed array constants (index control + element value glyphs)
  replace the raw Python `[…]` list repr.

### Closes #79 — Bundle-By-Name field names
- Field names resolve through the full depth-first flatten over a typedef;
  inherited class fields survive because typedef refs no longer spawn a bare-name
  stub beside the resolved node; nested fields show their full dotted path on
  hover.

### Also on this branch (render polish, no dedicated issue)
- **Bundle-By-Name node geometry (this branch's latest work):** the input and
  output cluster terminals share one aggregate DCO (the output owns the box; the
  input is a position-less bare reference). The input is now anchored to its
  **interior cluster column** *before* wire decode, so the faithful wire re-forms
  onto it instead of terminating inside the output box — the auto-router never
  runs. The glyph draws the two 8px columns from the real `termBounds`, name
  cells on the diagram background, and a rightward arrow for both Bundle and
  Unbundle. The hover panel no longer "double-drives" the input.
- Bundle/Unbundle aggregate terminal reads "input/output cluster"; the By-Name
  glyph is drawn as bordered name cells.
- Enum case-structure sub-ranges are no longer misread as spurious "Default"
  frames (all frame match values interpreted through the selector's type).

### Verification
- Full suite green (1949 passed, 24 skipped).
- Bundle input wire verified re-anchored to the interior column
  (`[(343,306),(354,306),(354,380.5)]` → `[(343,306),(346,306),(346,346)]`)
  via the shared `bundle_aggregate_columns()` — one rule, used by both the wire
  anchor (layout) and the glyph/panel bounds (scene).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
